### PR TITLE
Agregar parámetros fuera del scope `q` en `Filters` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `hidden attributes` to filters component. 
+- `additional query params` to filters component. This helps to add query parameters not related to the form.
 
 ## [0.54.1] - 2022-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.2] - 2022-11-14
+
+### Added
+
+- `hidden attributes` to filters component. 
+
 ## [0.54.1] - 2022-11-11
 
 ### Updated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.54.1)
+    bali_view_components (0.54.2)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/app/components/bali/filters/component.html.erb
+++ b/app/components/bali/filters/component.html.erb
@@ -1,6 +1,10 @@
 <%= form_with(model: form, url: url, method: :get, data: form_data, class: 'width-inherit') do |f| %>
   <div class="level filters-component is-mobile width-inherit">
     <div class="level-left width-inherit">
+      <% hidden_attributes.each do |hidden_attribute| %>
+        <%= hidden_attribute %>
+      <% end %>
+
       <% if text_field.present? %>
         <div class="level-item width-inherit">
           <%= render Bali::SearchInput::Component.new(form: form, method: text_field, auto_submit: auto_submit_search_input) %>

--- a/app/components/bali/filters/component.html.erb
+++ b/app/components/bali/filters/component.html.erb
@@ -1,8 +1,8 @@
 <%= form_with(model: form, url: url, method: :get, data: form_data, class: 'width-inherit') do |f| %>
   <div class="level filters-component is-mobile width-inherit">
     <div class="level-left width-inherit">
-      <% hidden_attributes.each do |hidden_attribute| %>
-        <%= hidden_attribute %>
+      <% additional_query_params.each do |query_param| %>
+        <%= query_param %>
       <% end %>
 
       <% if text_field.present? %>

--- a/app/components/bali/filters/component.rb
+++ b/app/components/bali/filters/component.rb
@@ -16,7 +16,7 @@ module Bali
           multiple: multiple
         )
       end
-    
+
       renders_many :additional_query_params
 
       def initialize(form:, url:, text_field: nil, opened: false, **options)

--- a/app/components/bali/filters/component.rb
+++ b/app/components/bali/filters/component.rb
@@ -16,6 +16,8 @@ module Bali
           multiple: multiple
         )
       end
+    
+      renders_many :hidden_attributes
 
       def initialize(form:, url:, text_field: nil, opened: false, **options)
         @form = form

--- a/app/components/bali/filters/component.rb
+++ b/app/components/bali/filters/component.rb
@@ -17,7 +17,7 @@ module Bali
         )
       end
     
-      renders_many :hidden_attributes
+      renders_many :additional_query_params
 
       def initialize(form:, url:, text_field: nil, opened: false, **options)
         @form = form

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.54.1'
+  VERSION = '0.54.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",


### PR DESCRIPTION
**Objetivo**

- Agregar la posibiidad de incluir `query params` fuera del scope `q` dentro del componente `Filters`. Por ejemplo, `locale`, `week number` son parámetros que deben aparecer en el query de búsqueda, pero no son parte de los atributos de la forma (`FilterForm`) del componente `Filters`