### PR TITLE
Viewport-locked app-shell layout (sidebar + topbar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Ruby 4.0 warnings: parenthesize double-splat in ERB templates, silence intentional method overrides, fix indentation
 - Fix pagination end alignment conflict between Rubocop and Ruby 4.0
 - **SimpleFilters** - Fix `simple_filter` DSL defaulting date/date_range predicate to `:eq` instead of `nil`, causing incorrect field names (`q[created_at_eq]` instead of `q[created_at]`)
+- **SideMenu** - Brand row uses fixed `h-14` (56px) + `border-b` so it aligns horizontally with `Bali::Topbar`, forming one continuous chrome divider across the top of the app shell
+- **SideMenu** - Replace `shadow-lg` on the fixed variant with a 1px right border on desktop (shadow stays on mobile overlay) — eliminates the shadow seam where sidebar meets the topbar
+- **SideMenu** - `menu_switcher` dropdown now uses `<details><summary>` instead of focus-based dropdown — fixes mobile-tap reliability (focus pattern is fragile on iOS Safari)
+- **SideMenu** - When sidebar is collapsed, the `menu_switcher` stays visible as an icon-only button (was hidden) with a tooltip on hover and a right-side popout for switching modules
 
 ### Added
 
+- **AppLayout** - New `viewport_locked:` parameter that locks the body to 100vh and scrolls only the inner `<main>`, matching the Linear/Notion app-shell pattern. Defaults to the value of `fixed_sidebar` so existing pages keep working; pass explicitly to decouple (e.g. `fixed_sidebar: true, viewport_locked: false` for a fixed sidebar with normal page scroll)
+- **SideMenu** - New `with_brand` slot for icon + text or arbitrary brand content (the existing `brand:` text param keeps working as a fallback)
+- **Topbar** - New component for the top-of-content bar inside `Bali::AppLayout`'s `with_topbar` slot. Slots: `brand`, `search`, `actions` (many), `user_menu`. Built-in mobile sidebar trigger via `mobile_trigger_id:` (defaults to `SideMenu::MOBILE_TRIGGER_ID`)
+- **Command** - New ⌘K-style command palette / launcher. Modal panel with search input, grouped results (`:searchable` / `:recent` / `:action` modes), keyboard navigation (↑/↓/⏎/Esc), substring highlighting, and a global ⌘K (Mac) / Ctrl+K (Windows/Linux) shortcut. Composable trigger slot, density variants (`:default` / `:compact`), and window events (`bali:command:open` / `close` / `toggle`)
 - **DocumentEditor / DocumentPage** - Forward `references_url`, `references_resolve_url`, and `references_config` to the inner `BlockEditor` so the `#` entity-reference picker and entity chip icons/colors work when the editor is used via `DocumentEditor` or `DocumentPage` (#541)
 - **SimpleFilters** - Configurable search input width via `search[:width]` option; widened defaults from `w-32 sm:w-80` to `w-48 sm:w-96`
 - **SlimSelect** - Added 8px detached gap between input and dropdown menu for improved visual separation

--- a/app/assets/stylesheets/bali/components.css
+++ b/app/assets/stylesheets/bali/components.css
@@ -10,6 +10,7 @@
 /* Navigation Components */
 @import "../../../components/bali/navbar/index.css";
 @import "../../../components/bali/side_menu/index.css";
+@import "../../../components/bali/command/index.css";
 
 /* Data Display Components */
 @import "../../../components/bali/calendar/index.css";

--- a/app/components/bali/app_layout/component.rb
+++ b/app/components/bali/app_layout/component.rb
@@ -80,11 +80,11 @@ module Bali
       end
 
       def flash_notice
-        @flash&.[](:notice)
+        @flash && @flash[:notice]
       end
 
       def flash_alert
-        @flash&.[](:alert)
+        @flash && @flash[:alert]
       end
     end
   end

--- a/app/components/bali/app_layout/component.rb
+++ b/app/components/bali/app_layout/component.rb
@@ -18,10 +18,18 @@ module Bali
         full:      ""
       }.freeze
 
-      def initialize(fixed_sidebar: false, flash: nil, modal: true, drawer: true,
+      # @param viewport_locked [Boolean, nil] When true, the layout locks to viewport
+      #   height and only the inner <main> scrolls (Linear/Notion app-shell pattern).
+      #   When false, the page scrolls naturally and the topbar scrolls with content.
+      #   When nil (default), follows `fixed_sidebar` — the typical app-shell wants both,
+      #   but you can decouple them, e.g. `fixed_sidebar: true, viewport_locked: false`
+      #   for a fixed sidebar with normal page scroll (long forms, marketing-style content).
+      def initialize(fixed_sidebar: false, viewport_locked: nil,
+                     flash: nil, modal: true, drawer: true,
                      modal_size: nil, drawer_size: nil,
                      body_container: :wide, **options)
         @fixed_sidebar = fixed_sidebar
+        @viewport_locked = viewport_locked.nil? ? fixed_sidebar : viewport_locked
         @flash = flash
         @modal = modal
         @drawer = drawer
@@ -42,6 +50,7 @@ module Bali
           { "app-layout--has-fixed-sidebar" => @fixed_sidebar && sidebar? },
           { "app-layout--has-navbar" => navbar? },
           { "app-layout--has-sidebar" => sidebar? },
+          { "app-layout--viewport-locked" => @viewport_locked },
           @options[:class]
         )
       end

--- a/app/components/bali/app_layout/index.css
+++ b/app/components/bali/app_layout/index.css
@@ -4,6 +4,40 @@
  * defined in side_menu/index.css :root.
  */
 
+/* Viewport-locked scroll model — activates via `viewport_locked: true`.
+ * Body locks to viewport height; only the inner <main> scrolls. This keeps
+ * sidebar AND topbar pinned naturally (no position: sticky needed) and
+ * matches the Linear/Notion app-shell pattern.
+ *
+ * Decoupled from `fixed_sidebar` so each can be toggled independently:
+ *   fixed_sidebar: true,  viewport_locked: true   → full app shell (default)
+ *   fixed_sidebar: true,  viewport_locked: false  → fixed sidebar, page scrolls
+ *   fixed_sidebar: false, viewport_locked: true   → topbar pinned, no sidebar
+ *   fixed_sidebar: false, viewport_locked: false  → marketing-style page scroll */
+.app-layout--viewport-locked {
+  height: 100vh;
+  overflow: hidden;
+}
+
+.app-layout--viewport-locked .app-layout-main {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.app-layout--viewport-locked .app-layout-content {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.app-layout--viewport-locked .app-layout-topbar {
+  flex-shrink: 0;
+}
+
+.app-layout--viewport-locked .app-layout-content > main {
+  overflow-y: auto;
+  min-height: 0;
+}
+
 @media (min-width: 1024px) {
   /* Push content right when a fixed sidebar is present */
   .app-layout--has-fixed-sidebar .app-layout-content {

--- a/app/components/bali/command/component.html.erb
+++ b/app/components/bali/command/component.html.erb
@@ -1,0 +1,50 @@
+<%= tag.div(class: container_classes, data: { controller: "command" }) do %>
+  <% if trigger? %>
+    <div data-action="click->command#open" class="bali-command-trigger-wrap">
+      <%= trigger %>
+    </div>
+  <% end %>
+
+  <%# Backdrop — click to close %>
+  <div data-command-target="backdrop"
+       data-action="click->command#close"
+       class="hidden fixed inset-0 bg-black/40 z-[100]"></div>
+
+  <%# Modal panel — centered, fixed position %>
+  <div data-command-target="panel"
+       class="hidden fixed top-24 left-1/2 -translate-x-1/2 z-[101] w-[520px] max-w-[calc(100vw-2rem)]">
+    <div class="<%= panel_classes %>">
+      <div class="cmd-input-wrap">
+        <%= render Bali::Icon::Component.new('search', class: 'size-4') %>
+        <input data-command-target="input"
+               data-action="input->command#filter keydown->command#nav"
+               type="text"
+               placeholder="<%= placeholder %>"
+               class="cmd-input"
+               aria-label="<%= placeholder %>" />
+        <span class="cmd-kbd">esc</span>
+      </div>
+
+      <div class="cmd-list">
+        <% groups.each do |group| %>
+          <%= group %>
+        <% end %>
+
+        <div data-command-target="noResults" class="hidden cmd-empty">
+          <div class="cmd-empty-title"><%= no_results_text %></div>
+          <% if no_results_subtitle %>
+            <div class="cmd-empty-sub"><%= no_results_subtitle %></div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="cmd-foot">
+        <span class="cmd-foot-key"><span class="cmd-kbd">↑</span><span class="cmd-kbd">↓</span> <%= t('bali.command.navigate', default: 'navigate') %></span>
+        <span class="cmd-foot-key"><span class="cmd-kbd">⏎</span> <%= t('bali.command.open_action', default: 'open') %></span>
+        <span class="cmd-foot-key"><span class="cmd-kbd">esc</span> <%= t('bali.command.close', default: 'close') %></span>
+        <span class="cmd-foot-spacer"></span>
+        <span class="cmd-foot-count" data-command-target="count"></span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/bali/command/component.html.erb
+++ b/app/components/bali/command/component.html.erb
@@ -8,7 +8,7 @@
   <%# Backdrop — click to close %>
   <div data-command-target="backdrop"
        data-action="click->command#close"
-       class="hidden fixed inset-0 bg-base-300/60 backdrop-blur-sm z-[100]"></div>
+       class="hidden fixed inset-0 bg-black/40 z-[100]"></div>
 
   <%# Modal panel — centered, fixed position %>
   <div data-command-target="panel"

--- a/app/components/bali/command/component.html.erb
+++ b/app/components/bali/command/component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(class: container_classes, data: { controller: "command" }) do %>
   <% if trigger? %>
-    <div data-action="click->command#open" class="bali-command-trigger-wrap">
+    <div data-action="click->command#open">
       <%= trigger %>
     </div>
   <% end %>
@@ -8,42 +8,45 @@
   <%# Backdrop — click to close %>
   <div data-command-target="backdrop"
        data-action="click->command#close"
-       class="hidden fixed inset-0 bg-black/40 z-[100]"></div>
+       class="hidden fixed inset-0 bg-base-300/60 backdrop-blur-sm z-[100]"></div>
 
   <%# Modal panel — centered, fixed position %>
   <div data-command-target="panel"
        class="hidden fixed top-24 left-1/2 -translate-x-1/2 z-[101] w-[520px] max-w-[calc(100vw-2rem)]">
-    <div class="<%= panel_classes %>">
-      <div class="cmd-input-wrap">
-        <%= render Bali::Icon::Component.new('search', class: 'size-4') %>
+    <div class="cmd-panel bg-base-100 border border-base-300 rounded-box shadow-xl flex flex-col overflow-hidden <%= 'is-compact' if compact? %>">
+      <%# Search input %>
+      <div class="cmd-input-wrap flex items-center gap-3 px-4 py-3 border-b border-base-200 text-base-content/60">
+        <%= render Bali::Icon::Component.new('search', class: 'size-4 shrink-0') %>
         <input data-command-target="input"
                data-action="input->command#filter keydown->command#nav"
                type="text"
                placeholder="<%= placeholder %>"
-               class="cmd-input"
+               class="cmd-input flex-1 min-w-0 bg-transparent border-0 outline-none text-base text-base-content placeholder:text-base-content/40"
                aria-label="<%= placeholder %>" />
-        <span class="cmd-kbd">esc</span>
+        <kbd class="kbd kbd-xs">esc</kbd>
       </div>
 
-      <div class="cmd-list">
+      <%# List %>
+      <div class="cmd-list p-1.5 max-h-80 overflow-y-auto">
         <% groups.each do |group| %>
           <%= group %>
         <% end %>
 
-        <div data-command-target="noResults" class="hidden cmd-empty">
-          <div class="cmd-empty-title"><%= no_results_text %></div>
+        <div data-command-target="noResults" class="hidden text-center px-4 pt-8 pb-3">
+          <div class="text-sm font-semibold text-base-content"><%= no_results_text %></div>
           <% if no_results_subtitle %>
-            <div class="cmd-empty-sub"><%= no_results_subtitle %></div>
+            <div class="text-xs text-base-content/60 mt-1"><%= no_results_subtitle %></div>
           <% end %>
         </div>
       </div>
 
-      <div class="cmd-foot">
-        <span class="cmd-foot-key"><span class="cmd-kbd">↑</span><span class="cmd-kbd">↓</span> <%= t('bali.command.navigate', default: 'navigate') %></span>
-        <span class="cmd-foot-key"><span class="cmd-kbd">⏎</span> <%= t('bali.command.open_action', default: 'open') %></span>
-        <span class="cmd-foot-key"><span class="cmd-kbd">esc</span> <%= t('bali.command.close', default: 'close') %></span>
-        <span class="cmd-foot-spacer"></span>
-        <span class="cmd-foot-count" data-command-target="count"></span>
+      <%# Footer %>
+      <div class="flex items-center gap-3 px-3 py-2 border-t border-base-200 bg-base-100 text-xs text-base-content/60">
+        <span class="inline-flex items-center gap-1.5"><kbd class="kbd kbd-xs">↑</kbd><kbd class="kbd kbd-xs">↓</kbd> <%= t('bali.command.navigate', default: 'navigate') %></span>
+        <span class="inline-flex items-center gap-1.5"><kbd class="kbd kbd-xs">⏎</kbd> <%= t('bali.command.open_action', default: 'open') %></span>
+        <span class="inline-flex items-center gap-1.5"><kbd class="kbd kbd-xs">esc</kbd> <%= t('bali.command.close', default: 'close') %></span>
+        <span class="flex-1"></span>
+        <span class="font-mono text-[10.5px] text-base-content/60" data-command-target="count"></span>
       </div>
     </div>
   </div>

--- a/app/components/bali/command/component.rb
+++ b/app/components/bali/command/component.rb
@@ -36,22 +36,22 @@ module Bali
         no_results_subtitle: nil,
         **options
       )
-        @placeholder = placeholder || I18n.t('bali.command.placeholder', default: 'Search…')
+        @placeholder = placeholder || I18n.t("bali.command.placeholder", default: "Search…")
         @shortcut_label = shortcut_label
         @density = DENSITIES.include?(density) ? density : :default
-        @no_results_text = no_results_text || I18n.t('bali.command.no_results', default: 'No results')
+        @no_results_text = no_results_text || I18n.t("bali.command.no_results", default: "No results")
         @no_results_subtitle = no_results_subtitle
         @options = options
+      end
+
+      def compact?
+        density == :compact
       end
 
       private
 
       attr_reader :placeholder, :shortcut_label, :density,
                   :no_results_text, :no_results_subtitle, :options
-
-      def panel_classes
-        class_names("cmd-panel", { "compact" => density == :compact })
-      end
 
       def container_classes
         class_names("bali-command", options[:class])

--- a/app/components/bali/command/component.rb
+++ b/app/components/bali/command/component.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Bali
+  module Command
+    # Command palette / launcher (⌘K-style). Renders a modal panel with grouped
+    # search results, recents, and quick actions. Opens via:
+    #   - Click on the `with_trigger` slot (any button/input shape)
+    #   - Global ⌘K (Mac) / Ctrl+K (Windows/Linux) keyboard shortcut
+    #   - Programmatically via the `bali:command:open` window event
+    #
+    # Items can be pre-rendered (server-side) and filtered client-side via the
+    # bundled Stimulus controller. Three group modes:
+    #   - :searchable (default) — hidden until the query matches
+    #   - :recent              — shown only when the query is empty
+    #   - :action              — always shown (used as a fallback)
+    class Component < ApplicationViewComponent
+      DENSITIES = %i[default compact].freeze
+
+      renders_one :trigger
+      renders_many :groups, lambda { |name:, mode: :searchable, **opts|
+        Group::Component.new(name: name, mode: mode, **opts)
+      }
+
+      # @param placeholder [String] Search input placeholder.
+      # @param shortcut_label [String, nil] Display label for the shortcut hint
+      #   (e.g. "⌘K"). Pass nil to hide the hint. The actual key binding is
+      #   ⌘K on Mac / Ctrl+K elsewhere — handled in the Stimulus controller.
+      # @param density [Symbol] :default (44px rows) or :compact (32px rows).
+      # @param no_results_text [String] Heading when the query has no matches.
+      # @param no_results_subtitle [String, nil] Optional secondary line.
+      def initialize(
+        placeholder: nil,
+        shortcut_label: "⌘K",
+        density: :default,
+        no_results_text: nil,
+        no_results_subtitle: nil,
+        **options
+      )
+        @placeholder = placeholder || I18n.t('bali.command.placeholder', default: 'Search…')
+        @shortcut_label = shortcut_label
+        @density = DENSITIES.include?(density) ? density : :default
+        @no_results_text = no_results_text || I18n.t('bali.command.no_results', default: 'No results')
+        @no_results_subtitle = no_results_subtitle
+        @options = options
+      end
+
+      private
+
+      attr_reader :placeholder, :shortcut_label, :density,
+                  :no_results_text, :no_results_subtitle, :options
+
+      def panel_classes
+        class_names("cmd-panel", { "compact" => density == :compact })
+      end
+
+      def container_classes
+        class_names("bali-command", options[:class])
+      end
+    end
+  end
+end

--- a/app/components/bali/command/group/component.html.erb
+++ b/app/components/bali/command/group/component.html.erb
@@ -1,0 +1,6 @@
+<div data-command-target="group" data-mode="<%= mode %>">
+  <div class="cmd-group"><%= name %></div>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+</div>

--- a/app/components/bali/command/group/component.html.erb
+++ b/app/components/bali/command/group/component.html.erb
@@ -1,5 +1,5 @@
 <div data-command-target="group" data-mode="<%= mode %>">
-  <div class="cmd-group"><%= name %></div>
+  <div class="cmd-group text-xs font-semibold uppercase tracking-wider text-base-content/50 px-3 pt-3 pb-1.5"><%= name %></div>
   <% items.each do |item| %>
     <%= item %>
   <% end %>

--- a/app/components/bali/command/group/component.rb
+++ b/app/components/bali/command/group/component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Bali
+  module Command
+    module Group
+      class Component < ApplicationViewComponent
+        MODES = %i[searchable recent action].freeze
+
+        renders_many :items, lambda { |**opts|
+          Item::Component.new(mode: @mode, **opts)
+        }
+
+        # @param name [String] Group header label.
+        # @param mode [Symbol] One of:
+        #   - :searchable (default) — items only show when the query matches them
+        #   - :recent — items only show when the query is empty
+        #   - :action — items always show (used as a fallback for no-results)
+        def initialize(name:, mode: :searchable)
+          @name = name
+          @mode = MODES.include?(mode) ? mode : :searchable
+        end
+
+        attr_reader :name, :mode
+      end
+    end
+  end
+end

--- a/app/components/bali/command/index.css
+++ b/app/components/bali/command/index.css
@@ -1,0 +1,194 @@
+/* Command Component
+ * ⌘K-style command palette: modal panel with grouped, filterable items.
+ * CSS lifted from the AFAL Bali design-system reference; classes are
+ * unprefixed (`.cmd-*`) because they're scoped to the .bali-command wrapper
+ * and the .cmd-panel modal — no risk of collision with utilities.
+ */
+
+.cmd-panel {
+  width: 520px;
+  max-width: 100%;
+  background: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
+  border-radius: var(--radius-box);
+  box-shadow: 0 24px 64px rgb(15 23 42 / 0.14), 0 4px 12px rgb(15 23 42 / 0.06);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font-sans);
+  color: var(--color-base-content);
+  margin: 0 auto;
+}
+
+.cmd-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-base-200);
+  color: var(--fg-muted);
+}
+.cmd-panel.compact .cmd-input-wrap { padding: 10px 14px; }
+.cmd-input-wrap > svg { flex-shrink: 0; width: 16px; height: 16px; color: var(--fg-muted); }
+
+.cmd-input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: 400 15px/1.2 var(--font-sans);
+  color: var(--color-base-content);
+  min-width: 0;
+}
+.cmd-panel.compact .cmd-input { font-size: 14px; }
+.cmd-input::placeholder { color: var(--fg-faint); }
+
+.cmd-list {
+  padding: 6px 6px 8px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.cmd-group {
+  font: 600 10px/1 var(--font-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
+  padding: 12px 12px 6px;
+}
+[data-command-target="group"]:first-child .cmd-group { padding-top: 8px; }
+
+.cmd-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-field);
+  text-align: left;
+  color: var(--color-base-content);
+  font: inherit;
+  cursor: pointer;
+}
+.cmd-panel.compact .cmd-row { padding: 6px 10px; }
+.cmd-row:hover { background: var(--color-base-200); }
+.cmd-row.is-active { background: var(--color-base-200); }
+
+.cmd-row-ic {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--color-base-200);
+  display: grid;
+  place-items: center;
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+.cmd-row-ic svg { width: 14px; height: 14px; }
+.cmd-row.is-active .cmd-row-ic { background: var(--color-base-100); color: var(--fg-strong); }
+
+.cmd-row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.cmd-panel.compact .cmd-row-body {
+  flex-direction: row;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.cmd-row-title {
+  font-size: 13px;
+  color: var(--fg-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cmd-row-meta {
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cmd-panel.compact .cmd-row-meta { font-size: 12px; flex: 1; }
+
+.cmd-row-hint {
+  flex-shrink: 0;
+  color: var(--fg-subtle);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.cmd-row.is-active .cmd-row-hint { opacity: 1; }
+
+.cmd-mark {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  padding: 0 1px;
+  border-radius: 2px;
+}
+
+.cmd-empty {
+  padding: 32px 16px 12px;
+  text-align: center;
+}
+.cmd-empty-title {
+  font: 600 14px/1.2 var(--font-sans);
+  color: var(--fg-strong);
+  margin-bottom: 4px;
+}
+.cmd-empty-sub { font-size: 12px; color: var(--fg-muted); }
+
+.cmd-foot {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--color-base-200);
+  background: var(--color-base-100);
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+.cmd-foot-key { display: inline-flex; align-items: center; gap: 5px; }
+.cmd-foot-spacer { flex: 1; }
+.cmd-foot-count { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-muted); }
+
+.cmd-kbd {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font: 500 10.5px/1 var(--font-mono);
+  background: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
+  border-radius: 3px;
+  color: var(--fg-subtle);
+}
+
+/* Default trigger style — input-shaped button used in topbar's search slot. */
+.cmd-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: var(--color-base-200);
+  border-radius: var(--radius-field);
+  padding: 7px 10px;
+  font: 400 13px/1 var(--font-sans);
+  color: var(--fg-muted);
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.cmd-trigger:hover { background: var(--color-base-300); }
+.cmd-trigger svg { width: 14px; height: 14px; flex-shrink: 0; }
+.cmd-trigger > .grow { flex: 1; }

--- a/app/components/bali/command/index.css
+++ b/app/components/bali/command/index.css
@@ -1,194 +1,48 @@
 /* Command Component
- * ⌘K-style command palette: modal panel with grouped, filterable items.
- * CSS lifted from the AFAL Bali design-system reference; classes are
- * unprefixed (`.cmd-*`) because they're scoped to the .bali-command wrapper
- * and the .cmd-panel modal — no risk of collision with utilities.
+ * Most styling lives in Tailwind/DaisyUI utility classes inline on the
+ * templates. This file only carries the rules that utilities can't
+ * cleanly express:
+ *   - Active row state (kbd-driven; class toggled by Stimulus)
+ *   - Search-match highlight (uses DaisyUI primary token)
+ *   - Compact-density density overrides (parent → child cascade)
  */
 
-.cmd-panel {
-  width: 520px;
-  max-width: 100%;
-  background: var(--color-base-100);
-  border: 1px solid var(--color-base-300);
-  border-radius: var(--radius-box);
-  box-shadow: 0 24px 64px rgb(15 23 42 / 0.14), 0 4px 12px rgb(15 23 42 / 0.06);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  font-family: var(--font-sans);
-  color: var(--color-base-content);
-  margin: 0 auto;
-}
-
-.cmd-input-wrap {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--color-base-200);
-  color: var(--fg-muted);
-}
-.cmd-panel.compact .cmd-input-wrap { padding: 10px 14px; }
-.cmd-input-wrap > svg { flex-shrink: 0; width: 16px; height: 16px; color: var(--fg-muted); }
-
-.cmd-input {
-  flex: 1;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  font: 400 15px/1.2 var(--font-sans);
-  color: var(--color-base-content);
-  min-width: 0;
-}
-.cmd-panel.compact .cmd-input { font-size: 14px; }
-.cmd-input::placeholder { color: var(--fg-faint); }
-
-.cmd-list {
-  padding: 6px 6px 8px;
-  max-height: 340px;
-  overflow-y: auto;
-}
-
-.cmd-group {
-  font: 600 10px/1 var(--font-sans);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--fg-subtle);
-  padding: 12px 12px 6px;
-}
-[data-command-target="group"]:first-child .cmd-group { padding-top: 8px; }
-
-.cmd-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 9px 10px;
-  border: 0;
-  background: transparent;
-  border-radius: var(--radius-field);
-  text-align: left;
-  color: var(--color-base-content);
-  font: inherit;
-  cursor: pointer;
-}
-.cmd-panel.compact .cmd-row { padding: 6px 10px; }
-.cmd-row:hover { background: var(--color-base-200); }
-.cmd-row.is-active { background: var(--color-base-200); }
-
-.cmd-row-ic {
-  width: 26px;
-  height: 26px;
-  border-radius: 6px;
+/* ── Active row state ─────────────────────────────────────────────────── */
+.cmd-row.is-active {
   background: var(--color-base-200);
-  display: grid;
-  place-items: center;
-  color: var(--fg-muted);
-  flex-shrink: 0;
 }
-.cmd-row-ic svg { width: 14px; height: 14px; }
-.cmd-row.is-active .cmd-row-ic { background: var(--color-base-100); color: var(--fg-strong); }
-
-.cmd-row-body {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
+.cmd-row.is-active .cmd-row-ic {
+  background: var(--color-base-100);
+  color: var(--color-base-content);
 }
-.cmd-panel.compact .cmd-row-body {
-  flex-direction: row;
-  align-items: baseline;
-  gap: 8px;
+.cmd-row.is-active .cmd-row-hint {
+  opacity: 1;
 }
 
-.cmd-row-title {
-  font-size: 13px;
-  color: var(--fg-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.cmd-row-meta {
-  font-size: 11.5px;
-  color: var(--fg-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.cmd-panel.compact .cmd-row-meta { font-size: 12px; flex: 1; }
-
-.cmd-row-hint {
-  flex-shrink: 0;
-  color: var(--fg-subtle);
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.12s;
-}
-.cmd-row.is-active .cmd-row-hint { opacity: 1; }
-
+/* ── Highlight matched substring — uses DaisyUI primary token ─────────── */
 .cmd-mark {
-  background: var(--color-primary-soft);
+  background: color-mix(in oklch, var(--color-primary) 15%, transparent);
   color: var(--color-primary);
   padding: 0 1px;
   border-radius: 2px;
 }
 
-.cmd-empty {
-  padding: 32px 16px 12px;
-  text-align: center;
+/* ── Compact density overrides ────────────────────────────────────────── */
+.cmd-panel.is-compact .cmd-input-wrap {
+  padding: 0.5rem 0.875rem;
 }
-.cmd-empty-title {
-  font: 600 14px/1.2 var(--font-sans);
-  color: var(--fg-strong);
-  margin-bottom: 4px;
+.cmd-panel.is-compact .cmd-input {
+  font-size: 0.875rem;
 }
-.cmd-empty-sub { font-size: 12px; color: var(--fg-muted); }
-
-.cmd-foot {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 8px 12px;
-  border-top: 1px solid var(--color-base-200);
-  background: var(--color-base-100);
-  font-size: 11px;
-  color: var(--fg-subtle);
+.cmd-panel.is-compact .cmd-row {
+  padding: 0.375rem 0.625rem;
 }
-.cmd-foot-key { display: inline-flex; align-items: center; gap: 5px; }
-.cmd-foot-spacer { flex: 1; }
-.cmd-foot-count { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-muted); }
-
-.cmd-kbd {
-  display: inline-grid;
-  place-items: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  font: 500 10.5px/1 var(--font-mono);
-  background: var(--color-base-100);
-  border: 1px solid var(--color-base-300);
-  border-radius: 3px;
-  color: var(--fg-subtle);
+.cmd-panel.is-compact .cmd-row-body {
+  flex-direction: row;
+  align-items: baseline;
+  gap: 0.5rem;
 }
-
-/* Default trigger style — input-shaped button used in topbar's search slot. */
-.cmd-trigger {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: var(--color-base-200);
-  border-radius: var(--radius-field);
-  padding: 7px 10px;
-  font: 400 13px/1 var(--font-sans);
-  color: var(--fg-muted);
-  border: 0;
-  cursor: pointer;
-  text-align: left;
+.cmd-panel.is-compact .cmd-row-meta {
+  font-size: 0.75rem;
+  flex: 1;
 }
-.cmd-trigger:hover { background: var(--color-base-300); }
-.cmd-trigger svg { width: 14px; height: 14px; flex-shrink: 0; }
-.cmd-trigger > .grow { flex: 1; }

--- a/app/components/bali/command/index.css
+++ b/app/components/bali/command/index.css
@@ -7,13 +7,16 @@
  *   - Compact-density density overrides (parent → child cascade)
  */
 
-/* ── Active row state ─────────────────────────────────────────────────── */
+/* ── Active row state — neutral darken (avoids primary-tint purple cast) ── */
 .cmd-row.is-active {
-  background: var(--color-base-200);
+  background: color-mix(in oklch, var(--color-base-content) 10%, transparent);
+}
+.cmd-row.is-active .cmd-row-title {
+  font-weight: 500;
 }
 .cmd-row.is-active .cmd-row-ic {
-  background: var(--color-base-100);
-  color: var(--color-base-content);
+  background: var(--color-base-content);
+  color: var(--color-base-100);
 }
 .cmd-row.is-active .cmd-row-hint {
   opacity: 1;

--- a/app/components/bali/command/index.js
+++ b/app/components/bali/command/index.js
@@ -1,0 +1,235 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * Command palette controller — Linear/Notion-style ⌘K launcher.
+ *
+ * Targets:
+ *   - panel      Modal container (toggled hidden/visible)
+ *   - backdrop   Click-to-close overlay
+ *   - input      Search input
+ *   - group      One per <Group> component (used to show/hide group headers)
+ *   - row        One per <Item> component (filtered + highlighted)
+ *   - noResults  "No matches" message (shown when query has no regular hits)
+ *   - count      Result count display in the footer
+ *
+ * Global events (window):
+ *   - bali:command:open    → opens the palette
+ *   - bali:command:close   → closes the palette
+ *   - bali:command:toggle  → toggles
+ */
+export class CommandController extends Controller {
+  static targets = [
+    'panel', 'backdrop', 'input', 'group', 'row', 'noResults', 'count'
+  ]
+
+  static values = {
+    open: { type: Boolean, default: false }
+  }
+
+  connect () {
+    this._handleKeydown = this._handleKeydown.bind(this)
+    this._handleGlobalOpen = () => this.open()
+    this._handleGlobalClose = () => this.close()
+    this._handleGlobalToggle = () => (this.openValue ? this.close() : this.open())
+
+    document.addEventListener('keydown', this._handleKeydown)
+    window.addEventListener('bali:command:open', this._handleGlobalOpen)
+    window.addEventListener('bali:command:close', this._handleGlobalClose)
+    window.addEventListener('bali:command:toggle', this._handleGlobalToggle)
+
+    this._activeIndex = 0
+    this.filter()
+  }
+
+  disconnect () {
+    document.removeEventListener('keydown', this._handleKeydown)
+    window.removeEventListener('bali:command:open', this._handleGlobalOpen)
+    window.removeEventListener('bali:command:close', this._handleGlobalClose)
+    window.removeEventListener('bali:command:toggle', this._handleGlobalToggle)
+  }
+
+  open (event) {
+    event?.preventDefault()
+    if (this.openValue) return
+    this.openValue = true
+    this.panelTarget.classList.remove('hidden')
+    this.backdropTarget.classList.remove('hidden')
+    this.filter()
+    requestAnimationFrame(() => this.inputTarget.focus())
+  }
+
+  close (event) {
+    event?.preventDefault()
+    if (!this.openValue) return
+    this.openValue = false
+    this.panelTarget.classList.add('hidden')
+    this.backdropTarget.classList.add('hidden')
+    if (this.hasInputTarget) this.inputTarget.value = ''
+  }
+
+  filter () {
+    const query = this.hasInputTarget
+      ? this.inputTarget.value.trim().toLowerCase()
+      : ''
+    const isEmpty = query.length === 0
+    let visibleCount = 0
+    let regularResultsCount = 0
+
+    this.rowTargets.forEach(row => {
+      const mode = row.dataset.mode || 'searchable'
+      let visible
+
+      if (mode === 'action') {
+        visible = true
+      } else if (mode === 'recent') {
+        visible = isEmpty
+      } else {
+        const text = (row.dataset.search || row.textContent).toLowerCase()
+        visible = !isEmpty && text.includes(query)
+        if (visible) regularResultsCount++
+      }
+
+      row.classList.toggle('hidden', !visible)
+      if (visible) visibleCount++
+
+      if (visible && !isEmpty && mode === 'searchable') {
+        this._highlight(row, query)
+      } else {
+        this._unhighlight(row)
+      }
+    })
+
+    // Hide groups whose items are all hidden
+    this.groupTargets.forEach(group => {
+      const visibleItems = group.querySelectorAll('.cmd-row:not(.hidden)').length
+      group.classList.toggle('hidden', visibleItems === 0)
+    })
+
+    // Show no-results message when there's a query but no regular matches
+    if (this.hasNoResultsTarget) {
+      this.noResultsTarget.classList.toggle(
+        'hidden',
+        isEmpty || regularResultsCount > 0
+      )
+    }
+
+    if (this.hasCountTarget) {
+      const label = visibleCount === 1 ? 'result' : 'results'
+      this.countTarget.textContent = `${visibleCount} ${label}`
+    }
+
+    this._activeIndex = 0
+    this._updateActive()
+  }
+
+  nav (event) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      this._move(1)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      this._move(-1)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      this._activate()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      this.close()
+    }
+  }
+
+  select (event) {
+    this._activateRow(event.currentTarget)
+  }
+
+  _move (delta) {
+    const visible = this._visibleRows()
+    if (visible.length === 0) return
+    this._activeIndex =
+      (this._activeIndex + delta + visible.length) % visible.length
+    this._updateActive()
+  }
+
+  _updateActive () {
+    this.rowTargets.forEach(r => r.classList.remove('is-active'))
+    const visible = this._visibleRows()
+    if (visible.length === 0) return
+    const idx = Math.min(this._activeIndex, visible.length - 1)
+    visible[idx].classList.add('is-active')
+    visible[idx].scrollIntoView({ block: 'nearest' })
+  }
+
+  _activate () {
+    const visible = this._visibleRows()
+    if (visible.length === 0) return
+    const idx = Math.min(this._activeIndex, visible.length - 1)
+    this._activateRow(visible[idx])
+  }
+
+  _activateRow (row) {
+    const href = row.dataset.href
+    if (href) {
+      window.location.href = href
+      return
+    }
+    // Custom event so consumers can hook actions without an href
+    this.element.dispatchEvent(new CustomEvent('bali:command:select', {
+      bubbles: true,
+      detail: { row, value: row.dataset.value }
+    }))
+    this.close()
+  }
+
+  _visibleRows () {
+    return this.rowTargets.filter(r => !r.classList.contains('hidden'))
+  }
+
+  _highlight (row, query) {
+    [
+      row.querySelector('.cmd-row-title'),
+      row.querySelector('.cmd-row-meta')
+    ].forEach(el => {
+      if (!el) return
+      const text = el.dataset.text || el.textContent
+      if (!el.dataset.text) el.dataset.text = text
+      const idx = text.toLowerCase().indexOf(query)
+      if (idx < 0) {
+        el.textContent = text
+        return
+      }
+      const before = this._escape(text.slice(0, idx))
+      const match = this._escape(text.slice(idx, idx + query.length))
+      const after = this._escape(text.slice(idx + query.length))
+      el.innerHTML = `${before}<mark class="cmd-mark">${match}</mark>${after}`
+    })
+  }
+
+  _unhighlight (row) {
+    [
+      row.querySelector('.cmd-row-title'),
+      row.querySelector('.cmd-row-meta')
+    ].forEach(el => {
+      if (el && el.dataset.text) el.textContent = el.dataset.text
+    })
+  }
+
+  _escape (s) {
+    const div = document.createElement('div')
+    div.textContent = s
+    return div.innerHTML
+  }
+
+  _handleKeydown (e) {
+    // ⌘K (Mac) / Ctrl+K (Windows/Linux) — toggles the palette globally
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault()
+      this.openValue ? this.close() : this.open()
+      return
+    }
+    // Esc closes the palette when it's open (even when input doesn't have focus)
+    if (e.key === 'Escape' && this.openValue) {
+      e.preventDefault()
+      this.close()
+    }
+  }
+}

--- a/app/components/bali/command/index.js
+++ b/app/components/bali/command/index.js
@@ -55,7 +55,7 @@ export class CommandController extends Controller {
     this.panelTarget.classList.remove('hidden')
     this.backdropTarget.classList.remove('hidden')
     this.filter()
-    requestAnimationFrame(() => this.inputTarget.focus())
+    window.requestAnimationFrame(() => this.inputTarget.focus())
   }
 
   close (event) {

--- a/app/components/bali/command/index.js
+++ b/app/components/bali/command/index.js
@@ -169,7 +169,13 @@ export class CommandController extends Controller {
   _activateRow (row) {
     const href = row.dataset.href
     if (href) {
-      window.location.href = href
+      // Prefer Turbo navigation when available so we stay inside the SPA shell;
+      // fall back to a hard navigation when Turbo isn't loaded.
+      if (window.Turbo && typeof window.Turbo.visit === 'function') {
+        window.Turbo.visit(href)
+      } else {
+        window.location.href = href
+      }
       return
     }
     // Custom event so consumers can hook actions without an href
@@ -223,7 +229,11 @@ export class CommandController extends Controller {
     // ⌘K (Mac) / Ctrl+K (Windows/Linux) — toggles the palette globally
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault()
-      this.openValue ? this.close() : this.open()
+      if (this.openValue) {
+        this.close()
+      } else {
+        this.open()
+      }
       return
     }
     // Esc closes the palette when it's open (even when input doesn't have focus)

--- a/app/components/bali/command/item/component.html.erb
+++ b/app/components/bali/command/item/component.html.erb
@@ -1,10 +1,6 @@
-<button type="button"
-        data-command-target="row"
-        data-mode="<%= mode %>"
-        <%= "data-href=\"#{href}\"".html_safe if href %>
-        data-search="<%= search.downcase %>"
-        data-action="click->command#select"
-        class="cmd-row group flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-left text-sm text-base-content cursor-pointer hover:bg-base-content/8">
+<%= tag.button(type: "button",
+               data: { command_target: "row", mode: mode, href: href, search: search.downcase, action: "click->command#select" }.compact,
+               class: "cmd-row group flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-left text-sm text-base-content cursor-pointer hover:bg-base-content/8") do %>
   <% if icon %>
     <span class="cmd-row-ic size-7 rounded-md bg-base-200 grid place-items-center text-base-content/70 shrink-0">
       <%= render Bali::Icon::Component.new(icon, class: 'size-3.5') %>
@@ -19,4 +15,4 @@
   <span class="cmd-row-hint shrink-0 text-base-content/50 inline-flex items-center gap-1 opacity-0 transition-opacity">
     <kbd class="kbd kbd-xs">⏎</kbd>
   </span>
-</button>
+<% end %>

--- a/app/components/bali/command/item/component.html.erb
+++ b/app/components/bali/command/item/component.html.erb
@@ -4,7 +4,7 @@
         <%= "data-href=\"#{href}\"".html_safe if href %>
         data-search="<%= search.downcase %>"
         data-action="click->command#select"
-        class="cmd-row group flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-left text-sm text-base-content cursor-pointer hover:bg-base-200">
+        class="cmd-row group flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-left text-sm text-base-content cursor-pointer hover:bg-base-content/8">
   <% if icon %>
     <span class="cmd-row-ic size-7 rounded-md bg-base-200 grid place-items-center text-base-content/70 shrink-0">
       <%= render Bali::Icon::Component.new(icon, class: 'size-3.5') %>

--- a/app/components/bali/command/item/component.html.erb
+++ b/app/components/bali/command/item/component.html.erb
@@ -4,17 +4,19 @@
         <%= "data-href=\"#{href}\"".html_safe if href %>
         data-search="<%= search.downcase %>"
         data-action="click->command#select"
-        class="cmd-row">
+        class="cmd-row group flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-left text-sm text-base-content cursor-pointer hover:bg-base-200">
   <% if icon %>
-    <span class="cmd-row-ic">
+    <span class="cmd-row-ic size-7 rounded-md bg-base-200 grid place-items-center text-base-content/70 shrink-0">
       <%= render Bali::Icon::Component.new(icon, class: 'size-3.5') %>
     </span>
   <% end %>
-  <span class="cmd-row-body">
-    <span class="cmd-row-title"><%= title %></span>
+  <span class="cmd-row-body flex-1 min-w-0 flex flex-col gap-px">
+    <span class="cmd-row-title text-sm text-base-content truncate"><%= title %></span>
     <% if meta %>
-      <span class="cmd-row-meta"><%= meta %></span>
+      <span class="cmd-row-meta text-xs text-base-content/60 truncate"><%= meta %></span>
     <% end %>
   </span>
-  <span class="cmd-row-hint"><span class="cmd-kbd">⏎</span></span>
+  <span class="cmd-row-hint shrink-0 text-base-content/50 inline-flex items-center gap-1 opacity-0 transition-opacity">
+    <kbd class="kbd kbd-xs">⏎</kbd>
+  </span>
 </button>

--- a/app/components/bali/command/item/component.html.erb
+++ b/app/components/bali/command/item/component.html.erb
@@ -1,0 +1,20 @@
+<button type="button"
+        data-command-target="row"
+        data-mode="<%= mode %>"
+        <%= "data-href=\"#{href}\"".html_safe if href %>
+        data-search="<%= search.downcase %>"
+        data-action="click->command#select"
+        class="cmd-row">
+  <% if icon %>
+    <span class="cmd-row-ic">
+      <%= render Bali::Icon::Component.new(icon, class: 'size-3.5') %>
+    </span>
+  <% end %>
+  <span class="cmd-row-body">
+    <span class="cmd-row-title"><%= title %></span>
+    <% if meta %>
+      <span class="cmd-row-meta"><%= meta %></span>
+    <% end %>
+  </span>
+  <span class="cmd-row-hint"><span class="cmd-kbd">⏎</span></span>
+</button>

--- a/app/components/bali/command/item/component.rb
+++ b/app/components/bali/command/item/component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Bali
+  module Command
+    module Item
+      class Component < ApplicationViewComponent
+        # @param title [String] Primary label.
+        # @param meta [String, nil] Secondary metadata (e.g. id, status, owner).
+        # @param icon [String, nil] Lucide icon name to render in the leading slot.
+        # @param href [String, nil] Navigate to this URL when activated.
+        # @param mode [Symbol] :searchable | :recent | :action — inherited from group.
+        # @param search [String, nil] Override the searchable text. Defaults to
+        #   "title meta" — title-and-meta concatenated for substring matching.
+        def initialize(title:, meta: nil, icon: nil, href: nil,
+                       mode: :searchable, search: nil)
+          @title = title
+          @meta = meta
+          @icon = icon
+          @href = href
+          @mode = mode
+          @search = search || [title, meta].compact.join(' ')
+        end
+
+        attr_reader :title, :meta, :icon, :href, :mode, :search
+      end
+    end
+  end
+end

--- a/app/components/bali/command/item/component.rb
+++ b/app/components/bali/command/item/component.rb
@@ -18,7 +18,7 @@ module Bali
           @icon = icon
           @href = href
           @mode = mode
-          @search = search || [title, meta].compact.join(' ')
+          @search = search || [ title, meta ].compact.join(" ")
         end
 
         attr_reader :title, :meta, :icon, :href, :mode, :search

--- a/app/components/bali/command/preview.rb
+++ b/app/components/bali/command/preview.rb
@@ -7,13 +7,13 @@ module Bali
       # Command palette with grouped pages, recents, and quick actions.
       # Click the trigger or press ⌘K (Mac) / Ctrl+K to open.
       def default
-        render_with_template(template: 'bali/command/previews/default')
+        render_with_template(template: "bali/command/previews/default")
       end
 
       # @label Compact density
       # Tighter rows for power users / dense workspaces.
       def compact
-        render_with_template(template: 'bali/command/previews/compact')
+        render_with_template(template: "bali/command/previews/compact")
       end
     end
   end

--- a/app/components/bali/command/preview.rb
+++ b/app/components/bali/command/preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Bali
+  module Command
+    class Preview < ApplicationViewComponentPreview
+      # @label Default
+      # Command palette with grouped pages, recents, and quick actions.
+      # Click the trigger or press ⌘K (Mac) / Ctrl+K to open.
+      def default
+        render_with_template(template: 'bali/command/previews/default')
+      end
+
+      # @label Compact density
+      # Tighter rows for power users / dense workspaces.
+      def compact
+        render_with_template(template: 'bali/command/previews/compact')
+      end
+    end
+  end
+end

--- a/app/components/bali/command/previews/compact.html.erb
+++ b/app/components/bali/command/previews/compact.html.erb
@@ -4,10 +4,11 @@
     density: :compact
   ) do |c| %>
     <% c.with_trigger do %>
-      <button type="button" class="cmd-trigger max-w-md">
-        <%= render Bali::Icon::Component.new('search') %>
-        <span class="grow">Search…</span>
-        <span class="cmd-kbd">⌘K</span>
+      <button type="button"
+              class="flex items-center gap-2 w-full max-w-md bg-base-200 hover:bg-base-300 rounded-md px-2.5 py-1.5 text-sm text-base-content/60 cursor-pointer transition-colors">
+        <%= render Bali::Icon::Component.new('search', class: 'size-4 shrink-0') %>
+        <span class="flex-1 text-left">Search…</span>
+        <kbd class="kbd kbd-xs">⌘K</kbd>
       </button>
     <% end %>
 

--- a/app/components/bali/command/previews/compact.html.erb
+++ b/app/components/bali/command/previews/compact.html.erb
@@ -1,0 +1,27 @@
+<div class="p-6 bg-base-200 min-h-[480px]">
+  <%= render Bali::Command::Component.new(
+    placeholder: 'Search…',
+    density: :compact
+  ) do |c| %>
+    <% c.with_trigger do %>
+      <button type="button" class="cmd-trigger max-w-md">
+        <%= render Bali::Icon::Component.new('search') %>
+        <span class="grow">Search…</span>
+        <span class="cmd-kbd">⌘K</span>
+      </button>
+    <% end %>
+
+    <% c.with_group(name: 'Pages') do |g| %>
+      <% g.with_item(title: 'Committees', meta: 'Structure', icon: 'users', href: '/lookbook') %>
+    <% end %>
+
+    <% c.with_group(name: 'Documents') do |g| %>
+      <% g.with_item(title: 'Audit Committee Minutes 2025-Q4', meta: 'ACT-2025-0042 · Signed', icon: 'file-text', href: '/lookbook') %>
+      <% g.with_item(title: 'Anti-Money Laundering Policy v3.2', meta: 'POL-2026-0218 · Ethics Committee', icon: 'file-text', href: '/lookbook') %>
+    <% end %>
+
+    <% c.with_group(name: 'Actions', mode: :action) do |g| %>
+      <% g.with_item(title: 'New document request', meta: 'Start an approval flow', icon: 'plus', href: '/lookbook') %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/bali/command/previews/default.html.erb
+++ b/app/components/bali/command/previews/default.html.erb
@@ -1,10 +1,11 @@
 <div class="p-6 bg-base-200 min-h-[480px]">
   <%= render Bali::Command::Component.new(placeholder: 'Search documents, folios, procedures…') do |c| %>
     <% c.with_trigger do %>
-      <button type="button" class="cmd-trigger max-w-md">
-        <%= render Bali::Icon::Component.new('search') %>
-        <span class="grow">Search documents, folios, procedures…</span>
-        <span class="cmd-kbd">⌘K</span>
+      <button type="button"
+              class="flex items-center gap-2 w-full max-w-md bg-base-200 hover:bg-base-300 rounded-md px-2.5 py-1.5 text-sm text-base-content/60 cursor-pointer transition-colors">
+        <%= render Bali::Icon::Component.new('search', class: 'size-4 shrink-0') %>
+        <span class="flex-1 text-left">Search documents, folios, procedures…</span>
+        <kbd class="kbd kbd-xs">⌘K</kbd>
       </button>
     <% end %>
 

--- a/app/components/bali/command/previews/default.html.erb
+++ b/app/components/bali/command/previews/default.html.erb
@@ -1,0 +1,36 @@
+<div class="p-6 bg-base-200 min-h-[480px]">
+  <%= render Bali::Command::Component.new(placeholder: 'Search documents, folios, procedures…') do |c| %>
+    <% c.with_trigger do %>
+      <button type="button" class="cmd-trigger max-w-md">
+        <%= render Bali::Icon::Component.new('search') %>
+        <span class="grow">Search documents, folios, procedures…</span>
+        <span class="cmd-kbd">⌘K</span>
+      </button>
+    <% end %>
+
+    <% c.with_group(name: 'Pages') do |g| %>
+      <% g.with_item(title: 'Policies', meta: 'Regulations', icon: 'book-open', href: '/lookbook') %>
+      <% g.with_item(title: 'Procedures', meta: 'Operations', icon: 'list-checks', href: '/lookbook') %>
+      <% g.with_item(title: 'Committees', meta: 'Structure', icon: 'users', href: '/lookbook') %>
+    <% end %>
+
+    <% c.with_group(name: 'Documents') do |g| %>
+      <% g.with_item(title: 'Anti-Money Laundering Policy v3.2', meta: 'POL-2026-0218 · Active · Ethics Committee', icon: 'file-text', href: '/lookbook') %>
+      <% g.with_item(title: 'Code of Ethics and Conduct', meta: 'POL-2026-0211 · Active · Board', icon: 'file-text', href: '/lookbook') %>
+      <% g.with_item(title: 'Conflict of Interest Policy', meta: 'POL-2025-0184 · Active · Ethics Committee', icon: 'file-text', href: '/lookbook') %>
+      <% g.with_item(title: 'Reinforced KYC Procedure', meta: 'PRO-2026-0094 · In review', icon: 'file-check', href: '/lookbook') %>
+    <% end %>
+
+    <% c.with_group(name: 'Recents', mode: :recent) do |g| %>
+      <% g.with_item(title: 'Anti-Money Laundering Policy v3.2', meta: 'POL-2026-0218 · Active', icon: 'file-text', href: '/lookbook') %>
+      <% g.with_item(title: 'Reinforced KYC Procedure', meta: 'PRO-2026-0094 · In review', icon: 'file-check', href: '/lookbook') %>
+      <% g.with_item(title: 'Inbox', meta: '7 pending', icon: 'inbox', href: '/lookbook') %>
+    <% end %>
+
+    <% c.with_group(name: 'Actions', mode: :action) do |g| %>
+      <% g.with_item(title: 'New document request', meta: 'Start an approval flow', icon: 'plus', href: '/lookbook') %>
+      <% g.with_item(title: 'Upload committee minutes', meta: 'Signed PDF', icon: 'paperclip', href: '/lookbook') %>
+      <% g.with_item(title: 'Import regulations', meta: 'CSV or Excel', icon: 'upload', href: '/lookbook') %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/bali/side_menu/component.html.erb
+++ b/app/components/bali/side_menu/component.html.erb
@@ -19,8 +19,10 @@
   <% if collapsible? %>
     <%# Expanded state header - toggle on the right %>
     <div class="side-menu-expanded flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
-      <% if brand? %>
-        <span class="side-menu-brand text-xl font-semibold grow"><%= brand %></span>
+      <% if brand_present? %>
+        <span class="side-menu-brand text-xl font-semibold grow flex items-center gap-2 min-w-0">
+          <%= brand || @brand %>
+        </span>
       <% elsif collapsible? %>
         <span class="grow"></span>
       <% end %>
@@ -49,10 +51,12 @@
               class: 'size-4') %>
       </label>
     </div>
-  <% elsif brand? || fixed? %>
+  <% elsif brand_present? || fixed? %>
     <div class="flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
-      <% if brand? %>
-        <span class="side-menu-brand text-xl font-semibold grow"><%= brand %></span>
+      <% if brand_present? %>
+        <span class="side-menu-brand text-xl font-semibold grow flex items-center gap-2 min-w-0">
+          <%= brand || @brand %>
+        </span>
       <% else %>
         <span class="grow"></span>
       <% end %>

--- a/app/components/bali/side_menu/component.html.erb
+++ b/app/components/bali/side_menu/component.html.erb
@@ -13,10 +13,12 @@
 <% end %>
 
 <%= tag.div(**container_options) do %>
-  <%# Header with collapse toggle %>
+  <%# Header with collapse toggle.
+      Height is fixed to h-14 (56px) so the row aligns horizontally with the
+      AppLayout topbar — both share one continuous border-b across the top. %>
   <% if collapsible? %>
     <%# Expanded state header - toggle on the right %>
-    <div class="side-menu-expanded flex min-h-10 items-center gap-3 px-2.5 pt-3">
+    <div class="side-menu-expanded flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
       <% if brand? %>
         <span class="side-menu-brand text-xl font-semibold grow"><%= brand %></span>
       <% elsif collapsible? %>
@@ -39,16 +41,16 @@
       <% end %>
     </div>
     <%# Collapsed state header - toggle centered like menu items %>
-    <div class="side-menu-collapsed hidden px-1 py-3">
+    <div class="side-menu-collapsed hidden h-14 items-center px-1 border-b border-base-300">
       <label for="<%= collapse_checkbox_id %>"
              title="<%= expand_label %>"
-             class="collapse-toggle menu-item justify-center cursor-pointer">
+             class="collapse-toggle menu-item justify-center cursor-pointer w-full">
         <%= render Bali::Icon::Component.new('panel-left-open',
               class: 'size-4') %>
       </label>
     </div>
   <% elsif brand? || fixed? %>
-    <div class="flex min-h-10 items-center gap-3 px-2.5 py-3">
+    <div class="flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
       <% if brand? %>
         <span class="side-menu-brand text-xl font-semibold grow"><%= brand %></span>
       <% else %>
@@ -68,14 +70,17 @@
   <%# Menu switcher dropdown (when multiple menus) %>
   <% if multiple_menus? %>
     <div class="menu-switcher px-2.5 mb-3 mt-3">
-      <div class="dropdown dropdown-bottom w-full">
-        <div tabindex="0" role="button"
-             class="border-base-300 hover:bg-base-200 rounded-box flex cursor-pointer items-center gap-2 border p-2">
+      <%# Use <details><summary> instead of focus-based dropdown — the focus
+          pattern is fragile on iOS Safari (focus loss on slide-in animation,
+          blur on scroll). <details> uses native browser toggling and works
+          reliably on all touch devices. %>
+      <details class="dropdown dropdown-bottom w-full">
+        <summary class="menu-switcher-trigger tooltip tooltip-right border-base-300 hover:bg-base-200 rounded-box flex w-full items-center gap-2 border p-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden"
+                 data-tip="<%= active_menu.title %>">
           <%= active_menu %>
-          <%= render Bali::Icon::Component.new('chevrons-up-down', class: 'ml-auto size-4 text-base-content/50') %>
-        </div>
-        <ul tabindex="0"
-            class="dropdown-content menu bg-base-100 rounded-box z-50 mt-1 w-full p-2 shadow-lg">
+          <%= render Bali::Icon::Component.new('chevrons-up-down', class: 'menu-switcher-chevron ml-auto size-4 text-base-content/50') %>
+        </summary>
+        <ul class="dropdown-content menu bg-base-100 rounded-box z-50 mt-1 w-full p-2 shadow-lg">
           <% authorized_menus.each do |menu| %>
             <li>
               <a href="<%= menu.href %>" class="<%= 'active' if menu == active_menu %>">
@@ -84,7 +89,7 @@
             </li>
           <% end %>
         </ul>
-      </div>
+      </details>
     </div>
   <% end %>
 

--- a/app/components/bali/side_menu/component.rb
+++ b/app/components/bali/side_menu/component.rb
@@ -10,6 +10,11 @@ module Bali
 
       renders_many :menu_switches, Bali::SideMenu::MenuSwitch::Component
 
+      # Brand slot — renders rich content (logo + text, just an icon, custom HTML)
+      # in the chrome row above the menu switcher. Falls back to the `brand:`
+      # parameter when the slot is not set, so existing string usage keeps working.
+      renders_one :brand
+
       renders_many :bottom_items, Item::Component.renderable
 
       renders_many :bottom_groups,
@@ -115,10 +120,13 @@ module Bali
         authorized_menus.find(&:active?) || authorized_menus.first
       end
 
-      attr_reader :brand, :mobile_trigger_id
+      attr_reader :mobile_trigger_id
 
-      def brand?
-        @brand.present?
+      # True when EITHER the brand slot is set OR the `brand:` text param is present.
+      # Overrides the slot's auto-generated `brand?` so the chrome row renders
+      # whichever path the consumer used.
+      def brand_present?
+        brand? || @brand.present?
       end
 
       # Translated aria-label for mobile trigger checkbox

--- a/app/components/bali/side_menu/index.css
+++ b/app/components/bali/side_menu/index.css
@@ -14,9 +14,35 @@
   overflow: visible;
 }
 
-/* Fixed positioning variant - for full-page sidebars */
+/* Menu-switcher needs position: relative so the dropdown-content can be
+   absolutely positioned beside the collapsed sidebar (see collapsed-state
+   block below). */
+.menu-switcher {
+  position: relative;
+}
+
+/* Menu-switcher tooltip is only useful when the sidebar is collapsed —
+   in expanded state the title is right there in the trigger button.
+   Hide DaisyUI's tooltip pseudo-elements unless the sidebar is collapsed. */
+.menu-switcher-trigger.tooltip::before,
+.menu-switcher-trigger.tooltip::after {
+  display: none;
+}
+.side-menu-collapse-trigger:checked + .side-menu-component .menu-switcher-trigger.tooltip:hover::before,
+.side-menu-collapse-trigger:checked + .side-menu-component .menu-switcher-trigger.tooltip:hover::after,
+.side-menu-component.is-collapsed .menu-switcher-trigger.tooltip:hover::before,
+.side-menu-component.is-collapsed .menu-switcher-trigger.tooltip:hover::after {
+  display: block;
+}
+
+/* Fixed positioning variant - for full-page sidebars.
+   Uses a 1px right border for desktop separation (lines up with the topbar's
+   bottom border to form one continuous app-chrome divider). On mobile, where
+   the sidebar slides in as an overlay over content, the border is replaced by
+   a drop shadow for visual depth. */
 .side-menu-component--fixed {
-  @apply fixed top-0 left-0 h-full shadow-lg z-40 bg-base-100;
+  @apply fixed top-0 left-0 h-full z-40 bg-base-100;
+  border-right: 1px solid var(--color-base-300);
   width: var(--bali-side-menu-width);
   transform: translateX(-100%);
   transition: transform 0.2s ease-in-out, width 0.2s ease-in-out;
@@ -29,6 +55,13 @@
   /* Active state (mobile menu open) */
   &.is-active {
     transform: translateX(0);
+  }
+}
+
+/* Mobile overlay shadow — only when the sidebar slides in over content */
+@media (max-width: 1023px) {
+  .side-menu-component--fixed.is-active {
+    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   }
 }
 
@@ -46,7 +79,12 @@
    ======================================== */
 
 .sidebar-menu {
-  @apply space-y-1;
+  /* Breathing room below the chrome row's bottom border. Applied when there's
+     no contextual chrome between the brand row and the first menu item:
+     - Mobile (sidebar overlay, no separate topbar)
+     - Desktop collapsed (no MAIN/section labels visible, icons sit bare)
+     The collapsed-state padding is added in the .is-collapsed block below. */
+  @apply space-y-1 max-lg:pt-2;
 
   /* Allow dropdowns to overflow outside the menu container */
   .dropdown {
@@ -142,9 +180,46 @@
     @apply hidden;
   }
 
-  /* Hide menu switcher */
+  /* Compact menu switcher to icon-only — keep it clickable to switch modules.
+     Hides the title/subtitle/chevron and removes the border, leaving just the
+     module icon centered in the collapsed-width sidebar.
+     IMPORTANT: title-hiding is scoped to .menu-switcher-trigger so the OPEN
+     dropdown popup still renders the full title + subtitle for each module. */
   .menu-switcher {
-    @apply hidden;
+    @apply px-1;
+  }
+  .menu-switcher-trigger {
+    @apply justify-center !border-0 !p-2;
+  }
+  .menu-switcher-trigger .menu-switcher-chevron {
+    @apply !hidden;
+  }
+  .menu-switcher-trigger .side-menu-component--menu-switch-component {
+    @apply !gap-0;
+  }
+  .menu-switcher-trigger .side-menu-component--menu-switch-component > div {
+    @apply !hidden;
+  }
+
+  /* Reposition the dropdown popup to open beside the collapsed sidebar
+     (instead of below, where it would overlap the menu items). Mirrors the
+     pattern used by .side-menu-bottom-group.dropdown above. */
+  .menu-switcher details {
+    position: static;
+  }
+  .menu-switcher .dropdown-content {
+    position: absolute !important;
+    top: 0;
+    left: var(--bali-side-menu-collapsed-width);
+    right: auto;
+    bottom: auto;
+    width: var(--bali-side-menu-width);
+    margin: 0;
+  }
+  /* In the dropdown items, don't stretch the title div — let icon + title
+     sit naturally next to each other with the menu_switch's gap-3 spacing. */
+  .menu-switcher .dropdown-content .side-menu-component--menu-switch-component > div {
+    @apply !flex-none;
   }
 
   /* Hide section labels */
@@ -152,13 +227,16 @@
     @apply hidden;
   }
 
-  /* Toggle expanded/collapsed item visibility */
+  /* Toggle expanded/collapsed item visibility.
+     Collapsed header uses !flex (not !block) so its `items-center` works —
+     the brand-row collapse toggle needs to vertically center inside the
+     56px chrome row to align with the topbar. */
   .side-menu-expanded {
     @apply !hidden;
   }
 
   .side-menu-collapsed {
-    @apply !block;
+    @apply !flex;
   }
 
   /* Center menu items in collapsed state */
@@ -174,6 +252,11 @@
   /* Style the collapse toggle like a menu item in collapsed state */
   .collapse-toggle {
     @apply justify-center p-2;
+  }
+
+  /* Breathing room above the first icon when collapsed (no labels visible) */
+  .sidebar-menu {
+    @apply pt-2;
   }
 
   /* Bottom group dropdown: open right instead of up when collapsed */

--- a/app/components/bali/side_menu/menu_switch/component.rb
+++ b/app/components/bali/side_menu/menu_switch/component.rb
@@ -4,8 +4,8 @@ module Bali
   module SideMenu
     module MenuSwitch
       class Component < ApplicationViewComponent
-        # href is public for use in parent component template
-        attr_reader :href
+        # href and title are public for use in parent component template
+        attr_reader :href, :title
 
         def initialize(title:, href:, icon:, subtitle: nil, active: false, authorized: true)
           @title = title
@@ -30,7 +30,7 @@ module Bali
 
         private
 
-        attr_reader :title, :subtitle, :icon
+        attr_reader :subtitle, :icon
       end
     end
   end

--- a/app/components/bali/topbar/component.html.erb
+++ b/app/components/bali/topbar/component.html.erb
@@ -1,8 +1,9 @@
 <%= tag.div(class: container_classes, **container_attributes) do %>
   <% if mobile_trigger_id %>
-    <%# Mobile sidebar trigger — only on small screens. %>
+    <%# Mobile sidebar trigger — only on small screens. The <label> toggles the
+        sibling checkbox on click; native browser behavior already maps Space to
+        the associated checkbox via `for`, so no role/tabindex polyfill needed. %>
     <label for="<%= mobile_trigger_id %>"
-           role="button" tabindex="0"
            class="btn btn-ghost btn-sm lg:hidden"
            aria-label="<%= toggle_mobile_label %>">
       <%= render Bali::Icon::Component.new('menu', size: :small) %>

--- a/app/components/bali/topbar/component.html.erb
+++ b/app/components/bali/topbar/component.html.erb
@@ -1,0 +1,32 @@
+<%= tag.div(class: container_classes, **container_attributes) do %>
+  <% if mobile_trigger_id %>
+    <%# Mobile sidebar trigger — only on small screens. %>
+    <label for="<%= mobile_trigger_id %>"
+           role="button" tabindex="0"
+           class="btn btn-ghost btn-sm lg:hidden"
+           aria-label="<%= toggle_mobile_label %>">
+      <%= render Bali::Icon::Component.new('menu', size: :small) %>
+    </label>
+  <% end %>
+
+  <% if brand? %>
+    <div class="bali-topbar-brand"><%= brand %></div>
+  <% end %>
+
+  <% if search? %>
+    <div class="flex-1 max-w-md">
+      <%= search %>
+    </div>
+  <% end %>
+
+  <% if actions? || user_menu? %>
+    <div class="flex items-center gap-1 ml-auto">
+      <% actions.each do |action| %>
+        <%= action %>
+      <% end %>
+      <% if user_menu? %>
+        <%= user_menu %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/bali/topbar/component.rb
+++ b/app/components/bali/topbar/component.rb
@@ -20,9 +20,11 @@ module Bali
       renders_one :user_menu
 
       # @param mobile_trigger_id [String, nil] When set, renders a hamburger label
-      #   (lg:hidden) that toggles the matching sidebar checkbox. Pass `nil` to
-      #   skip — useful for layouts without a sidebar.
-      def initialize(mobile_trigger_id: Bali::SideMenu::Component::MOBILE_TRIGGER_ID,
+      #   (lg:hidden) that toggles the matching sidebar checkbox. Defaults to the
+      #   value of `Bali::SideMenu::Component::MOBILE_TRIGGER_ID` so the standard
+      #   AppLayout pairing works without configuration. Pass `nil` to skip the
+      #   hamburger — useful for layouts without a sidebar.
+      def initialize(mobile_trigger_id: SideMenu::Component::MOBILE_TRIGGER_ID,
                      **options)
         @mobile_trigger_id = mobile_trigger_id
         @options = options

--- a/app/components/bali/topbar/component.rb
+++ b/app/components/bali/topbar/component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Bali
+  module Topbar
+    # Renders the topbar that sits inside the AppLayout's `with_topbar` slot.
+    # Designed to align horizontally with the SideMenu's brand row (both 56px,
+    # h-14) so the bottom border forms one continuous chrome divider.
+    #
+    # Composes 4 zones — brand (left, optional), search (center), actions
+    # (right, many icon buttons), user_menu (far right). Pair with a sidebar
+    # by passing the sidebar's `mobile_trigger_id` to render the hamburger on
+    # small screens.
+    class Component < ApplicationViewComponent
+      BASE_CLASSES = "bali-topbar flex items-center gap-3 px-4 md:px-6 h-14 " \
+                     "bg-base-100 border-b border-base-300"
+
+      renders_one :brand
+      renders_one :search
+      renders_many :actions
+      renders_one :user_menu
+
+      # @param mobile_trigger_id [String, nil] When set, renders a hamburger label
+      #   (lg:hidden) that toggles the matching sidebar checkbox. Pass `nil` to
+      #   skip — useful for layouts without a sidebar.
+      def initialize(mobile_trigger_id: Bali::SideMenu::Component::MOBILE_TRIGGER_ID,
+                     **options)
+        @mobile_trigger_id = mobile_trigger_id
+        @options = options
+      end
+
+      private
+
+      attr_reader :mobile_trigger_id
+
+      def container_classes
+        class_names(BASE_CLASSES, @options[:class])
+      end
+
+      def container_attributes
+        @options.except(:class)
+      end
+
+      def toggle_mobile_label
+        I18n.t("bali.side_menu.toggle_mobile", default: "Toggle sidebar")
+      end
+    end
+  end
+end

--- a/app/components/bali/topbar/preview.rb
+++ b/app/components/bali/topbar/preview.rb
@@ -7,25 +7,25 @@ module Bali
       # Topbar with all four zones populated: search, two icon actions, and a
       # user dropdown.
       def default
-        render_with_template(template: 'bali/topbar/previews/default')
+        render_with_template(template: "bali/topbar/previews/default")
       end
 
       # @label Search Only
       # Minimal topbar with just a global search input.
       def search_only
-        render_with_template(template: 'bali/topbar/previews/search_only')
+        render_with_template(template: "bali/topbar/previews/search_only")
       end
 
       # @label Without Search
       # Topbar without a search input — actions and user menu only.
       def without_search
-        render_with_template(template: 'bali/topbar/previews/without_search')
+        render_with_template(template: "bali/topbar/previews/without_search")
       end
 
       # @label Without Mobile Trigger
       # Topbar for layouts that have no sidebar (no hamburger button).
       def without_mobile_trigger
-        render_with_template(template: 'bali/topbar/previews/without_mobile_trigger')
+        render_with_template(template: "bali/topbar/previews/without_mobile_trigger")
       end
     end
   end

--- a/app/components/bali/topbar/preview.rb
+++ b/app/components/bali/topbar/preview.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Bali
+  module Topbar
+    class Preview < ApplicationViewComponentPreview
+      # @label Default
+      # Topbar with all four zones populated: search, two icon actions, and a
+      # user dropdown.
+      def default
+        render_with_template(template: 'bali/topbar/previews/default')
+      end
+
+      # @label Search Only
+      # Minimal topbar with just a global search input.
+      def search_only
+        render_with_template(template: 'bali/topbar/previews/search_only')
+      end
+
+      # @label Without Search
+      # Topbar without a search input — actions and user menu only.
+      def without_search
+        render_with_template(template: 'bali/topbar/previews/without_search')
+      end
+
+      # @label Without Mobile Trigger
+      # Topbar for layouts that have no sidebar (no hamburger button).
+      def without_mobile_trigger
+        render_with_template(template: 'bali/topbar/previews/without_mobile_trigger')
+      end
+    end
+  end
+end

--- a/app/components/bali/topbar/previews/default.html.erb
+++ b/app/components/bali/topbar/previews/default.html.erb
@@ -29,10 +29,10 @@
         <span class="hidden md:inline">Ana García</span>
         <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
       <% end %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.profile') } %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.settings') } %>
+      <% dropdown.with_item(href: '#') { 'Profile' } %>
+      <% dropdown.with_item(href: '#') { 'Settings' } %>
       <li class="divider my-1"></li>
-      <% dropdown.with_item(href: logout_path, class: 'text-error', data: { turbo_method: :delete }) { t('navbar.sign_out') } %>
+      <% dropdown.with_item(href: '#', class: 'text-error') { 'Sign out' } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/bali/topbar/previews/search_only.html.erb
+++ b/app/components/bali/topbar/previews/search_only.html.erb
@@ -1,0 +1,9 @@
+<%= render Bali::Topbar::Component.new do |topbar| %>
+  <% topbar.with_search do %>
+    <label class="input input-sm input-bordered flex items-center gap-2 bg-base-200 border-0">
+      <%= render Bali::Icon::Component.new('search', class: 'size-4 text-base-content/50') %>
+      <input type="text" class="grow" placeholder="Search..." />
+      <kbd class="kbd kbd-xs hidden sm:inline-flex">⌘K</kbd>
+    </label>
+  <% end %>
+<% end %>

--- a/app/components/bali/topbar/previews/without_mobile_trigger.html.erb
+++ b/app/components/bali/topbar/previews/without_mobile_trigger.html.erb
@@ -1,0 +1,18 @@
+<%= render Bali::Topbar::Component.new(mobile_trigger_id: nil) do |topbar| %>
+  <% topbar.with_brand do %>
+    <span class="font-semibold text-base">My App</span>
+  <% end %>
+
+  <% topbar.with_search do %>
+    <label class="input input-sm input-bordered flex items-center gap-2 bg-base-200 border-0">
+      <%= render Bali::Icon::Component.new('search', class: 'size-4 text-base-content/50') %>
+      <input type="text" class="grow" placeholder="Search..." />
+    </label>
+  <% end %>
+
+  <% topbar.with_user_menu do %>
+    <%= render Bali::Avatar::Component.new(size: :xs) do |avatar| %>
+      <% avatar.with_placeholder { 'AG' } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bali/topbar/previews/without_search.html.erb
+++ b/app/components/bali/topbar/previews/without_search.html.erb
@@ -1,22 +1,8 @@
 <%= render Bali::Topbar::Component.new do |topbar| %>
-  <% topbar.with_search do %>
-    <label class="input input-sm input-bordered flex items-center gap-2 bg-base-200 border-0">
-      <%= render Bali::Icon::Component.new('search', class: 'size-4 text-base-content/50') %>
-      <input type="text" class="grow" placeholder="Search..." />
-      <kbd class="kbd kbd-xs hidden sm:inline-flex">⌘K</kbd>
-    </label>
-  <% end %>
-
   <% topbar.with_action do %>
     <button type="button" class="btn btn-ghost btn-sm btn-square relative" aria-label="Notifications">
       <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
       <span class="absolute top-1.5 right-1.5 size-2 rounded-full bg-error border-2 border-base-100"></span>
-    </button>
-  <% end %>
-
-  <% topbar.with_action do %>
-    <button type="button" class="btn btn-ghost btn-sm btn-square" aria-label="Help">
-      <%= render Bali::Icon::Component.new('circle-help', class: 'size-5') %>
     </button>
   <% end %>
 
@@ -29,10 +15,8 @@
         <span class="hidden md:inline">Ana García</span>
         <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
       <% end %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.profile') } %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.settings') } %>
-      <li class="divider my-1"></li>
-      <% dropdown.with_item(href: logout_path, class: 'text-error', data: { turbo_method: :delete }) { t('navbar.sign_out') } %>
+      <% dropdown.with_item(href: '#') { 'Profile' } %>
+      <% dropdown.with_item(href: '#') { 'Sign out' } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/frontend/bali/components/index.js
+++ b/app/frontend/bali/components/index.js
@@ -50,6 +50,7 @@ import { DocumentEditorController } from '../../../components/bali/document_edit
 import { DocumentPageController } from '../../../components/bali/document_page/index'
 import { TreeViewItemController } from '../../../components/bali/tree_view/item/index'
 import { FeedbackWidgetController } from '../../../components/bali/feedback_widget/index'
+import { CommandController } from '../../../components/bali/command/index'
 
 export { TableController } from '../../../components/bali/table/index'
 export { ModalController } from '../../../components/bali/modal/index'
@@ -105,6 +106,9 @@ export { TreeViewItemController } from '../../../components/bali/tree_view/item/
 
 // Integration components
 export { FeedbackWidgetController } from '../../../components/bali/feedback_widget/index'
+
+// Command palette
+export { CommandController } from '../../../components/bali/command/index'
 
 /**
  * Register all core Bali component controllers with a Stimulus application
@@ -170,4 +174,7 @@ export function registerAll (application) {
 
   // Integration
   application.register('feedback-widget', FeedbackWidgetController)
+
+  // Command palette
+  application.register('command', CommandController)
 }

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -131,6 +131,77 @@ Slots allow you to inject content into specific areas of a component:
 
 ### Layout Components
 
+#### AppLayout
+
+Top-level page shell. Renders `<body>` directly with optional banner, navbar,
+sidebar, topbar, and main body slots. Designed for admin shells but the
+slots are independent so non-shell layouts work too.
+
+```erb
+<%= render Bali::AppLayout::Component.new(fixed_sidebar: true) do |layout| %>
+  <% layout.with_sidebar do %>
+    <%= render 'layouts/admin_sidebar' %>  <%# typically a Bali::SideMenu %>
+  <% end %>
+  <% layout.with_topbar do %>
+    <%= render 'layouts/admin_topbar' %>   <%# typically a Bali::Topbar %>
+  <% end %>
+  <% layout.with_body do %>
+    <%= yield %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `fixed_sidebar` - Sidebar uses `position: fixed`; content gets left padding (default: false)
+- `viewport_locked` - Body locks to 100vh; only inner `<main>` scrolls (Linear/Notion app-shell pattern). Defaults to `fixed_sidebar` value — pass explicitly to decouple
+- `body_container` - `:wide` (default), `:contained`, `:narrow`, `:full`
+- `flash` - Pass `flash` for built-in toast notifications
+- `modal` / `drawer` - Render shared modal/drawer slots (default: true)
+
+**Decoupled scroll model**:
+| `fixed_sidebar` | `viewport_locked` | Behavior |
+|-----------------|-------------------|----------|
+| `true` | `true` (default) | Full app shell — sidebar + topbar pinned, only body scrolls |
+| `true` | `false` | Fixed sidebar but page scrolls (long forms) |
+| `false` | `true` | Topbar pinned, no sidebar |
+| `false` | `false` | Marketing-style page scroll |
+
+#### Topbar
+
+Top-of-content bar that sits inside the AppLayout's `with_topbar` slot. 56px
+tall to align horizontally with the SideMenu's brand row. Slots: brand,
+search, actions (many), user_menu.
+
+```erb
+<%= render Bali::Topbar::Component.new do |topbar| %>
+  <% topbar.with_search do %>
+    <%= render Bali::Command::Component.new do |cmd| %>
+      <% cmd.with_trigger do %>
+        <button type="button" class="...">Search… <kbd>⌘K</kbd></button>
+      <% end %>
+      <% cmd.with_group(name: "Pages") do |g| %>
+        <% g.with_item(title: "Dashboard", icon: 'layout-dashboard', href: '/') %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% topbar.with_action do %>
+    <button class="btn btn-ghost btn-sm btn-square" aria-label="Notifications">
+      <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
+    </button>
+  <% end %>
+
+  <% topbar.with_user_menu do %>
+    <%= render Bali::Dropdown::Component.new do |d| %>
+      <%# avatar + dropdown items %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `mobile_trigger_id` - ID of the sidebar's mobile checkbox (renders the `lg:hidden` hamburger). Defaults to `Bali::SideMenu::Component::MOBILE_TRIGGER_ID`. Pass `nil` for layouts without a sidebar
+
 #### Card
 
 Content container with optional header, image, and actions.
@@ -187,6 +258,94 @@ Slide-in panel from edge of screen.
 ---
 
 ### Navigation Components
+
+#### SideMenu
+
+Vertical sidebar with brand row, sectioned nav, optional module switcher, and
+bottom-pinned items. Used inside `Bali::AppLayout`'s `with_sidebar` slot.
+
+```erb
+<%= render Bali::SideMenu::Component.new(current_path: request.path, collapsible: true) do |menu| %>
+  <%# Brand slot — accepts icon + text or any custom HTML %>
+  <% menu.with_brand do %>
+    <%= lucide_icon('clapperboard', size: 24) %>
+    <span class="truncate">My App</span>
+  <% end %>
+
+  <%# Optional: multiple modules → renders a switcher dropdown above the lists %>
+  <% menu.with_menu_switch(title: 'Admin', icon: 'shield', href: admin_root_path) %>
+  <% menu.with_menu_switch(title: 'Reports', icon: 'bar-chart-3', href: reports_path) %>
+
+  <% menu.with_list(title: 'Main') do |list| %>
+    <% list.with_item(name: 'Dashboard', href: '/', icon: 'layout-dashboard', match: :exact) %>
+    <% list.with_item(name: 'Movies', href: movies_path, icon: 'film', match: :crud) %>
+  <% end %>
+
+  <% menu.with_bottom_group(name: 'Settings', icon: 'settings') do |group| %>
+    <% group.with_item(name: 'Profile', href: '#', icon: 'circle-user') %>
+    <% group.with_item(name: 'Sign out', href: '#', icon: 'log-out') %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `current_path` (required) - For active-state matching
+- `fixed` - Fixed-to-viewport sidebar (default: true)
+- `collapsible` - Show desktop collapse toggle and icon-only collapsed state
+- `brand` - Simple text brand. For richer brand (logo + text, custom HTML), use the `with_brand` slot instead
+- `group_behavior` - `:expandable` (default, DaisyUI collapse) or `:dropdown` (hover dropdown for nested items)
+
+**Brand row aligns** with `Bali::Topbar` (both 56px) so they form one continuous chrome divider when paired in `Bali::AppLayout`.
+
+**Match types** for `with_item`: `:exact`, `:partial`, `:starts_with`, `:crud` (matches `/path` and `/path/123/edit` etc).
+
+#### Command
+
+⌘K-style command palette / launcher. Modal panel with search input, grouped
+results, keyboard navigation, and a global ⌘K (Mac) / Ctrl+K (Windows) shortcut.
+
+```erb
+<%= render Bali::Command::Component.new(placeholder: 'Search…') do |c| %>
+  <% c.with_trigger do %>
+    <button type="button" class="...">
+      <%= render Bali::Icon::Component.new('search') %>
+      <span>Search…</span>
+      <kbd class="kbd kbd-xs">⌘K</kbd>
+    </button>
+  <% end %>
+
+  <% c.with_group(name: 'Pages') do |g| %>
+    <% g.with_item(title: 'Dashboard', meta: 'Overview', icon: 'layout-dashboard', href: '/') %>
+    <% g.with_item(title: 'Movies', meta: 'Catalog', icon: 'film', href: movies_path) %>
+  <% end %>
+
+  <% c.with_group(name: 'Recents', mode: :recent) do |g| %>
+    <% g.with_item(title: 'Last viewed doc', icon: 'file-text', href: '/docs/1') %>
+  <% end %>
+
+  <% c.with_group(name: 'Actions', mode: :action) do |g| %>
+    <% g.with_item(title: 'New movie', meta: 'Create a record', icon: 'plus', href: new_movie_path) %>
+  <% end %>
+<% end %>
+```
+
+**Group modes:**
+- `:searchable` (default) - Items only show when the query matches `title + meta`
+- `:recent` - Only shown when query is empty (recent activity)
+- `:action` - Always shown (used as a fallback when no matches)
+
+**Options:**
+- `placeholder` - Search input placeholder
+- `density` - `:default` (44px rows) or `:compact` (32px rows)
+- `no_results_text` / `no_results_subtitle` - Empty-state copy
+- `shortcut_label` - Display label for the shortcut hint (default `⌘K`). Actual binding is hardcoded to ⌘K/Ctrl+K
+
+**Triggers:**
+- `with_trigger` slot — any clickable element opens the palette (input-shaped buttons are common)
+- Global keyboard: ⌘K (Mac) / Ctrl+K (Windows/Linux)
+- Window events: `bali:command:open` / `bali:command:close` / `bali:command:toggle`
+
+**Keyboard:** ↑/↓ to navigate, ⏎ to activate, Esc to close.
 
 #### Breadcrumb
 

--- a/spec/dummy/app/controllers/pages_controller.rb
+++ b/spec/dummy/app/controllers/pages_controller.rb
@@ -12,6 +12,7 @@ class PagesController < ApplicationController
     case action_name
     when 'landing' then 'marketing'
     when 'sidemenu_example' then 'lookbook_preview' # Minimal layout for full-page demo
+    when 'workspace' then 'admin'
     else 'application'
     end
   end
@@ -35,5 +36,16 @@ class PagesController < ApplicationController
 
   def sidemenu_example
     # Uses application layout by default (inherits from layout setting)
+  end
+
+  def workspace
+    # Reference page demonstrating the standard "navbar + sidebar + content" admin shell.
+    @stats = [
+      { label: 'Total Movies', value: Movie.count, change: '+12.5%', icon: 'film', color: 'primary' },
+      { label: 'Studios', value: Tenant.count, change: '+3.2%', icon: 'building-2', color: 'secondary' },
+      { label: 'Revenue', value: '$45.2K', change: '+18.1%', icon: 'dollar-sign', color: 'success' },
+      { label: 'Active Users', value: 892, change: '-2.4%', icon: 'users', color: 'info' }
+    ]
+    @recent_movies = Movie.includes(:studio).order(created_at: :desc).limit(6)
   end
 end

--- a/spec/dummy/app/views/layouts/_admin_sidebar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_sidebar.html.erb
@@ -1,4 +1,11 @@
-<%= render Bali::SideMenu::Component.new(current_path: request.path, collapsible: true, brand: t('app.name')) do |menu| %>
+<%= render Bali::SideMenu::Component.new(current_path: request.path, collapsible: true) do |menu| %>
+  <% menu.with_brand do %>
+    <span class="text-primary shrink-0 inline-flex">
+      <%= lucide_icon('clapperboard', size: 24) %>
+    </span>
+    <span class="truncate"><%= t('app.name') %></span>
+  <% end %>
+
   <% menu.with_menu_switch(title: t('app.name'), icon: 'clapperboard', href: admin_root_path) %>
   <% menu.with_menu_switch(title: t('sidebar.reports'), icon: 'bar-chart-3', href: admin_analytics_path) %>
 

--- a/spec/dummy/app/views/layouts/_admin_sidebar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_sidebar.html.erb
@@ -4,6 +4,7 @@
 
   <% menu.with_list(title: t('sidebar.main')) do |list| %>
     <% list.with_item(name: t('navbar.dashboard'), href: admin_root_path, icon: 'layout-dashboard', match: :exact) %>
+    <% list.with_item(name: 'Workspace', href: workspace_path, icon: 'sparkles', match: :exact) %>
     <% list.with_item(name: t('navbar.movies'), href: admin_movies_path, icon: 'film', match: :crud) %>
     <% list.with_item(name: t('sidebar.studios'), href: admin_studios_path, icon: 'building-2', match: :crud) %>
     <% list.with_item(name: 'Projects', href: admin_projects_path, icon: 'kanban', match: :crud) %>

--- a/spec/dummy/app/views/layouts/_admin_topbar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_topbar.html.erb
@@ -4,10 +4,11 @@
       placeholder: 'Search documents, pages, actions…'
     ) do |cmd| %>
       <% cmd.with_trigger do %>
-        <button type="button" class="cmd-trigger">
-          <%= render Bali::Icon::Component.new('search') %>
-          <span class="grow">Search…</span>
-          <span class="cmd-kbd hidden sm:inline-grid">⌘K</span>
+        <button type="button"
+                class="flex items-center gap-2 w-full bg-base-200 hover:bg-base-300 rounded-md px-2.5 py-1.5 text-sm text-base-content/60 cursor-pointer transition-colors">
+          <%= render Bali::Icon::Component.new('search', class: 'size-4 shrink-0') %>
+          <span class="flex-1 text-left">Search…</span>
+          <kbd class="kbd kbd-xs hidden sm:inline-grid">⌘K</kbd>
         </button>
       <% end %>
 

--- a/spec/dummy/app/views/layouts/_admin_topbar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_topbar.html.erb
@@ -1,10 +1,38 @@
 <%= render Bali::Topbar::Component.new do |topbar| %>
   <% topbar.with_search do %>
-    <label class="input input-sm input-bordered flex items-center gap-2 bg-base-200 border-0">
-      <%= render Bali::Icon::Component.new('search', class: 'size-4 text-base-content/50') %>
-      <input type="text" class="grow" placeholder="Search..." />
-      <kbd class="kbd kbd-xs hidden sm:inline-flex">⌘K</kbd>
-    </label>
+    <%= render Bali::Command::Component.new(
+      placeholder: 'Search documents, pages, actions…'
+    ) do |cmd| %>
+      <% cmd.with_trigger do %>
+        <button type="button" class="cmd-trigger">
+          <%= render Bali::Icon::Component.new('search') %>
+          <span class="grow">Search…</span>
+          <span class="cmd-kbd hidden sm:inline-grid">⌘K</span>
+        </button>
+      <% end %>
+
+      <% cmd.with_group(name: 'Pages') do |g| %>
+        <% g.with_item(title: 'Dashboard', meta: 'Admin overview', icon: 'layout-dashboard', href: admin_root_path) %>
+        <% g.with_item(title: 'Workspace', meta: 'Reference shell', icon: 'sparkles', href: workspace_path) %>
+        <% g.with_item(title: 'Movies', meta: 'Catalog', icon: 'film', href: admin_movies_path) %>
+        <% g.with_item(title: 'Studios', meta: 'Production houses', icon: 'building-2', href: admin_studios_path) %>
+        <% g.with_item(title: 'Projects', meta: 'Kanban board', icon: 'kanban', href: admin_projects_path) %>
+        <% g.with_item(title: 'Documents', meta: 'Knowledge base', icon: 'file-text', href: documents_path) %>
+        <% g.with_item(title: 'Analytics', meta: 'Reports', icon: 'bar-chart-3', href: admin_analytics_path) %>
+        <% g.with_item(title: 'Revenue', meta: 'Reports', icon: 'dollar-sign', href: admin_revenue_index_path) %>
+        <% g.with_item(title: 'Settings', meta: 'Profile and preferences', icon: 'settings', href: admin_settings_path) %>
+      <% end %>
+
+      <% cmd.with_group(name: 'Recents', mode: :recent) do |g| %>
+        <% g.with_item(title: 'Dashboard', meta: 'Last visit · today', icon: 'layout-dashboard', href: admin_root_path) %>
+        <% g.with_item(title: 'Movies', meta: 'Last visit · yesterday', icon: 'film', href: admin_movies_path) %>
+      <% end %>
+
+      <% cmd.with_group(name: 'Actions', mode: :action) do |g| %>
+        <% g.with_item(title: 'New movie', meta: 'Create a new movie record', icon: 'plus', href: new_admin_movie_path) %>
+        <% g.with_item(title: 'New studio', meta: 'Create a new studio', icon: 'plus', href: new_admin_studio_path) %>
+      <% end %>
+    <% end %>
   <% end %>
 
   <% topbar.with_action do %>

--- a/spec/dummy/app/views/layouts/_admin_topbar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_topbar.html.erb
@@ -1,0 +1,53 @@
+<%# Workspace topbar — sits inside the content column, right of the sidebar.
+    Aligns horizontally with the sidebar's brand row (both 56px tall) so the
+    divider underline reads as one continuous line.
+
+    TODO(you): pick the global controls that belong here.
+    Common picks: search, notifications, help, user menu.
+    Keep ≤ 4 items so it stays readable on tablets. %>
+<div class="flex items-center gap-3 px-6 h-14 bg-base-100 border-b border-base-300">
+  <%# Mobile sidebar trigger — only on small screens %>
+  <label for="<%= Bali::SideMenu::Component::MOBILE_TRIGGER_ID %>"
+         role="button" tabindex="0"
+         class="btn btn-ghost btn-sm lg:hidden"
+         aria-label="<%= t('bali.side_menu.toggle_mobile', default: 'Toggle sidebar') %>">
+    <%= render Bali::Icon::Component.new('menu', size: :small) %>
+  </label>
+
+  <%# Global search — typeahead trigger, Cmd+K-style %>
+  <div class="flex-1 max-w-md">
+    <label class="input input-sm input-bordered flex items-center gap-2 bg-base-200 border-0">
+      <%= render Bali::Icon::Component.new('search', class: 'size-4 text-base-content/50') %>
+      <input type="text" class="grow" placeholder="Search..." />
+      <kbd class="kbd kbd-xs hidden sm:inline-flex">⌘K</kbd>
+    </label>
+  </div>
+
+  <div class="flex items-center gap-1 ml-auto">
+    <%# Notifications %>
+    <button type="button" class="btn btn-ghost btn-sm btn-square relative" aria-label="Notifications">
+      <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
+      <span class="absolute top-1.5 right-1.5 size-2 rounded-full bg-error border-2 border-base-100"></span>
+    </button>
+
+    <%# Help %>
+    <button type="button" class="btn btn-ghost btn-sm btn-square" aria-label="Help">
+      <%= render Bali::Icon::Component.new('circle-help', class: 'size-5') %>
+    </button>
+
+    <%# User menu %>
+    <%= render Bali::Dropdown::Component.new(align: :left, class: 'lg:dropdown-end') do |dropdown| %>
+      <% dropdown.with_trigger(variant: :ghost, class: 'btn-sm gap-2') do %>
+        <%= render Bali::Avatar::Component.new(size: :xs) do |avatar| %>
+          <% avatar.with_placeholder { 'AG' } %>
+        <% end %>
+        <span class="hidden md:inline">Ana García</span>
+        <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
+      <% end %>
+      <% dropdown.with_item(href: admin_settings_path) { t('navbar.profile') } %>
+      <% dropdown.with_item(href: admin_settings_path) { t('navbar.settings') } %>
+      <li class="divider my-1"></li>
+      <% dropdown.with_item(href: logout_path, class: 'text-error', data: { turbo_method: :delete }) { t('navbar.sign_out') } %>
+    <% end %>
+  </div>
+</div>

--- a/spec/dummy/app/views/layouts/admin.html.erb
+++ b/spec/dummy/app/views/layouts/admin.html.erb
@@ -10,15 +10,7 @@
     <% end %>
 
     <% layout.with_topbar do %>
-      <div class="flex items-center gap-2 px-4 py-2 bg-base-100 shadow-sm lg:hidden">
-        <label for="<%= Bali::SideMenu::Component::MOBILE_TRIGGER_ID %>"
-               role="button" tabindex="0"
-               class="btn btn-ghost btn-sm"
-               aria-label="<%= t('bali.side_menu.toggle_mobile', default: 'Toggle sidebar') %>">
-          <%= render Bali::Icon::Component.new('menu', size: :small) %>
-        </label>
-        <span class="font-semibold text-sm"><%= t('app.name') %> Admin</span>
-      </div>
+      <%= render 'layouts/admin_topbar' %>
     <% end %>
 
     <% layout.with_body do %>

--- a/spec/dummy/app/views/pages/workspace.html.erb
+++ b/spec/dummy/app/views/pages/workspace.html.erb
@@ -1,0 +1,87 @@
+<% content_for :topbar do %>
+  <%= render Bali::Breadcrumb::Component.new do |bc| %>
+    <% bc.with_item(name: 'Home', href: root_path) %>
+    <% bc.with_item(name: 'Workspace') %>
+  <% end %>
+<% end %>
+
+<%= render Bali::PageHeader::Component.new(
+  title: 'Workspace',
+  subtitle: 'Reference page demonstrating the standard navbar + sidebar shell.'
+) do %>
+  <div class="flex items-center gap-2">
+    <%= render Bali::Button::Component.new(name: 'Export', variant: :ghost, icon_name: 'download') %>
+    <%= render Bali::Link::Component.new(name: 'New Movie', variant: :primary, icon_name: 'plus', href: new_admin_movie_path) %>
+  </div>
+<% end %>
+
+<%= render Bali::Columns::Component.new(cols: 1, cols_md: 2, cols_lg: 4, gap: :lg, class: 'mb-6') do %>
+  <% @stats.each do |stat| %>
+    <%= render Bali::Card::Component.new(style: :bordered, body_class: 'p-4') do %>
+      <div class="flex items-center justify-between">
+        <div>
+          <p class="text-sm text-base-content/60"><%= stat[:label] %></p>
+          <p class="text-2xl font-bold"><%= stat[:value] %></p>
+          <p class="text-xs <%= stat[:change].start_with?('-') ? 'text-error' : 'text-success' %> mt-1">
+            <%= stat[:change] %> vs last month
+          </p>
+        </div>
+        <div class="rounded-lg bg-<%= stat[:color] %>/10 p-3">
+          <%= render Bali::Icon::Component.new(stat[:icon], class: "size-6 text-#{stat[:color]}") %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render Bali::Columns::Component.new(cols: 1, cols_lg: 3, gap: :lg) do %>
+  <div class="lg:col-span-2">
+    <%= render Bali::Card::Component.new(style: :bordered) do |card| %>
+      <% card.with_header(title: 'Recent Movies') %>
+
+      <%= render Bali::Table::Component.new do |table| %>
+        <% table.with_header(name: 'Title') %>
+        <% table.with_header(name: 'Studio') %>
+        <% table.with_header(name: 'Genre') %>
+        <% table.with_header(name: 'Status') %>
+        <% @recent_movies.each do |movie| %>
+          <% table.with_row do %>
+            <td class="font-medium"><%= movie.name %></td>
+            <td class="text-base-content/70"><%= movie.studio&.name || '—' %></td>
+            <td class="text-base-content/70"><%= movie.genre&.titleize %></td>
+            <td>
+              <%= render Bali::Tag::Component.new(
+                text: movie.status&.titleize || 'Draft',
+                color: movie.status == 'published' ? :success : :warning
+              ) %>
+            </td>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= render Bali::Card::Component.new(style: :bordered) do |card| %>
+    <% card.with_header(title: 'Activity') %>
+    <ul class="space-y-3">
+      <% [
+        { who: 'Carlos', what: 'published', target: 'The Matrix Resurrections', when: '2h ago', icon: 'check-circle', color: 'success' },
+        { who: 'María', what: 'commented on', target: 'Dune Part Two', when: '4h ago', icon: 'message-square', color: 'info' },
+        { who: 'Ana', what: 'created', target: 'Studio Ghibli', when: 'Yesterday', icon: 'plus-circle', color: 'primary' },
+        { who: 'David', what: 'archived', target: 'Old Project Alpha', when: '2d ago', icon: 'archive', color: 'neutral' }
+      ].each do |item| %>
+        <li class="flex gap-3 text-sm">
+          <%= render Bali::Icon::Component.new(item[:icon], class: "size-5 text-#{item[:color]} shrink-0 mt-0.5") %>
+          <div class="flex-1 min-w-0">
+            <p class="text-base-content">
+              <span class="font-medium"><%= item[:who] %></span>
+              <span class="text-base-content/70"><%= item[:what] %></span>
+              <span class="font-medium"><%= item[:target] %></span>
+            </p>
+            <p class="text-xs text-base-content/50 mt-0.5"><%= item[:when] %></p>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   root 'dashboard#index'
   get 'landing', to: 'pages#landing'
   get 'showcase', to: 'pages#showcase'
+  get 'workspace', to: 'pages#workspace'
 
   # Auth pages (demo/reference)
   get 'login', to: 'sessions#new'

--- a/test/bali/components/command_test.rb
+++ b/test/bali/components/command_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliCommandComponentTest < ComponentTestCase
+  def test_renders_the_command_container_with_stimulus_controller
+    render_inline(Bali::Command::Component.new)
+    assert_selector(".bali-command[data-controller='command']")
+  end
+
+  def test_renders_panel_and_backdrop_targets
+    render_inline(Bali::Command::Component.new)
+    assert_selector("[data-command-target='panel']")
+    assert_selector("[data-command-target='backdrop']")
+    assert_selector("[data-command-target='input']")
+  end
+
+  def test_panel_and_backdrop_start_hidden
+    render_inline(Bali::Command::Component.new)
+    assert_selector("[data-command-target='panel'].hidden")
+    assert_selector("[data-command-target='backdrop'].hidden")
+  end
+
+  def test_renders_default_placeholder
+    render_inline(Bali::Command::Component.new)
+    assert_selector("input[placeholder='Search…']")
+  end
+
+  def test_uses_custom_placeholder
+    render_inline(Bali::Command::Component.new(placeholder: "Find anything"))
+    assert_selector("input[placeholder='Find anything']")
+  end
+
+  def test_renders_trigger_slot
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_trigger { "<button>Open palette</button>".html_safe }
+    end
+    assert_selector("[data-action*='click->command#open']")
+    assert_selector("button", text: "Open palette")
+  end
+
+  def test_renders_groups_with_items
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Pages") do |g|
+        g.with_item(title: "Dashboard", icon: "layout-dashboard", href: "/dashboard")
+        g.with_item(title: "Settings", icon: "settings", href: "/settings")
+      end
+    end
+    assert_selector("[data-command-target='group']", text: "Pages")
+    assert_selector("[data-command-target='row']", count: 2)
+    assert_selector(".cmd-row-title", text: "Dashboard")
+    assert_selector(".cmd-row-title", text: "Settings")
+  end
+
+  def test_item_href_is_html_escaped_in_data_attribute
+    # Regression: previously used `html_safe` on a string concatenation, which
+    # could let an attacker inject attribute markup if href came from user input.
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Pages") do |g|
+        g.with_item(title: "Evil", href: '"><script>alert(1)</script>')
+      end
+    end
+    # The dangerous quote should be escaped so it never breaks out of the attribute.
+    refute_match(%r{<script>}, page.native.to_html)
+  end
+
+  def test_group_default_mode_is_searchable
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Stuff") do |g|
+        g.with_item(title: "X")
+      end
+    end
+    assert_selector("[data-command-target='group'][data-mode='searchable']")
+    assert_selector("[data-command-target='row'][data-mode='searchable']")
+  end
+
+  def test_group_recent_mode
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Recents", mode: :recent) do |g|
+        g.with_item(title: "Yesterday's doc")
+      end
+    end
+    assert_selector("[data-command-target='group'][data-mode='recent']")
+    assert_selector("[data-command-target='row'][data-mode='recent']")
+  end
+
+  def test_group_action_mode
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Actions", mode: :action) do |g|
+        g.with_item(title: "New")
+      end
+    end
+    assert_selector("[data-command-target='group'][data-mode='action']")
+  end
+
+  def test_invalid_group_mode_falls_back_to_searchable
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "Bad", mode: :nonsense) do |g|
+        g.with_item(title: "X")
+      end
+    end
+    assert_selector("[data-command-target='group'][data-mode='searchable']")
+  end
+
+  def test_item_search_text_defaults_to_title_and_meta
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "G") do |g|
+        g.with_item(title: "Hello", meta: "World")
+      end
+    end
+    assert_selector("[data-search='hello world']")
+  end
+
+  def test_item_search_text_can_be_overridden
+    render_inline(Bali::Command::Component.new) do |c|
+      c.with_group(name: "G") do |g|
+        g.with_item(title: "Hello", search: "Custom")
+      end
+    end
+    assert_selector("[data-search='custom']")
+  end
+
+  def test_compact_density_adds_modifier_class
+    render_inline(Bali::Command::Component.new(density: :compact))
+    assert_selector(".cmd-panel.is-compact")
+  end
+
+  def test_default_density_omits_modifier_class
+    render_inline(Bali::Command::Component.new)
+    assert_no_selector(".cmd-panel.is-compact")
+  end
+
+  def test_invalid_density_falls_back_to_default
+    render_inline(Bali::Command::Component.new(density: :nonsense))
+    assert_no_selector(".cmd-panel.is-compact")
+  end
+
+  def test_compact_predicate
+    assert(Bali::Command::Component.new(density: :compact).compact?)
+    refute(Bali::Command::Component.new(density: :default).compact?)
+  end
+
+  def test_renders_no_results_message_with_default_text
+    render_inline(Bali::Command::Component.new)
+    assert_selector("[data-command-target='noResults']", text: "No results")
+  end
+
+  def test_renders_custom_no_results_text
+    render_inline(Bali::Command::Component.new(no_results_text: "Nothing here"))
+    assert_selector("[data-command-target='noResults']", text: "Nothing here")
+  end
+
+  def test_renders_no_results_subtitle_when_provided
+    render_inline(Bali::Command::Component.new(no_results_subtitle: "Try another term"))
+    assert_text("Try another term")
+  end
+
+  def test_omits_no_results_subtitle_when_nil
+    render_inline(Bali::Command::Component.new)
+    assert_no_text("Try another term")
+  end
+
+  def test_accepts_custom_classes
+    render_inline(Bali::Command::Component.new(class: "my-palette"))
+    assert_selector(".bali-command.my-palette")
+  end
+end

--- a/test/bali/components/topbar_test.rb
+++ b/test/bali/components/topbar_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliTopbarComponentTest < ComponentTestCase
+  def test_renders_the_topbar_container
+    render_inline(Bali::Topbar::Component.new)
+    assert_selector(".bali-topbar")
+  end
+
+  def test_renders_brand_when_provided
+    render_inline(Bali::Topbar::Component.new) do |topbar|
+      topbar.with_brand { "ACME" }
+    end
+    assert_selector(".bali-topbar-brand", text: "ACME")
+  end
+
+  def test_does_not_render_brand_when_not_provided
+    render_inline(Bali::Topbar::Component.new)
+    assert_no_selector(".bali-topbar-brand")
+  end
+
+  def test_renders_search_when_provided
+    render_inline(Bali::Topbar::Component.new) do |topbar|
+      topbar.with_search { "<input class='search'/>".html_safe }
+    end
+    assert_selector("input.search")
+  end
+
+  def test_renders_actions_when_provided
+    render_inline(Bali::Topbar::Component.new) do |topbar|
+      topbar.with_action { "<button>Bell</button>".html_safe }
+      topbar.with_action { "<button>Help</button>".html_safe }
+    end
+    assert_selector("button", text: "Bell")
+    assert_selector("button", text: "Help")
+  end
+
+  def test_renders_user_menu_when_provided
+    render_inline(Bali::Topbar::Component.new) do |topbar|
+      topbar.with_user_menu { "<div class='avatar-stub'>AG</div>".html_safe }
+    end
+    assert_selector(".avatar-stub", text: "AG")
+  end
+
+  def test_renders_mobile_trigger_label_by_default
+    render_inline(Bali::Topbar::Component.new)
+    assert_selector("label[for='#{Bali::SideMenu::Component::MOBILE_TRIGGER_ID}']")
+  end
+
+  def test_does_not_render_mobile_trigger_when_nil
+    render_inline(Bali::Topbar::Component.new(mobile_trigger_id: nil))
+    assert_no_selector("label.lg\\:hidden")
+  end
+
+  def test_uses_custom_mobile_trigger_id
+    render_inline(Bali::Topbar::Component.new(mobile_trigger_id: "custom-id"))
+    assert_selector("label[for='custom-id']")
+  end
+
+  def test_mobile_trigger_has_aria_label
+    render_inline(Bali::Topbar::Component.new)
+    assert_selector("label[aria-label]")
+  end
+
+  def test_mobile_trigger_does_not_use_role_button_polyfill
+    # role="button" + tabindex on a <label> is an a11y anti-pattern: the label
+    # already toggles the checkbox on click, but Space/Enter wouldn't work.
+    render_inline(Bali::Topbar::Component.new)
+    assert_no_selector("label[role='button']")
+    assert_no_selector("label[tabindex]")
+  end
+
+  def test_accepts_custom_classes
+    render_inline(Bali::Topbar::Component.new(class: "custom-topbar"))
+    assert_selector(".bali-topbar.custom-topbar")
+  end
+
+  def test_passes_through_data_attributes
+    render_inline(Bali::Topbar::Component.new(data: { controller: "theme" }))
+    assert_selector(".bali-topbar[data-controller='theme']")
+  end
+end


### PR DESCRIPTION
## Summary
- Add `viewport_locked` parameter to `Bali::AppLayout` (decoupled from `fixed_sidebar`) that locks body to 100vh and scrolls only the inner `<main>` — Linear/Notion app-shell pattern
- Align `Bali::SideMenu` with the new pattern: 56px brand row + bottom border that matches the topbar, replace `shadow-lg` with 1px right border on desktop (shadow stays on mobile overlay)
- Fix menu_switcher reliability on mobile (`<details><summary>` instead of focus-based dropdown) and keep it visible when sidebar is collapsed (icon-only with right-side popout + hover tooltip)
- Wire the standard shell into the dummy admin layout and add `/workspace` as a reference page

## Test plan
- [ ] `/admin` and `/workspace` render with sidebar + topbar pinned, only the body content scrolls
- [ ] Collapse the sidebar — first menu item has breathing room; menu_switcher compacts to icon-only with tooltip on hover
- [ ] Click the collapsed menu_switcher icon — popup opens to the right of the sidebar with the full module list
- [ ] Mobile (Chrome devtools, iPhone preset) — hamburger opens sidebar; menu_switcher dropdown opens reliably on tap
- [ ] Marketing pages (`/`, `/landing`, `/showcase`) still scroll normally (viewport_locked defaults to false there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)