### PR TITLE
Allow to specify match type on sidemenu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.4] - 2022-07-18
+
+- Only consider exact URL matches for displaying a `SideMenu::Item` as active. This fixes a problem where 2 items had a similar URL and both were considered active.
+
 ## [0.30.3] - 2022-07-14
 
 - `step-number-input` controller was updated to be able to set a custom step.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.30.3)
+    bali_view_components (0.30.4)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/side_menu/component.rb
+++ b/app/components/bali/side_menu/component.rb
@@ -3,7 +3,7 @@
 module Bali
   module SideMenu
     class Component < ApplicationViewComponent
-      renders_many :lists, ->(title:, **options) do
+      renders_many :lists, ->(title: nil, **options) do
         List::Component.new(title: title, current_path: @current_path, **options)
       end
 

--- a/app/components/bali/side_menu/component.rb
+++ b/app/components/bali/side_menu/component.rb
@@ -3,9 +3,12 @@
 module Bali
   module SideMenu
     class Component < ApplicationViewComponent
-      renders_many :lists, List::Component
+      renders_many :lists, ->(title:, **options) do
+        List::Component.new(title: title, current_path: @current_path, **options)
+      end
 
-      def initialize(**options)
+      def initialize(current_path:, **options)
+        @current_path = current_path
         @options = options
         @options = prepend_class_name(@options, 'side-menu-component')
         @options = prepend_data_attribute(@options, :side_menu_target, 'container')

--- a/app/components/bali/side_menu/item/component.html.erb
+++ b/app/components/bali/side_menu/item/component.html.erb
@@ -1,9 +1,14 @@
 <li>
-  <%= render Bali::Link::Component.new(href: @href, name: @name, icon_name: @icon, active_path: request.path, **@options) %>
+  <%= render Bali::Link::Component.new(
+             href: @href,
+             name: @name,
+             icon_name: @icon,
+             active_path: current_path,
+             **@options) %>
 
-  <% if active?(request.path) && child_items.present? %>
+  <% if active? && items.present? %>
     <ul>
-      <% child_items.each do |item| %>
+      <% items.each do |item| %>
         <%= item %>
       <% end %>
     </ul>

--- a/app/components/bali/side_menu/item/component.rb
+++ b/app/components/bali/side_menu/item/component.rb
@@ -50,7 +50,7 @@ module Bali
         end
 
         def active_child_items?
-          items.reject(&:disabled?).any? { |i| i.active? }
+          items.reject(&:disabled?).any?(&:active?)
         end
       end
     end

--- a/app/components/bali/side_menu/item/component.rb
+++ b/app/components/bali/side_menu/item/component.rb
@@ -4,22 +4,29 @@ module Bali
   module SideMenu
     module Item
       class Component < ApplicationViewComponent
-        renders_many :child_items, 'Bali::SideMenu::Item::Component'
+        renders_many :items, ->(name:, href:, icon: nil, authorized: true, **options) do
+          Item::Component.new(
+            name: name,
+            href: href,
+            icon: icon,
+            authorized: authorized,
+            current_path: @current_path,
+            **options
+          )
+        end
 
-        attr_reader :href
+        attr_reader :href, :current_path, :match_type
 
-        def initialize(name:, href:, icon: nil, authorized: true, **options)
+        def initialize(name:, href:, current_path:, icon: nil, authorized: true, **options)
           @name = name
           @href = href
           @icon = icon
           @authorized = authorized
+          @current_path = current_path
+          @match_type = options.delete(:match) || :exact
+
           @options = options
-        end
-
-        def before_render
-          super
-
-          @options = prepend_class_name(@options, 'is-active') if active?(request.path)
+          @options = prepend_class_name(options, 'is-active') if active?
         end
 
         def render?
@@ -34,12 +41,12 @@ module Bali
           @href.blank?
         end
 
-        def active?(base_path)
-          base_path.include?(uri.path) || active_child_items?(base_path)
+        def active?
+          active_path?(uri.path, current_path, match: match_type) || active_child_items?
         end
 
-        def active_child_items?(base_path)
-          child_items.reject(&:disabled?).any? { |child_item| child_item.active?(base_path) }
+        def active_child_items?
+          items.reject(&:disabled?).any?(&:active?)
         end
       end
     end

--- a/app/components/bali/side_menu/item/component.rb
+++ b/app/components/bali/side_menu/item/component.rb
@@ -24,9 +24,13 @@ module Bali
           @authorized = authorized
           @current_path = current_path
           @match_type = options.delete(:match) || :exact
-
           @options = options
-          @options = prepend_class_name(options, 'is-active') if active?
+        end
+
+        def before_render
+          super
+
+          @options = prepend_class_name(@options, 'is-active') if active?
         end
 
         def render?
@@ -46,7 +50,7 @@ module Bali
         end
 
         def active_child_items?
-          items.reject(&:disabled?).any?(&:active?)
+          items.reject(&:disabled?).any? { |i| i.active? }
         end
       end
     end

--- a/app/components/bali/side_menu/list/component.rb
+++ b/app/components/bali/side_menu/list/component.rb
@@ -4,12 +4,22 @@ module Bali
   module SideMenu
     module List
       class Component < ApplicationViewComponent
-        renders_many :items, Item::Component
+        renders_many :items, ->(name:, href:, icon: nil, authorized: true, **options) do
+          Item::Component.new(
+            name: name,
+            href: href,
+            icon: icon,
+            authorized: authorized,
+            current_path: @current_path,
+            **options
+          )
+        end
 
         attr_reader :title
 
-        def initialize(title: nil, **options)
+        def initialize(current_path:, title: nil, **options)
           @title = title
+          @current_path = current_path
           @options = options
         end
 

--- a/app/components/bali/side_menu/preview.rb
+++ b/app/components/bali/side_menu/preview.rb
@@ -61,6 +61,22 @@ module Bali
           end
         end
       end
+
+      # SideMenu with Active Child Item
+      # -------------------
+      # Will display parent as active when a child item is active
+      # @param title text
+      def with_active_sub_item(title: 'Section title')
+        render(SideMenu::Component.new(current_path: '/child-item-1')) do |c|
+          c.list(title: title) do |list|
+            list.item(name: 'Parent Item', href: '/parent-item') do |item|
+              item.item(name: 'Child Item 1', href: '/child-item-1')
+              item.item(name: 'Child Item 2', href: '/child-item-2')
+              item.item(name: 'Child Item 3', href: '/child-item-3')
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/components/bali/side_menu/preview.rb
+++ b/app/components/bali/side_menu/preview.rb
@@ -5,11 +5,14 @@ module Bali
       # -------------------
       # Default menu with a section name and an item
       # @param title text
-      # @param name text
-      def default(title: 'Section Title', name: 'Item')
-        render(SideMenu::Component.new) do |c|
+      def default(title: 'Section Title')
+        render(SideMenu::Component.new(current_path: '/dashboard')) do |c|
           c.list(title: title) do |list|
-            list.item(name: name, href: '#')
+            list.item(name: 'Dashboard', href: '/dashboard')
+            list.item(name: 'Dashboard 2', href: '/t/dashboard')
+            list.item(name: 'Inventory', href: '/inventory')
+            list.item(name: 'Purchasing', href: '/purchasing')
+            list.item(name: 'Configuration', href: '/configuration')
           end
         end
       end
@@ -18,12 +21,12 @@ module Bali
       # -------------------
       # This will add an icon in the item specified
       # @param title text
-      # @param name text
-      # @param icon_name select [attachment, alert, paypal]
-      def with_icon(title: 'Section title', name: 'Item', icon_name: 'attachment')
-        render(SideMenu::Component.new) do |c|
+      def with_icon(title: 'Section title')
+        render(SideMenu::Component.new(current_path: '/attachment')) do |c|
           c.list(title: title) do |list|
-            list.item(name: name, href: '#', icon: icon_name)
+            list.item(name: 'Attachment', href: '/attachment', icon: 'attachment')
+            list.item(name: 'Alert', href: '/alert', icon: 'alert')
+            list.item(name: 'Paypal', href: '/paypal', icon: 'paypal')
           end
         end
       end
@@ -32,12 +35,13 @@ module Bali
       # -------------------
       # This will add a conditional to the item specified
       # @param title text
-      # @param name text
-      # @param authorized toggle
-      def authorized(title: 'Section title', name: 'Authorized Item', authorized: true)
-        render(SideMenu::Component.new) do |c|
+      def authorized(title: 'Section title')
+        render(SideMenu::Component.new(current_path: '/auth-1')) do |c|
           c.list(title: title) do |list|
-            list.item(name: name, authorized: authorized, href: '#')
+            list.item(name: 'Authorized 1', authorized: true, href: '/auth-1')
+            list.item(name: 'Authorized 2', authorized: true, href: '/auth-2')
+            list.item(name: 'Not authorized 1', authorized: false, href: '/not-auth-1')
+            list.item(name: 'Not authorized 2', authorized: false, href: '/not-auth-1')
           end
         end
       end
@@ -46,28 +50,14 @@ module Bali
       # -------------------
       # This will add subitems to an item
       # @param title text
-      # @param name text
-      # @param subitem_1 text
-      def with_sub_item(title: 'Section title', name: 'Item', subitem_1: 'Subitem 1')
-        render(SideMenu::Component.new) do |c|
+      def with_sub_item(title: 'Section title')
+        render(SideMenu::Component.new(current_path: '/parent-item')) do |c|
           c.list(title: title) do |list|
-            list.item(name: name, href: '#') do |item|
-              item.child_item(name: subitem_1, href: '#')
+            list.item(name: 'Parent Item', href: '/parent-item') do |item|
+              item.item(name: 'Child Item 1', href: '/child-item-1')
+              item.item(name: 'Child Item 2', href: '/child-item-2')
+              item.item(name: 'Child Item 3', href: '/child-item-3')
             end
-          end
-        end
-      end
-
-      # SideMenu with item disabled
-      # -------------------
-      # This will render a Menu with a disable item
-      # @param title text
-      # @param name text
-      # @param disabled toggle
-      def disabled(title: 'Section title', name: 'Item', disabled: true)
-        render(SideMenu::Component.new) do |c|
-          c.list(title: title) do |list|
-            list.item(name: name, href: '#', disabled: disabled)
           end
         end
       end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.30.3'
+  VERSION = '0.30.4'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/spec/bali/components/side_menu_spec.rb
+++ b/spec/bali/components/side_menu_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Bali::SideMenu::Component, type: :component do
-  let(:component) { Bali::SideMenu::Component.new }
+  before { @options = { current_path: '/' } }
+  let(:component) { Bali::SideMenu::Component.new(**@options) }
 
   it 'renders the side menu' do
     render_inline(component) do |c|
@@ -44,11 +45,10 @@ RSpec.describe Bali::SideMenu::Component, type: :component do
   end
 
   it 'renders an active link' do
-    with_request_url '/#' do
-      render_inline(component) do |c|
-        c.list(title: 'Section title') do |list|
-          list.item(name: 'item', href: '/#')
-        end
+    @options[:current_path] = '/item'
+    render_inline(component) do |c|
+      c.list(title: 'Section title') do |list|
+        list.item(name: 'item', href: '/item')
       end
     end
 

--- a/spec/bali/components/side_menu_spec.rb
+++ b/spec/bali/components/side_menu_spec.rb
@@ -44,15 +44,34 @@ RSpec.describe Bali::SideMenu::Component, type: :component do
     end
   end
 
-  it 'renders an active link' do
-    @options[:current_path] = '/item'
-    render_inline(component) do |c|
-      c.list(title: 'Section title') do |list|
-        list.item(name: 'item', href: '/item')
+  context 'with partial match' do
+    it 'renders an active link' do
+      @options[:current_path] = '/item/menu'
+      render_inline(component) do |c|
+        c.list(title: 'Section title') do |list|
+          list.item(name: 'item root', href: '/item', match: :partial)
+          list.item(name: 'item menu', href: '/item/menu')
+        end
       end
-    end
 
-    expect(page).to have_css 'a.is-active', text: 'item'
+      expect(page).to have_css 'a.is-active', text: 'item root'
+      expect(page).to have_css 'a.is-active', text: 'item menu'
+    end
+  end
+
+  context 'with exact match' do
+    it 'renders an active link' do
+      @options[:current_path] = '/item'
+      render_inline(component) do |c|
+        c.list(title: 'Section title') do |list|
+          list.item(name: 'item root', href: '/item')
+          list.item(name: 'item 1', href: '/item/1')
+        end
+      end
+
+      expect(page).to have_css 'a.is-active', text: 'item root'
+      expect(page).not_to have_css 'a.is-active', text: 'item 1'
+    end
   end
 
   it 'renders a disabled link' do


### PR DESCRIPTION
Only consider exact URL matches for displaying a `SideMenu::Item` as active. This fixes a problem where 2 items had a similar URL and both were considered active.