### PR TITLE
Addind border bottom to the reveal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2022-07-29
+
+- Add `border` to `Reveal::Component` to show or hide the `border-bottom` just below the trigger.
+
 ## [0.32.2] - 2022-07-28
 
 - Add `new` to CRUD actions to display an active tab when current_path is matched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.33.0] - 2022-07-29
 
-- Add `border` to `Reveal::Component` to show or hide the `border-bottom` just below the trigger.
+- Add `show_border` to `Reveal::Component` to show or hide the `border-bottom` just below the trigger.
 
 ## [0.32.2] - 2022-07-28
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.32.2)
+    bali_view_components (0.33.0)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/reveal/index.scss
+++ b/app/components/bali/reveal/index.scss
@@ -7,12 +7,15 @@
     align-items: center;
     padding-bottom: $size-4;
     margin-bottom: $size-4;
-    border-bottom: 0.0625rem solid rgba(0, 0, 0, 0.23);
-  
+
     .icon {
       height: $size-7;
       transform: rotate(270deg);
     }
+  }
+
+  .is-border-bottom {
+    border-bottom: 0.0625rem solid rgba(0, 0, 0, 0.23);
   }
 
   .reveal-content {

--- a/app/components/bali/reveal/index.scss
+++ b/app/components/bali/reveal/index.scss
@@ -1,3 +1,6 @@
+$border-thickness: 0.0625rem;
+$border-color: rgba(0, 0, 0, 0.23);
+
 .reveal-component {
   user-select: none;
 
@@ -15,7 +18,7 @@
   }
 
   .is-border-bottom {
-    border-bottom: 0.0625rem solid rgba(0, 0, 0, 0.23);
+    border-bottom: $border-thickness solid $border-color;
   }
 
   .reveal-content {

--- a/app/components/bali/reveal/preview.rb
+++ b/app/components/bali/reveal/preview.rb
@@ -8,9 +8,10 @@ module Bali
       # Displays hidden content when clicked
       #
       # @param opened toggle
-      def default(opened: false)
+      # @param border toggle
+      def default(opened: false, border: false)
         render Reveal::Component.new(opened: opened) do |c|
-          c.trigger(title: 'Click to see contents')
+          c.trigger(title: 'Click to see contents', border: border)
 
           c.tag.h1 'Revealed contents'
         end

--- a/app/components/bali/reveal/preview.rb
+++ b/app/components/bali/reveal/preview.rb
@@ -8,10 +8,10 @@ module Bali
       # Displays hidden content when clicked
       #
       # @param opened toggle
-      # @param border toggle
-      def default(opened: false, border: false)
+      # @param show_border toggle
+      def default(opened: false, show_border: false)
         render Reveal::Component.new(opened: opened) do |c|
-          c.trigger(title: 'Click to see contents', border: border)
+          c.trigger(title: 'Click to see contents', show_border: show_border)
 
           c.tag.h1 'Revealed contents'
         end

--- a/app/components/bali/reveal/trigger/component.rb
+++ b/app/components/bali/reveal/trigger/component.rb
@@ -6,7 +6,7 @@ module Bali
       class Component < ApplicationViewComponent
         attr_reader :title, :options
 
-        def initialize(title:, border: true, **options)
+        def initialize(title:, show_border: true, **options)
           @title = title
           @title_class = options.delete(:title_class)
           @icon_class = options.delete(:icon_class)
@@ -14,7 +14,7 @@ module Bali
           @options = prepend_class_name(options, 'reveal-trigger')
           @options = prepend_action(@options, 'click->reveal#toggle')
 
-          @options = prepend_class_name(options, 'is-border-bottom') if border
+          @options = prepend_class_name(options, 'is-border-bottom') if show_border
         end
       end
     end

--- a/app/components/bali/reveal/trigger/component.rb
+++ b/app/components/bali/reveal/trigger/component.rb
@@ -6,13 +6,15 @@ module Bali
       class Component < ApplicationViewComponent
         attr_reader :title, :options
 
-        def initialize(title:, **options)
+        def initialize(title:, border: true, **options)
           @title = title
           @title_class = options.delete(:title_class)
           @icon_class = options.delete(:icon_class)
 
           @options = prepend_class_name(options, 'reveal-trigger')
           @options = prepend_action(@options, 'click->reveal#toggle')
+
+          @options = prepend_class_name(options, 'is-border-bottom') if border
         end
       end
     end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.32.2'
+  VERSION = '0.33.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/spec/bali/components/reveal_spec.rb
+++ b/spec/bali/components/reveal_spec.rb
@@ -30,4 +30,22 @@ RSpec.describe Bali::Reveal::Component, type: :component do
     expect(page).to have_css 'div.reveal-title', text: 'Click here'
     expect(page).to have_css '.icon-component'
   end
+
+  it 'renders border at bottom' do
+    render_inline(component) do |c|
+      c.trigger(title: 'Click here', title_class: 'reveal-title')
+    end
+
+    expect(page).to have_css 'div.is-border-bottom'
+  end
+
+  it 'does not render border at bottom' do
+    render_inline(component) do |c|
+      c.trigger(title: 'Click here', border: false)
+    end
+
+    render_inline(component)
+
+    expect(page).not_to have_css 'div.is-border-bottom'
+  end
 end

--- a/spec/bali/components/reveal_spec.rb
+++ b/spec/bali/components/reveal_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Bali::Reveal::Component, type: :component do
 
   it 'does not render border at bottom' do
     render_inline(component) do |c|
-      c.trigger(title: 'Click here', border: false)
+      c.trigger(title: 'Click here', show_border: false)
     end
 
     render_inline(component)


### PR DESCRIPTION
- It adds a boolean to validate to show or not the border at bottom. 
- by default will render as is the current behavior right now..
- So if you dont want to render border, send `border: false` on the trigger