### PR TITLE
Update `hyphenize_keys` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2022-06-30
+
+- Update `hyphenize_keys` to return a hash in which the keys are symbols instead of strings.
+
 ## [0.17.0] - 2022-06-30
 
 - Create `BooleanIcon::Component` and update Component Generator templates.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.17.0)
+    bali_view_components (0.17.1)
       rails (>= 7.0.2.3)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/lib/bali/html_element_helper.rb
+++ b/lib/bali/html_element_helper.rb
@@ -20,7 +20,7 @@ module Bali
     end
 
     def hyphenize_keys(options)
-      options.transform_keys { |k| k.to_s.gsub('_', '-') }
+      options.transform_keys { |k| k.to_s.gsub('_', '-').to_sym }
     end
 
     def prepend_data_attribute(options, attr_name, attr_value)

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.17.0'
+  VERSION = '0.17.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
**Objetivo**

- Actualizar `hyphenize_keys` para que regrese un hash donde los keys son símbolos en lugar de strings. Este método no funciona en conjunto con `preprend_class_name` cuando los keys son strings.