### PR TITLE
Notificaion personalizada para `no results/no records` en `Table::Component`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2022-07-01
+
+- Custom notifications have been added for `no results/no records` in the table component.
+
 ## [0.17.1] - 2022-06-30
 
 - Update `hyphenize_keys` to return a hash in which the keys are symbols instead of strings.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.17.1)
+    bali_view_components (0.19.1)
       rails (>= 7.0.2.3)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/table/component.html.erb
+++ b/app/components/bali/table/component.html.erb
@@ -17,11 +17,15 @@
           <td class="empty-table" colspan="<%= headers.count %>">
             <div class='has-text-centered m-6'>
               <% if form&.active_filters? %>
-                <p class="body-1"><%= t('.no_results') %></p>
+                <%= no_results_notification || tag.p(t('.no_results')) %>
               <% else %>
-                  <p class='body-1'><%= t('.no_records') %></p>
+                <% if no_records_notification.present? %>
+                  <%= no_records_notification %>
+                <% else %>
+                  <p><%= t('.no_records') %></p>
                   <br />
                   <%= new_record_link %>
+                <% end %>
               <% end %>
             </div>
           </td>

--- a/app/components/bali/table/component.rb
+++ b/app/components/bali/table/component.rb
@@ -15,6 +15,9 @@ module Bali
         Bali::Link::Component.new(name: name, href: href, type: :success, modal: modal, **options)
       end
 
+      renders_one :no_records_notification
+      renders_one :no_results_notification
+
       attr_reader :form, :options, :tbody_options
 
       def initialize(form: nil, **options)

--- a/app/components/bali/table/preview.rb
+++ b/app/components/bali/table/preview.rb
@@ -33,6 +33,16 @@ module Bali
           }
         )
       end
+
+      def with_custom_no_records_notification
+        render_with_template(
+          template: 'bali/table/previews/with_custom_no_records_notification',
+          locals: {
+            headers: HEADERS,
+            records: []
+          }
+        )
+      end
     end
   end
 end

--- a/app/components/bali/table/previews/with_custom_no_records_notification.html.erb
+++ b/app/components/bali/table/previews/with_custom_no_records_notification.html.erb
@@ -1,0 +1,17 @@
+<%= render(Bali::Table::Component.new) do |c| %>
+  <% c.headers(headers) %>
+
+  <% c.no_records_notification do %>
+    <%= render Bali::Icon::Component.new('alert-alt') %>
+    <p>So sorry, no records found!</p>
+  <% end %>
+
+  <% records.each do |record| %>
+    <%= c.row do %>
+      <td><%= record[:name] %></td>
+      <td><%= record[:amount] %></td>
+    <% end %>
+  <% end %>
+
+  <%= c.new_record_link name: 'Nuevo registro', href: '#' %>
+<% end %>

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.17.1'
+  VERSION = '0.19.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.17.1",
+  "version": "0.19.1",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/spec/bali/components/table_spec.rb
+++ b/spec/bali/components/table_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Bali::Table::Component, type: :component do
     it 'renders an empty query message' do
       @options.merge!(form: @filter_form)
       render_inline(component) do |c|
-        c.no_records_notification { 'So sorry, no records found!'}
+        c.no_records_notification { 'So sorry, no records found!' }
       end
-  
+
       is_expected.to have_css '.empty-table', text: 'So sorry, no records found!'
     end
   end
@@ -81,12 +81,12 @@ RSpec.describe Bali::Table::Component, type: :component do
       form = double('form')
       allow(form).to receive(:active_filters?) { true }
       allow(form).to receive(:id) { '1' }
-  
+
       @options = { form: form }
       render_inline(component) do |c|
         c.no_results_notification { 'So sorry, no results!' }
       end
-  
+
       is_expected.to have_css '.empty-table', text: 'So sorry, no results!'
     end
   end

--- a/spec/bali/components/table_spec.rb
+++ b/spec/bali/components/table_spec.rb
@@ -64,4 +64,30 @@ RSpec.describe Bali::Table::Component, type: :component do
 
     is_expected.to have_css 'a', text: 'Add New Record'
   end
+
+  context 'with custom no records notification' do
+    it 'renders an empty query message' do
+      @options.merge!(form: @filter_form)
+      render_inline(component) do |c|
+        c.no_records_notification { 'So sorry, no records found!'}
+      end
+  
+      is_expected.to have_css '.empty-table', text: 'So sorry, no records found!'
+    end
+  end
+
+  context 'with custom no results notification' do
+    it 'renders an empty table without results' do
+      form = double('form')
+      allow(form).to receive(:active_filters?) { true }
+      allow(form).to receive(:id) { '1' }
+  
+      @options = { form: form }
+      render_inline(component) do |c|
+        c.no_results_notification { 'So sorry, no results!' }
+      end
+  
+      is_expected.to have_css '.empty-table', text: 'So sorry, no results!'
+    end
+  end
 end


### PR DESCRIPTION
**Objetivo**

- Permitir desplegar un mensaje personalizado para las notificaciones `no reults/ no records` en el `Table::Component`