### PR TITLE
Display cancel button in native apps (not inside a modal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.0] - 2022-09-27
+
+### Updated
+
+- `submit_actions` to display the cancel button in native apps when it is not being displayed inside a modal.
+
 ## [0.46.2] - 2022-09-27
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.46.2)
+    bali_view_components (0.47.0)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/lib/bali/form_builder/submit_fields.rb
+++ b/lib/bali/form_builder/submit_fields.rb
@@ -39,8 +39,9 @@ module Bali
           submit(value, options)
         end
 
+        render_cancel_button = cancel.present? && !(Bali.native_app && options[:modal])
         @template.content_tag(:div, id: field_id, class: field_class, data: field_data) do
-          cancel.present? && !Bali.native_app ? cancel + submit : submit
+          render_cancel_button ? cancel + submit : submit
         end
       end
 

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.46.2'
+  VERSION = '0.47.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
**Objetivo**

- Display the cancel button in native apps when it is not being displayed inside a modal.