### PR TITLE
feat(document_editor): forward references_url/config to inner BlockEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **DocumentEditor** - Forward `references_url`, `references_resolve_url`, and `references_config` to the inner `BlockEditor` so the `#` entity-reference picker works when the editor is used via `DocumentEditor` (#541)
+- **DocumentEditor / DocumentPage** - Forward `references_url`, `references_resolve_url`, and `references_config` to the inner `BlockEditor` so the `#` entity-reference picker and entity chip icons/colors work when the editor is used via `DocumentEditor` or `DocumentPage` (#541)
 - **SimpleFilters** - Configurable search input width via `search[:width]` option; widened defaults from `w-32 sm:w-80` to `w-48 sm:w-96`
 - **SlimSelect** - Added 8px detached gap between input and dropdown menu for improved visual separation
 - **SlimSelect** - Matched focus ring style with DaisyUI native selects (2px outline with 2px offset)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DocumentEditor** - Forward `references_url`, `references_resolve_url`, and `references_config` to the inner `BlockEditor` so the `#` entity-reference picker works when the editor is used via `DocumentEditor` (#541)
 - **SimpleFilters** - Configurable search input width via `search[:width]` option; widened defaults from `w-32 sm:w-80` to `w-48 sm:w-96`
 - **SlimSelect** - Added 8px detached gap between input and dropdown menu for improved visual separation
 - **SlimSelect** - Matched focus ring style with DaisyUI native selects (2px outline with 2px offset)

--- a/app/components/bali/document_editor/component.html.erb
+++ b/app/components/bali/document_editor/component.html.erb
@@ -113,7 +113,10 @@
           export_filename: export_filename,
           ai_url: ai_url,
           mentions_url: mentions_url,
-          mentions: mentions
+          mentions: mentions,
+          references_url: references_url,
+          references_resolve_url: references_resolve_url,
+          references_config: references_config
         ) %>
       </div>
     </div>

--- a/app/components/bali/document_editor/component.rb
+++ b/app/components/bali/document_editor/component.rb
@@ -22,6 +22,9 @@ module Bali
         ai_url: nil,
         mentions_url: nil,
         mentions: nil,
+        references_url: nil,
+        references_resolve_url: nil,
+        references_config: nil,
         **options
       )
         # rubocop:enable Metrics/ParameterLists
@@ -40,6 +43,9 @@ module Bali
         @ai_url = ai_url
         @mentions_url = mentions_url
         @mentions = mentions
+        @references_url = references_url
+        @references_resolve_url = references_resolve_url
+        @references_config = references_config
         @options = options
         @instance_id = SecureRandom.hex(4)
       end
@@ -61,8 +67,9 @@ module Bali
       attr_reader :title, :initial_content, :document_url, :close_url,
                   :versions_url, :auto_save, :auto_save_delay,
                   :export, :export_filename, :input_name,
-                  :ai_url, :mentions_url, :mentions, :options,
-                  :instance_id
+                  :ai_url, :mentions_url, :mentions,
+                  :references_url, :references_resolve_url, :references_config,
+                  :options, :instance_id
 
       def toc_container_id
         "document-editor-toc-#{instance_id}"

--- a/app/components/bali/document_page/component.html.erb
+++ b/app/components/bali/document_page/component.html.erb
@@ -64,7 +64,10 @@
             editable: false,
             table_of_contents: toc?,
             table_of_contents_container_id: toc? ? "document-page-toc-container" : nil,
-            show_export_buttons: false
+            show_export_buttons: false,
+            references_url: references_url,
+            references_resolve_url: references_resolve_url,
+            references_config: references_config
           ) %>
         <% elsif preview? %>
           <%= preview %>
@@ -88,7 +91,10 @@
         <%= render Bali::BlockEditor::Component.new(
           initial_content: initial_content,
           editable: false,
-          show_export_buttons: false
+          show_export_buttons: false,
+          references_url: references_url,
+          references_resolve_url: references_resolve_url,
+          references_config: references_config
         ) %>
       <% elsif preview? %>
         <%= preview %>

--- a/app/components/bali/document_page/component.rb
+++ b/app/components/bali/document_page/component.rb
@@ -19,6 +19,9 @@ module Bali
         initial_content: nil,
         toc_open: true,
         metadata_open: true,
+        references_url: nil,
+        references_resolve_url: nil,
+        references_config: nil,
         **options
       )
         @title = title
@@ -28,6 +31,9 @@ module Bali
         @initial_content = initial_content
         @toc_open = toc_open
         @metadata_open = metadata_open
+        @references_url = references_url
+        @references_resolve_url = references_resolve_url
+        @references_config = references_config
         @options = options
       end
 
@@ -46,7 +52,9 @@ module Bali
       private
 
       attr_reader :title, :subtitle, :breadcrumbs, :back,
-                  :initial_content, :options
+                  :initial_content,
+                  :references_url, :references_resolve_url, :references_config,
+                  :options
 
       def container_attributes
         options.except(:class).merge(

--- a/spec/dummy/app/views/documents/show.html.erb
+++ b/spec/dummy/app/views/documents/show.html.erb
@@ -91,7 +91,9 @@
       ]
     },
     export: true,
-    export_filename: @document.title.parameterize
+    export_filename: @document.title.parameterize,
+    references_url: "/entity_references",
+    references_resolve_url: "/entity_references/resolve"
   ) %>
 </div>
 
@@ -112,6 +114,8 @@
         { id: "user-2", username: "Jane Smith" },
         { id: "user-3", username: "Bob Wilson" }
       ]
-    }
+    },
+    references_url: "/entity_references",
+    references_resolve_url: "/entity_references/resolve"
   ) %>
 </div>


### PR DESCRIPTION
## Summary

Closes #541.

`Bali::DocumentEditor::Component` wraps `Bali::BlockEditor::Component` but didn't expose or forward the entity-reference props (`references_url`, `references_resolve_url`, `references_config`), so the `#` entity-reference picker never activated on pages using the wrapper.

This PR threads the three params through in the same way `ai_url`, `mentions_url`, and `mentions` are already forwarded.

## Changes

- `app/components/bali/document_editor/component.rb` — add the three params to `#initialize`, store as instance vars, expose as `attr_reader`s
- `app/components/bali/document_editor/component.html.erb` — forward to the inner `Bali::BlockEditor::Component.new(...)` call
- `spec/dummy/app/views/documents/show.html.erb` — wire `references_url`/`references_resolve_url` into both DocumentEditor renders so the showcase dummy covers the behavior end-to-end
- `CHANGELOG.md` — entry under `[Unreleased] → Added`

## Test plan

- [ ] Open the dummy `/documents/:id` page, click **Edit** to open the overlay, type `#` in the editor → picker opens with entities from `/entity_references`
- [ ] Close, click **Full screen** to open the read-only viewer → entity-reference chips still render (resolve path works)
- [ ] Existing pages that didn't pass references args continue to work unchanged (all three params default to `nil`, which the BlockEditor already treats as "references disabled")

🤖 Generated with [Claude Code](https://claude.com/claude-code)