### PR TITLE
Test form_builder methods with Capybara matchers

### DIFF
--- a/spec/form_builder/step_number_fields_spec.rb
+++ b/spec/form_builder/step_number_fields_spec.rb
@@ -2,55 +2,45 @@
 
 require 'rails_helper'
 
-RSpec.describe Bali::FormBuilder do
+RSpec.describe Bali::FormBuilder, type: :form_builder do
   include_context 'form builder'
 
   describe '#step_number_field_group' do
-    it 'renders an input' do
-      expect(builder.step_number_field_group(:duration)).to include(
-        '<div id="field-duration" class="field-group-wrapper-component field ">'\
-        '<label class="label " for="movie_duration">Duration</label>'\
-        '<div class="field has-addons" data-controller="step-number-input">'\
-        '<div class="control"><a class="button" data-action="step-number-input#subtract" '\
-        'data-step-number-input-target="subtract" title="subtract" href="">'\
-        "<span class=\"icon-component icon\">\n        <svg viewBox=\"0 0 14 2\" "\
-        "class=\"svg-inline\" fill=\"none\">\n          <path d=\"M0.599609 0H13.3996V1.60001H0."\
-        "599609V0Z\" fill=\"currentColor\"/>\n        </svg>\n      </span></a></div><div "\
-        'class="control"><div class="control "><input data-step-number-input-target="input"'\
-        ' class="input " type="number" value="2022-06-29 00:00:00" name="movie[duration]"'\
-        ' id="movie_duration" /></div></div><div class="control"><a class="button" '\
-        'data-action="step-number-input#add" data-step-number-input-target="add" '\
-        "title=\"add\" href=\"\"><span class=\"icon-component icon\">\n        <svg "\
-        "viewBox=\"0 0 448 512\" class=\"svg-inline\">\n          <path fill=\"currentColor\"\n "\
-        '           d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H3'\
-        '2c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c1'\
-        "7.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z\"\n   "\
-        "         class=\"\"></path>\n        </svg>\n      </span></a></div></div></div>"
-      )
+    let(:step_number_group) { builder.step_number_field_group(:duration) }
+
+    it 'renders the input and label within a wrapper' do
+      expect(step_number_group).to have_css '#field-duration.field-group-wrapper-component'
+    end
+
+    it 'renders the label' do
+      expect(step_number_group).to have_css '.label[for="movie_duration"]', text: 'Duration'
+    end
+
+    it 'renders the input' do
+      expect(step_number_group).to have_css 'input#movie_duration[name="movie[duration]"]'
     end
   end
 
   describe '#step_number_field' do
-    it 'renders an input' do
-      expect(builder.step_number_field(:duration)).to include(
-        '<div class="field has-addons" data-controller="step-number-input">'\
-        '<div class="control"><a class="button" data-action="step-number-input#subtract"'\
-        ' data-step-number-input-target="subtract" title="subtract" href="">'\
-        "<span class=\"icon-component icon\">\n        <svg viewBox=\"0 0 14 2\" "\
-        "class=\"svg-inline\" fill=\"none\">\n          <path d=\"M0.599609 0H13.3996V1.60001H"\
-        "0.599609V0Z\" fill=\"currentColor\"/>\n        </svg>\n      </span></a></div><div "\
-        'class="control"><div class="control "><input data-step-number-input-target'\
-        '="input" class="input " type="number" value="2022-06-29 00:00:00" '\
-        'name="movie[duration]" id="movie_duration" /></div></div><div class="control">'\
-        '<a class="button" data-action="step-number-input#add" data-step-number-input-'\
-        "target=\"add\" title=\"add\" href=\"\"><span class=\"icon-component icon\">\n        "\
-        "<svg viewBox=\"0 0 448 512\" class=\"svg-inline\">\n          "\
-        "<path fill=\"currentColor\"\n            d=\"M416 208H272V64c0-17.67-14.33-32-32-32h-"\
-        '32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h1'\
-        '44v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-3'\
-        "2v-32c0-17.67-14.33-32-32-32z\"\n            class=\"\"></path>\n        </svg>\n    "\
-        '  </span></a></div></div>'
-      )
+    let(:step_number_field) { builder.step_number_field(:duration) }
+
+    it 'renders the field with the step-number-input controller' do
+      expect(step_number_field).to have_css '.field[data-controller="step-number-input"]'
+    end
+
+    it 'renders the field with the subtract button' do
+      expect(step_number_field).to have_css '.button[data-action="step-number-input#subtract"]'
+      expect(step_number_field).to have_css '.button[data-step-number-input-target="subtract"]'
+    end
+
+    it 'renders the input' do
+      expect(step_number_field).to have_css 'input[data-step-number-input-target="input"]'
+      expect(step_number_field).to have_css '#movie_duration[name="movie[duration]"]'
+    end
+
+    it 'renders the field with the add button' do
+      expect(step_number_field).to have_css '.button[data-action="step-number-input#add"]'
+      expect(step_number_field).to have_css '.button[data-step-number-input-target="add"]'
     end
   end
 end

--- a/spec/form_builder/time_fields_spec.rb
+++ b/spec/form_builder/time_fields_spec.rb
@@ -2,33 +2,64 @@
 
 require 'rails_helper'
 
-RSpec.describe Bali::FormBuilder do
+RSpec.describe Bali::FormBuilder, type: :form_builder do
   include_context 'form builder'
 
   describe '#time_field_group' do
-    it 'renders an input' do
-      expect(builder.time_field_group(:duration)).to include(
-        '<div id="field-duration" class="field-group-wrapper-component field ">'\
-        '<label class="label " for="movie_duration">Duration</label><div '\
-        'class="field flatpickr" data-controller="datepicker" data-datepicker-locale'\
-        '-value="en" data-datepicker-enable-time-value="true" data-datepicker-no-cale'\
-        'ndar-value="true"><div class="control is-fullwidth "><input control_class="is'\
-        '-fullwidth " class="input " type="text" value="2022-06-29 00:00:00" name="movie'\
-        '[duration]" id="movie_duration" /></div></div></div>'
-      )
+    let(:time_group) { builder.time_field_group(:duration) }
+
+    it 'renders the input and label within a wrapper' do
+      expect(time_group).to have_css '#field-duration.field-group-wrapper-component'
+    end
+
+    it 'renders the label' do
+      expect(time_group).to have_css '.label[for="movie_duration"]', text: 'Duration'
+    end
+
+    it 'renders the input' do
+      expect(time_group).to have_css 'input#movie_duration[name="movie[duration]"]'
     end
   end
 
-  describe '#time_field_group' do
-    it 'renders an input' do
-      expect(builder.time_field(:duration)).to include(
-        '<div class="field flatpickr" data-controller="datepicker" '\
-        'data-datepicker-locale-value="en" data-datepicker-enable-time-value="true"'\
-        ' data-datepicker-no-calendar-value="true"><div class="control is-fullwidth ">'\
-        '<input control_class="is-fullwidth " class="input " type="text" '\
-        'value="2022-06-29 00:00:00" name="movie[duration]" id="movie_duration" />'\
-        '</div></div>'
-      )
+  describe '#time_field' do
+    before { @options = {} }
+
+    let(:time_field) { builder.time_field(:duration, @options) }
+
+    it 'renders the field with the datepicker controller' do
+      expect(time_field).to have_css '.field[data-controller="datepicker"]'
+    end
+
+    it 'renders the input' do
+      expect(time_field).to have_css '#movie_duration[name="movie[duration]"]'
+    end
+
+    it 'renders with datepicker time enabled' do
+      expect(time_field).to have_css '.field[data-datepicker-enable-time-value="true"]'
+    end
+
+    it 'renders with datepicker calendar disabled' do
+      expect(time_field).to have_css '.field[data-datepicker-no-calendar-value="true"]'
+    end
+
+    it 'renders with datepicker seconds enabled' do
+      @options.merge!(seconds: true)
+      expect(time_field).to have_css '.field[data-datepicker-enable-seconds-value="true"]'
+    end
+
+    it 'renders with datepicker default date' do
+      @options.merge!(default_date: '1983-04-13')
+      expect(time_field).to have_css '.field[data-datepicker-default-date-value="1983-04-13"]'
+    end
+
+    it 'renders with datepicker min time' do
+      @options.merge!(min_time: '08:00')
+      expect(time_field).to have_css '.field[data-datepicker-min-time-value="08:00"]'
+    end
+
+    it 'renders with datepicker max time' do
+      @options.merge!(max_time: '23:00')
+      expect(time_field).to have_css '.field[data-datepicker-max-time-value="23:00"]'
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include Capybara::RSpecMatchers, type: :form_builder
 
   # Remove this line to enable support for ActiveRecord
   config.use_active_record = false


### PR DESCRIPTION
- Use capybara matchers to test form_builder methods instead of testing against a large String
- Be more specific about tests and create individual tests for each piece of functionality