### PR TITLE
Fix gantt chart component current date and dates offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.1] - 2022-09-21
+
+### Fixed
+
+- Updated `GanttChart::Component` timeline headers calculation to fix current day flag and chart offset.
+
 ## [0.44.0] - 2022-09-15
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.44.0)
+    bali_view_components (0.44.1)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/gantt_chart/component.rb
+++ b/app/components/bali/gantt_chart/component.rb
@@ -35,8 +35,6 @@ module Bali
         @list_param_name = list_param_name
 
         @start_date = start_date
-        @default_min_date = Date.current - 2.months
-        @default_max_date = Date.current + 2.months
 
         @task_colors = options.delete(:colors) || {
           default: 'hsl(196, 82%, 62%)',  # blue-4
@@ -99,7 +97,7 @@ module Bali
 
         case zoom
         when :day
-          (min_date - 1.month).beginning_of_month
+          (min_date - 3.months).beginning_of_month
         when :week
           (min_date - 2.months).beginning_of_week
         when :month
@@ -110,7 +108,7 @@ module Bali
       def end_date
         case zoom
         when :day
-          (max_date + 1.month).end_of_month
+          (max_date + 3.months).end_of_month
         when :week
           (max_date + 2.months).end_of_week
         when :month
@@ -142,11 +140,11 @@ module Bali
       end
 
       def min_date
-        @min_date ||= [earliest_task&.start_date, @default_min_date].compact.min
+        @min_date ||= [earliest_task&.start_date, Date.current].compact.min
       end
 
       def max_date
-        @max_date ||= [latest_task&.end_date, @default_max_date].compact.max
+        @max_date ||= [latest_task&.end_date, Date.current].compact.max
       end
 
       def earliest_task

--- a/app/components/bali/gantt_chart/component.rb
+++ b/app/components/bali/gantt_chart/component.rb
@@ -43,6 +43,8 @@ module Bali
         @tasks = tasks.map { |task| Task.new(**task) }
         @tasks = setup_parent_child_relationships(@tasks)
 
+        @months_count = months_to_today.to_i
+
         @options = setup_options(options)
       end
       # rubocop:enable Metrics/ParameterLists
@@ -92,13 +94,15 @@ module Bali
       end
 
       def start_date
+        date = min_date > Date.current ? Date.current : min_date
+
         case zoom
         when :day
-          (min_date - 1.month).beginning_of_month
+          (date - 1.month).beginning_of_month
         when :week
-          (min_date - 2.months).beginning_of_week
+          (date - 2.months).beginning_of_week
         when :month
-          (min_date - 1.year).beginning_of_year
+          (date - 1.year).beginning_of_year
         end
       end
 
@@ -170,7 +174,8 @@ module Bali
       def months_to_today
         start_month = (start_date.year * 12) + start_date.month
         current_month = (Date.current.year * 12) + Date.current.month
-        (start_month - current_month).to_i.abs + (Date.current.day / 30.0)
+
+        @months_to_today ||= (start_month - current_month).to_i.abs + (Date.current.day / 30.0)
       end
     end
   end

--- a/app/components/bali/gantt_chart/component.rb
+++ b/app/components/bali/gantt_chart/component.rb
@@ -43,8 +43,6 @@ module Bali
         @tasks = tasks.map { |task| Task.new(**task) }
         @tasks = setup_parent_child_relationships(@tasks)
 
-        @months_count = months_to_today.to_i
-
         @options = setup_options(options)
       end
       # rubocop:enable Metrics/ParameterLists
@@ -94,15 +92,13 @@ module Bali
       end
 
       def start_date
-        date = min_date > Date.current ? Date.current : min_date
-
         case zoom
         when :day
-          (date - 1.month).beginning_of_month
+          (min_date - 1.month).beginning_of_month
         when :week
-          (date - 2.months).beginning_of_week
+          (min_date - 2.months).beginning_of_week
         when :month
-          (date - 1.year).beginning_of_year
+          (min_date - 1.year).beginning_of_year
         end
       end
 
@@ -141,7 +137,7 @@ module Bali
       end
 
       def min_date
-        @min_date ||= earliest_task&.start_date || @default_min_date
+        @min_date ||= [earliest_task&.start_date, @default_min_date].compact.min
       end
 
       def max_date
@@ -174,8 +170,7 @@ module Bali
       def months_to_today
         start_month = (start_date.year * 12) + start_date.month
         current_month = (Date.current.year * 12) + Date.current.month
-
-        @months_to_today ||= (start_month - current_month).to_i.abs + (Date.current.day / 30.0)
+        (start_month - current_month).to_i.abs + (Date.current.day / 30.0)
       end
     end
   end

--- a/app/components/bali/gantt_chart/component.rb
+++ b/app/components/bali/gantt_chart/component.rb
@@ -20,6 +20,7 @@ module Bali
         offset: nil,
         resource_name: nil,
         list_param_name: 'list_id',
+        start_date: nil,
         **options
       )
         @row_height = row_height
@@ -33,6 +34,7 @@ module Bali
         @resource_name = resource_name
         @list_param_name = list_param_name
 
+        @start_date = start_date
         @default_min_date = Date.current - 2.months
         @default_max_date = Date.current + 2.months
 
@@ -83,7 +85,8 @@ module Bali
           today_offset: today_offset,
           row_height: row_height,
           col_width: col_width,
-          zoom: zoom
+          zoom: zoom,
+          start_date: start_date
         }
       end
 
@@ -92,6 +95,8 @@ module Bali
       end
 
       def start_date
+        return Date.parse(@start_date) if @start_date.present?
+
         case zoom
         when :day
           (min_date - 1.month).beginning_of_month

--- a/app/components/bali/gantt_chart/index.js
+++ b/app/components/bali/gantt_chart/index.js
@@ -32,7 +32,8 @@ export class GanttChartController extends Controller {
     colWidth: Number,
     zoom: String,
     listWidth: { type: Number, default: 200 },
-    responseKind: { type: String, default: 'turbo-stream' }
+    responseKind: { type: String, default: 'turbo-stream' },
+    startDate: String
   }
 
   connect () {
@@ -249,6 +250,11 @@ export class GanttChartController extends Controller {
     }
 
     let body = {}
+
+    if (this.hasStartDateValue) {
+      body.chart_start_date = this.startDateValue
+    }
+
     if (this.resourceNameValue) {
       body[this.resourceNameValue] = attributes
     } else {

--- a/app/components/bali/gantt_chart/index.js
+++ b/app/components/bali/gantt_chart/index.js
@@ -66,7 +66,7 @@ export class GanttChartController extends Controller {
   }
 
   disconnect () {
-    this.clearConnectionCavnas()
+    this.clearConnectionCanvas()
     this.timelineTarget.removeEventListener(
       'scroll',
       this.throttledUpdateScroll
@@ -162,7 +162,7 @@ export class GanttChartController extends Controller {
     })
 
     const anyFolded = Object.values(rowData).some(({ folded }) => folded)
-    anyFolded ? this.clearConnectionCavnas() : this.drawConnections()
+    anyFolded ? this.clearConnectionCanvas() : this.drawConnections()
   }
 
   calculateHeight (listRow) {
@@ -337,11 +337,11 @@ export class GanttChartController extends Controller {
   }
 
   drawConnections = () => {
-    this.clearConnectionCavnas()
+    this.clearConnectionCanvas()
     this.dependentConnections.forEach(line => line.draw())
   }
 
-  clearConnectionCavnas () {
+  clearConnectionCanvas () {
     const { width, height } = this.connectionCanvasTarget
     this.canvasContext.clearRect(0, 0, width, height)
   }

--- a/app/components/bali/gantt_chart/preview.rb
+++ b/app/components/bali/gantt_chart/preview.rb
@@ -64,8 +64,10 @@ module Bali
             id: 3, name: 'Task 1.2', start_date: date + 2.days, end_date: date + 6.days,
             update_url: '/gantt_chart/3', parent_id: 1
           },
-          { id: 4, name: 'Task 1.3', start_date: date + 6.days, end_date: date + 20.days,
-            update_url: '/gantt_chart/4', parent_id: 1, progress: 60 },
+          {
+            id: 4, name: 'Task 1.3', start_date: date + 6.days, end_date: date + 20.days,
+            update_url: '/gantt_chart/4', parent_id: 1, progress: 60
+          },
           {
             id: 5, name: 'Task 1.3.1', start_date: date + 6.days, end_date: date + 12.days,
             update_url: '/gantt_chart/5', parent_id: 4, critical: true, progress: 20

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd spec/dummy && bin/dev

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.44.0'
+  VERSION = '0.44.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/spec/bali/components/gantt_chart_spec.rb
+++ b/spec/bali/components/gantt_chart_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Bali::GanttChart::Component, type: :component do
   let(:options) { { tasks: tasks } }
   let(:component) { Bali::GanttChart::Component.new(**options) }
 
+  def month_name(number)
+    I18n.t('date.month_names')[number]
+  end
+
   context 'chart actions' do
     before do
       render_inline(component) do |c|
@@ -108,14 +112,28 @@ RSpec.describe Bali::GanttChart::Component, type: :component do
           @end_date = @date + 20.days
         end
 
-        it 'renders headers from 1 month before the first task' do
-          start_month = I18n.t('date.month_names')[(@date - 1.month).beginning_of_month.month]
-          expect(page).to have_css '.gantt-chart-header-month', text: start_month
+        context 'earliest header' do
+          it 'renders headers from 3 months before the first task' do
+            start_month = month_name((@date - 3.months).beginning_of_month.month)
+            expect(page).to have_css '.gantt-chart-header-month', text: start_month
+          end
+
+          it 'does not render header before gantt chart start_date' do
+            invalid_start_month = month_name((@date - 4.months).beginning_of_month.month)
+            expect(page).not_to have_css '.gantt-chart-header-month', text: invalid_start_month
+          end
         end
 
-        it 'renders headers 1 month after the last task' do
-          end_month = I18n.t('date.month_names')[(@end_date + 1.month).end_of_month.month]
-          expect(page).to have_css '.gantt-chart-header-month', text: end_month
+        context 'latest header' do
+          it 'renders headers 3 months after the last task' do
+            end_month = month_name((@end_date + 3.months).end_of_month.month)
+            expect(page).to have_css '.gantt-chart-header-month', text: end_month
+          end
+
+          it 'does not render header after gantt chart end_date' do
+            invalid_end_month = month_name((@end_date + 4.months).end_of_month.month)
+            expect(page).not_to have_css '.gantt-chart-header-month', text: invalid_end_month
+          end
         end
       end
 

--- a/spec/bali/components/gantt_chart_spec.rb
+++ b/spec/bali/components/gantt_chart_spec.rb
@@ -101,20 +101,47 @@ RSpec.describe Bali::GanttChart::Component, type: :component do
     end
 
     context 'day zoom' do
-      before do
-        options.merge!(zoom: :day)
-        render_inline(component)
-        @end_date = @date + 20.days
+      context 'when tasks begin from current month' do
+        before do
+          options.merge!(zoom: :day)
+          render_inline(component)
+          @end_date = @date + 20.days
+        end
+
+        it 'renders headers from 1 month before the first task' do
+          start_month = I18n.t('date.month_names')[(@date - 1.month).beginning_of_month.month]
+          expect(page).to have_css '.gantt-chart-header-month', text: start_month
+        end
+
+        it 'renders headers 1 month after the last task' do
+          end_month = I18n.t('date.month_names')[(@end_date + 1.month).end_of_month.month]
+          expect(page).to have_css '.gantt-chart-header-month', text: end_month
+        end
       end
 
-      it 'renders headers from 1 month before the first task' do
-        start_month = I18n.t('date.month_names')[(@date - 1.month).beginning_of_month.month]
-        expect(page).to have_css '.gantt-chart-header-month', text: start_month
-      end
+      context 'when tasks begin after current month' do
+        before do
+          @date = Date.current.beginning_of_month
 
-      it 'renders headers 1 month after the last task' do
-        end_month = I18n.t('date.month_names')[(@end_date + 1.month).end_of_month.month]
-        expect(page).to have_css '.gantt-chart-header-month', text: end_month
+          @tasks = [
+            { id: 1, name: 'Task 1', start_date: @date + 5.months,
+              end_date: @date + 5.months + 1.week },
+            { id: 2, name: 'Task 2', start_date: @date + 6.months,
+              end_date: @date + 6.months + 1.week }
+          ]
+
+          render_inline(Bali::GanttChart::Component.new(tasks: @tasks))
+        end
+
+        it 'renders headers from 1 month before current date' do
+          start_month = I18n.t('date.month_names')[(@date - 1.month).month]
+          expect(page).to have_css '.gantt-chart-header-month', text: start_month
+        end
+
+        it 'renders headers 1 month after the last task' do
+          end_month = I18n.t('date.month_names')[(@date + 7.months).month]
+          expect(page).to have_css '.gantt-chart-header-month', text: end_month
+        end
       end
     end
 

--- a/spec/bali/components/gantt_chart_spec.rb
+++ b/spec/bali/components/gantt_chart_spec.rb
@@ -152,12 +152,12 @@ RSpec.describe Bali::GanttChart::Component, type: :component do
         end
 
         it 'renders headers from 1 month before current date' do
-          start_month = I18n.t('date.month_names')[(@date - 1.month).month]
+          start_month = month_name((@date - 1.month).month)
           expect(page).to have_css '.gantt-chart-header-month', text: start_month
         end
 
         it 'renders headers 1 month after the last task' do
-          end_month = I18n.t('date.month_names')[(@date + 7.months).month]
+          end_month = month_name((@date + 7.months).month)
           expect(page).to have_css '.gantt-chart-header-month', text: end_month
         end
       end


### PR DESCRIPTION
- Updated `GanttChart::Component` timeline headers calculation to fix current day flag and chart offset.
- Gantt chart component now receives an optional start_date value