### PR TITLE
Remove stroke attribute from svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.1] - 2022-08-3
+
+- remove `stroke` attribute from `svg` icons.
+
 ## [0.35.0] - 2022-08-3
 
 - Add `under-modal` class to hide the hover-card when is necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.1] - 2022-08-3
 
-- remove `stroke` attribute from `svg` icons.
+- Remove `stroke` attribute from `rect` and add `stroke` and `fill` in `svg` icons.
 
 ## [0.35.0] - 2022-08-3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.35.0)
+    bali_view_components (0.35.1)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/icon/options.rb
+++ b/app/components/bali/icon/options.rb
@@ -526,17 +526,17 @@ module Bali
       )
 
       DAY = %(
-        <svg viewBox="0 0 10 10" class="svg-inline">
-          <rect x="9.5" y="0.5" width="9" height="9" rx="0.5" transform="rotate(90 9.5 0.5)" stroke="white"/>
+        <svg viewBox="0 0 10 10" class="svg-inline" stroke="currentColor">
+          <rect x="9.5" y="0.5" width="9" height="9" rx="0.5" transform="rotate(90 9.5 0.5)" />
         </svg>
       )
 
       MONTH = %(
-        <svg viewBox="0 0 18 19" class="svg-inline">
-          <rect x="17.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 0.5)" stroke="white"/>
-          <rect x="7.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 7.5 0.5)" stroke="white"/>
-          <rect x="17.5" y="11.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 11.5)" stroke="white"/>
-          <rect x="7.5" y="11.5" width="7" height="7" rx="0.5" transform="rotate(90 7.5 11.5)" stroke="white"/>
+        <svg viewBox="0 0 18 19" class="svg-inline" stroke="currentColor">
+          <rect x="17.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 0.5)" />
+          <rect x="7.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 7.5 0.5)" />
+          <rect x="17.5" y="11.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 11.5)" />
+          <rect x="7.5" y="11.5" width="7" height="7" rx="0.5" transform="rotate(90 7.5 11.5)" />
         </svg>
       )
 
@@ -547,10 +547,10 @@ module Bali
       )
 
       WEEK = %(
-        <svg viewBox="0 0 20 19" class="svg-inline">
-          <rect x="19.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 19.5 0.5)" stroke="white"/>
-          <rect x="12.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 12.5 0.5)" stroke="white"/>
-          <rect x="4.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 4.5 0.5)" stroke="white"/>
+        <svg viewBox="0 0 20 19" class="svg-inline" stroke="currentColor">
+          <rect x="19.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 19.5 0.5)" />
+          <rect x="12.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 12.5 0.5)" />
+          <rect x="4.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 4.5 0.5)" />
         </svg>
       )
 

--- a/app/components/bali/icon/options.rb
+++ b/app/components/bali/icon/options.rb
@@ -526,13 +526,13 @@ module Bali
       )
 
       DAY = %(
-        <svg viewBox="0 0 10 10" class="svg-inline" stroke="currentColor">
+        <svg viewBox="0 0 10 10" class="svg-inline" stroke="currentColor" fill="none">
           <rect x="9.5" y="0.5" width="9" height="9" rx="0.5" transform="rotate(90 9.5 0.5)" />
         </svg>
       )
 
       MONTH = %(
-        <svg viewBox="0 0 18 19" class="svg-inline" stroke="currentColor">
+        <svg viewBox="0 0 18 19" class="svg-inline" stroke="currentColor" fill="none">
           <rect x="17.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 0.5)" />
           <rect x="7.5" y="0.5" width="7" height="7" rx="0.5" transform="rotate(90 7.5 0.5)" />
           <rect x="17.5" y="11.5" width="7" height="7" rx="0.5" transform="rotate(90 17.5 11.5)" />
@@ -547,7 +547,7 @@ module Bali
       )
 
       WEEK = %(
-        <svg viewBox="0 0 20 19" class="svg-inline" stroke="currentColor">
+        <svg viewBox="0 0 20 19" class="svg-inline" stroke="currentColor" fill="none">
           <rect x="19.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 19.5 0.5)" />
           <rect x="12.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 12.5 0.5)" />
           <rect x="4.5" y="0.5" width="18" height="4" rx="0.5" transform="rotate(90 4.5 0.5)" />

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.35.0'
+  VERSION = '0.35.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
- Remove `stroke` attribute from `rect` and add `stroke` and `fill` in `svg` icons.