### PR TITLE
Fix: `percentage_field_group`, `currency_field_group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.0] - 2023-01-31
+
+### Fixed
+
+- Added `Bali::Concerns::NumericAttributesWithCommas`. This concern complements the `percentage_field_group` and `currency_field_group` methods by removing the `commas` before saving the value to the DB.
+
 ## [0.56.3] - 2023-01-29
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (0.56.3)
+    bali_view_components (0.57.0)
       rails (>= 7.0.2)
       ransack
       view_component (>= 2.0.0, < 3.0)

--- a/lib/bali.rb
+++ b/lib/bali.rb
@@ -14,6 +14,7 @@ require 'bali/html_element_helper'
 require 'bali/path_helper'
 require 'bali/form_helper'
 require 'bali/auto_submit_select_helper'
+require 'bali/concerns/numeric_attributes_with_commas'
 
 builder_helpers = File.join(File.dirname(__FILE__), 'bali/form_builder', '*_fields.rb')
 

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -9,20 +9,24 @@ module Bali
 
       class_methods do
         def percentage_attribute(name)
-          numeric_attribute_with_commas(name)
+          define_numeric_attribute_setter(name)
+          define_numeric_attribute_getter(name)
         end
 
         def currency_attribute(name)
-          numeric_attribute_with_commas(name)
+          define_numeric_attribute_setter(name)
+          define_numeric_attribute_getter(name)
         end
 
-        def numeric_attribute_with_commas(name)
+        def define_numeric_attribute_setter(name)
           define_method name do
             return read_attribute(name.to_sym) if respond_to?(:read_attribute)
 
             instance_variable_get("@#{name}")
           end
+        end
 
+        def define_numeric_attribute_getter(name)
           define_method "#{name}=" do |value|
             value = value.gsub(',', '').to_d if value.is_a?(String)
 

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bali
   module Concerns
     module NumericAttributesWithCommas
@@ -14,13 +16,13 @@ module Bali
 
         def numeric_attribute_with_commas(name)
           define_method name do
-            self.read_attribute(name.to_sym)
+            read_attribute(name.to_sym)
           end
-  
+
           define_method "#{name}=" do |value|
             value = value.gsub(',', '') if value.is_a?(String)
 
-            self.write_attribute(name.to_sym, value)
+            write_attribute(name.to_sym, value)
           end
         end
       end

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -19,7 +19,7 @@ module Bali
         def numeric_attribute_with_commas(name)
           define_method name do
             return read_attribute(name.to_sym) if respond_to?(:read_attribute)
-              
+
             instance_variable_get("@#{name}")
           end
 

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Complements the `percentage_field_group` and `currency_field_group` methods 
+# Complements the `percentage_field_group` and `currency_field_group` methods
 # by removing the `commas` before saving the value to the DB.
 module Bali
   module Concerns

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -18,13 +18,19 @@ module Bali
 
         def numeric_attribute_with_commas(name)
           define_method name do
-            read_attribute(name.to_sym)
+            return read_attribute(name.to_sym) if respond_to?(:read_attribute)
+              
+            instance_variable_get("@#{name}")
           end
 
           define_method "#{name}=" do |value|
             value = value.gsub(',', '').to_d if value.is_a?(String)
 
-            write_attribute(name.to_sym, value)
+            if respond_to?(:write_attribute)
+              write_attribute(name.to_sym, value)
+            else
+              instance_variable_set("@#{name}", value)
+            end
           end
         end
       end

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -1,0 +1,29 @@
+module Bali
+  module Concerns
+    module NumericAttributesWithCommas
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def percentage_attribute(name)
+          numeric_attribute_with_commas(name)
+        end
+
+        def currency_attribute(name)
+          numeric_attribute_with_commas(name)
+        end
+
+        def numeric_attribute_with_commas(name)
+          define_method name do
+            self.read_attribute(name.to_sym)
+          end
+  
+          define_method "#{name}=" do |value|
+            value = value.gsub(',', '') if value.is_a?(String)
+
+            self.write_attribute(name.to_sym, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Complements the `percentage_field_group` and `currency_field_group` methods 
+# by removing the `commas` before saving the value to the DB.
 module Bali
   module Concerns
     module NumericAttributesWithCommas

--- a/lib/bali/concerns/numeric_attributes_with_commas.rb
+++ b/lib/bali/concerns/numeric_attributes_with_commas.rb
@@ -20,7 +20,7 @@ module Bali
           end
 
           define_method "#{name}=" do |value|
-            value = value.gsub(',', '') if value.is_a?(String)
+            value = value.gsub(',', '').to_d if value.is_a?(String)
 
             write_attribute(name.to_sym, value)
           end

--- a/lib/bali/form_builder/percentage_fields.rb
+++ b/lib/bali/form_builder/percentage_fields.rb
@@ -8,10 +8,11 @@ module Bali
           placeholder: 0,
           addon_right: tag.span('%', class: 'button is-static'),
           step: '0.01',
+          pattern_type: :number_with_commas
         )
 
         @template.render Bali::FieldGroupWrapper::Component.new self, method, options do
-          number_field(method, options)
+          text_field(method, options)
         end
       end
     end

--- a/lib/bali/form_builder/percentage_fields.rb
+++ b/lib/bali/form_builder/percentage_fields.rb
@@ -8,11 +8,10 @@ module Bali
           placeholder: 0,
           addon_right: tag.span('%', class: 'button is-static'),
           step: '0.01',
-          pattern_type: :number_with_commas
         )
 
         @template.render Bali::FieldGroupWrapper::Component.new self, method, options do
-          text_field(method, options)
+          number_field(method, options)
         end
       end
     end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '0.56.3'
+  VERSION = '0.57.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "0.56.3",
+  "version": "0.57.0",
   "description": "Bali ViewComponents",
   "main": "app/javascript/bali/index.js",
   "repository": "git@github.com:Grupo-AFAL/bali.git",

--- a/spec/bali/concerns/numeric_attributes_with_commas_spec.rb
+++ b/spec/bali/concerns/numeric_attributes_with_commas_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class ModelWithNumericAttributesWithCommas
+  include Bali::Concerns::NumericAttributesWithCommas
+
+  currency_attribute :price
+  percentage_attribute :waste_percentage
+end
+
+RSpec.describe Bali::Concerns::NumericAttributesWithCommas do
+  let(:model) { ModelWithNumericAttributesWithCommas.new }
+
+  describe '#price' do
+    before { model.price = 10 }
+
+    it { expect(model.price).to eq(10) }
+  end
+
+  describe '#price=' do
+    context 'with integer' do
+      before { model.price = 10 }
+
+      it { expect(model.price).to eq(10) }
+    end
+
+    context 'with decimal' do
+      before { model.price = 10.0 }
+
+      it { expect(model.price).to eq(10.0) }
+    end
+
+    context 'with integer as string' do
+      before { model.price = '10' }
+
+      it { expect(model.price).to eq(10) }
+    end
+
+    context 'with decimal as string' do
+      before { model.price = '10.0' }
+
+      it { expect(model.price).to eq(10.0) }
+    end
+
+    context 'with decimal as string using "," as delimiter' do
+      before { model.price = '1,000.50' }
+
+      it { expect(model.price).to eq(1000.5) }
+    end
+  end
+end


### PR DESCRIPTION
**Objetivo**

- Corregir la siguiente situación:
    - El valor almacenado en la DB es incorrecto cuando el valor de `percentage_field_group`/`currency_field_group` contiene una o más comas. 