### PR TITLE
Add simple filter translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix Ruby 4.0 warnings: parenthesize double-splat in ERB templates, silence intentional method overrides, fix indentation
 - Fix pagination end alignment conflict between Rubocop and Ruby 4.0
+- **SimpleFilters** - Fix `simple_filter` DSL defaulting date/date_range predicate to `:eq` instead of `nil`, causing incorrect field names (`q[created_at_eq]` instead of `q[created_at]`)
 
 ### Added
 

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -88,6 +88,11 @@ en:
         greater_than_or_equal: "greater than or equal"
         less_than_or_equal: "less than or equal"
 
+    # Simple filters
+    simple_filters:
+      apply: "Filter"
+      clear: "Clear"
+
     # File input
     file_input:
       remove: "Remove %{name}"

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -88,6 +88,11 @@ es:
         greater_than_or_equal: "mayor o igual que"
         less_than_or_equal: "menor o igual que"
 
+    # Simple filters
+    simple_filters:
+      apply: "Filtrar"
+      clear: "Limpiar"
+
     # File input
     file_input:
       remove: "Eliminar %{name}"


### PR DESCRIPTION
This pull request adds translations for the "Simple filters" UI in both English and Spanish locale files. These changes introduce new labels for filter actions, enabling the interface to display "apply" and "clear" actions in both languages.

Localization updates:

* Added `apply` and `clear` labels for simple filters under the `simple_filters` section in the English locale file `bali.en.yml`.
* Added `apply` and `clear` labels for simple filters under the `simple_filters` section in the Spanish locale file `bali.es.yml`.