### PR TITLE
Add `type="button"` to carousel controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.2] - 2022-07-05
+
+- Add `type="button"` to Carousel controls (`arrows`, `bullets`).
+
 ## [0.24.1] - 2022-07-05
 
 - Set SideMenu list with optional title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.1] - 2022-07-05
+## [0.24.3] - 2022-07-05
 
 - Add `type="button"` to Carousel controls (`arrows`, `bullets`).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.24.2)
+    bali_view_components (0.24.3)
       rails (>= 7.0.2.3)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.24.1)
+    bali_view_components (0.24.2)
       rails (>= 7.0.2.3)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/carousel/arrows/component.html.erb
+++ b/app/components/bali/carousel/arrows/component.html.erb
@@ -1,8 +1,8 @@
 <%= tag.div **options do %>
-  <button class="glide__arrow glide__arrow--left" data-glide-dir="<">
+  <button type="button" class="glide__arrow glide__arrow--left" data-glide-dir="<">
     <%= render Bali::Icon::Component.new(previous_icon) %>
   </button>
-  <button class="glide__arrow glide__arrow--right" data-glide-dir=">">
+  <button type="button" class="glide__arrow glide__arrow--right" data-glide-dir=">">
     <%= render Bali::Icon::Component.new(next_icon) %>
   </button>
 <% end %>

--- a/app/components/bali/carousel/bullets/component.html.erb
+++ b/app/components/bali/carousel/bullets/component.html.erb
@@ -1,5 +1,8 @@
 <%= tag.div **options do %>
   <% count.times do |index| %>
-    <%= tag.button(class: "slider__bullet glide__bullet", 'aria-label': "Carousel Item #{index + 1}", data: { 'glide-dir': "=#{index}" }) %>
+    <%= tag.button(
+        class: "slider__bullet glide__bullet", 'aria-label': "Carousel Item #{index + 1}", 
+        data: { 'glide-dir': "=#{index}" },
+        type: 'button') %>
   <% end %>
 <% end %>

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.24.2'
+  VERSION = '0.24.3'
 end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.24.1'
+  VERSION = '0.24.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
**Objetivo**

- Agregar `type="button"` a `arrows` y `bullets` del Carousel. Al asignar `type="button"` aseguramos que cuando se de click a un control del carousel, este no intenté hacer submit de la forma (cuando el carousel está dentro de una forma).