### PR TITLE
Fix pagination end alignment for Ruby 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Ruby 4.0 warnings: parenthesize double-splat in ERB templates, silence intentional method overrides, fix indentation
+- Fix pagination end alignment conflict between Rubocop and Ruby 4.0
 
 ### Added
 

--- a/app/components/bali/pagination/component.rb
+++ b/app/components/bali/pagination/component.rb
@@ -73,8 +73,8 @@ module Bali
         params = Rack::Utils.parse_nested_query(uri.query || "")
         page_key = if @pagy.respond_to?(:vars)
                      @pagy.vars[:page_key]
-                   else
-                     @pagy.respond_to?(:page_key) ? @pagy.page_key : nil
+                   elsif @pagy.respond_to?(:page_key)
+                     @pagy.page_key
         end || "page"
         params[page_key] = page
         uri.query = Rack::Utils.build_nested_query(params)


### PR DESCRIPTION
## Summary

- Use `elsif` instead of `else` in pagination `build_page_url` to avoid conflicting alignment requirements between Rubocop's `Layout/EndAlignment` (wants `end` aligned with variable) and Ruby 4.0's parser (wants `end` aligned with `else`)

Follow-up to #533 — this was the one warning that slipped through.

## Test plan

- [x] `bundle exec rubocop` passes (0 offenses)
- [x] `ruby -c` passes (no syntax warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)