### PR TITLE
SideMenu: Preserve scroll position when a link has been clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2025-04-23
+
+### Changed
+- `Bali::SideMenu::Component` component to preserve scroll position when a link has been clicked
+- `Bali::SideMenu::Item::Component` component to add `is-list` class when items are present.
+
 ## [1.4.1] - 2025-03-27
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bali_view_components (1.4.1)
+    bali_view_components (1.4.2)
       caxlsx
       rails (>= 8.0)
       ransack
@@ -173,7 +173,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
-    net-imap (0.5.6)
+    net-imap (0.5.7)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/components/bali/side_menu/index.js
+++ b/app/components/bali/side_menu/index.js
@@ -3,7 +3,7 @@ import { Controller } from '@hotwired/stimulus'
 export class SideMenuController extends Controller {
   static targets = ['container', 'overlay', 'link']
 
-  connect() {
+  connect () {
     this.scrollToActiveLinkPreviousPosition()
 
     if (this.hasOverlayTarget && this.hasContainerTarget) {
@@ -12,14 +12,14 @@ export class SideMenuController extends Controller {
     }
   }
 
-  disconnect() {
+  disconnect () {
     if (this.hasOverlayTarget && this.hasContainerTarget) {
       this.overlayTarget.removeEventListener('click', this.closeMenu)
       this.containerTarget.removeEventListener('click', this.closeMenu)
     }
   }
 
-  toggleMenu(e) {
+  toggleMenu (e) {
     e.stopPropagation()
 
     if (this.hasContainerTarget) {
@@ -42,11 +42,11 @@ export class SideMenuController extends Controller {
   scrollToActiveLinkPreviousPosition () {
     const activeLinkPrevPosition = window.sessionStorage.getItem('activeLinkPreviousPosition')
     const activeLink = this.linkTargets.findLast((element) => element.classList.contains('is-active'))
-    if (!activeLinkPrevPosition || !activeLink) return 
+    if (!activeLinkPrevPosition || !activeLink) return
 
     const { top } = activeLink.getBoundingClientRect()
     this.containerTarget.scrollTo(
       { top: top - parseFloat(activeLinkPrevPosition), behavior: 'instant' }
-    ) 
+    )
   }
 }

--- a/app/components/bali/side_menu/index.js
+++ b/app/components/bali/side_menu/index.js
@@ -1,23 +1,25 @@
 import { Controller } from '@hotwired/stimulus'
 
 export class SideMenuController extends Controller {
-  static targets = ['container', 'overlay']
+  static targets = ['container', 'overlay', 'link']
 
-  connect () {
+  connect() {
+    this.scrollToActiveLinkPreviousPosition()
+
     if (this.hasOverlayTarget && this.hasContainerTarget) {
       this.overlayTarget.addEventListener('click', this.closeMenu)
       this.containerTarget.addEventListener('click', this.closeMenu)
     }
   }
 
-  disconnect () {
+  disconnect() {
     if (this.hasOverlayTarget && this.hasContainerTarget) {
       this.overlayTarget.removeEventListener('click', this.closeMenu)
       this.containerTarget.removeEventListener('click', this.closeMenu)
     }
   }
 
-  toggleMenu (e) {
+  toggleMenu(e) {
     e.stopPropagation()
 
     if (this.hasContainerTarget) {
@@ -26,8 +28,25 @@ export class SideMenuController extends Controller {
   }
 
   closeMenu = e => {
+    const closestLink = e.target.closest('.link-component')
+    if (closestLink && closestLink.dataset.sideMenuTarget === 'link') {
+      const { top } = closestLink.getBoundingClientRect()
+      window.sessionStorage.setItem('activeLinkPreviousPosition', top)
+    }
+
     if (this.hasContainerTarget) {
       this.containerTarget.classList.remove('is-active')
     }
+  }
+
+  scrollToActiveLinkPreviousPosition () {
+    const activeLinkPrevPosition = window.sessionStorage.getItem('activeLinkPreviousPosition')
+    const activeLink = this.linkTargets.findLast((element) => element.classList.contains('is-active'))
+    if (!activeLinkPrevPosition || !activeLink) return 
+
+    const { top } = activeLink.getBoundingClientRect()
+    this.containerTarget.scrollTo(
+      { top: top - parseFloat(activeLinkPrevPosition), behavior: 'instant' }
+    ) 
   }
 }

--- a/app/components/bali/side_menu/item/component.rb
+++ b/app/components/bali/side_menu/item/component.rb
@@ -26,13 +26,14 @@ module Bali
 
           @active = options.delete(:active)
           @match_type = options.delete(:match) || :exact
-          @options = options
+          @options = prepend_data_attribute(options, :side_menu_target, 'link')
         end
 
         def before_render
           super
 
           @options = prepend_class_name(@options, 'is-active') if active?
+          @options = prepend_class_name(@options, 'is-list') if items.present?
         end
 
         def render?

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Bali ViewComponents",
   "repository": "git@github.com:Grupo-AFAL/bali.git",
   "author": "Federico Gonzalez <fedegl@hey.com>",


### PR DESCRIPTION
**Objective**
- Preserve scroll position of the side menu when a link has been clicked.

**Demo: Without of the Scroll Position Preservation**

https://github.com/user-attachments/assets/86e1c722-a79e-4837-bb5b-52041281ef38

**Demo: With Scroll Position Preservation**

https://github.com/user-attachments/assets/0cca6820-2878-4513-afb5-d398ca9afc65

