### PR TITLE
Replace image url for url stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `dartsass-rails` requires replaceing `image-url` with `url` to display icons/images. 
+- `dartsass-rails` requires replacing `image-url` with `url` to display icons/images. 
 
 ## [0.43.0] - 2022-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `dartsass-rails` requires to replace `image-url` for `url` to display icons/images. 
+- `dartsass-rails` requires replaceing `image-url` with `url` to display icons/images. 
 
 ## [0.43.0] - 2022-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.1] - 2022-09-13
+
+### Fixed
+
+- `dartsass-rails` requires to replace `image-url` for `url` to display icons/images. 
+
 ## [0.43.0] - 2022-09-05
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.43.0)
+    bali_view_components (0.43.1)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/search_input/index.scss
+++ b/app/components/bali/search_input/index.scss
@@ -12,7 +12,7 @@
     position: relative;
   
     &::after {
-      content: image-url('bali/svg/search.svg');
+      content: url('bali/svg/search.svg');
       position: absolute;
       right: $size-6;
       top: 50%;

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.43.0'
+  VERSION = '0.43.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
**Objetivo**

- Remplazar `image-url` con `url` en los archivos `scss` para cumplir con el formato de `dartsass-rails`