### PR TITLE
Create Rubocop Github Action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,16 @@
+name: Rubocop
+on: push
+
+jobs:
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle install
+      - name: Rubocop
+        run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ AllCops:
     - 'bin/**/*'
     - 'vendor/**/*'
     - 'spec/spec_helper.rb'
+    - 'spec/dummy/bin/*'
+    - 'spec/dummy/config/**/*'
+    - 'spec/dummy/db/**/*'
     - !ruby/regexp /old_and_unused\.rb$/
 
 Gemspec/RequiredRubyVersion:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'lib/tasks/bali_tasks.rake'
     - 'bin/**/*'
+    - 'vendor/**/*'
     - 'spec/spec_helper.rb'
     - !ruby/regexp /old_and_unused\.rb$/
 


### PR DESCRIPTION
- Create`rubocop github action setup`
- Exclude `vendor` (to solve an issue that appears when working with GitHub Actions and using the ruby/setup-ruby@v1 action, which installs and caches the gems automatically.) and `dummy app directories from rubocop`

Closes #10 