### PR TITLE
Agregar parámetro con clases opcionales en delete link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.2] - 2022-07-06
+
+- Add option to delete link to add or not default classes
+
 ## [0.25.1] - 2022-07-06
 
 - Export `domHelpers`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.25.1)
+    bali_view_components (0.25.2)
       rails (>= 7.0.2.3)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/delete_link/component.rb
+++ b/app/components/bali/delete_link/component.rb
@@ -16,6 +16,7 @@ module Bali
         disabled: false,
         disabled_hover_url: nil,
         skip_confirm: false,
+        with_default_classes: true,
         **options
       )
         @model = model
@@ -27,7 +28,8 @@ module Bali
         @skip_confirm = skip_confirm
         @form_class = class_names('button_to', options.delete(:form_class))
 
-        @options = prepend_class_name(options, default_classes)
+        @options = options
+        @options = prepend_class_name(options, default_classes) if with_default_classes
 
         return unless @href.blank? && @model.blank?
 

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.25.1'
+  VERSION = '0.25.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
Objetivo:
En algunas opciones del delete link no se requieren las clases predeterminadas y no hay forma de omitirlas.