### PR TITLE
form-builder + app-shell + breadcrumb + i18n follow-ups (#545, #544, #539, #538, #506, #530)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,8 @@ spec/dummy/log/test.log.0
 # AI session memory (local, not committed)
 .ai-sessions/*.md
 
+# SocratiCode linked projects (user-specific absolute paths)
+.socraticode.json
+
 # Sandbox environment secrets (written by bin/docker-claude, read once by container)
 .sandbox-env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FormBuilder** - `select_group`, `text_area_group`, `time_zone_select_group`, and `slim_select_field` now apply DaisyUI's element-specific error classes (`select-error` / `textarea-error`) instead of always using `input-error`. Validation errors on these fields actually paint the field red now (#545)
+- **FilterForm** - Default search placeholder is localized via `bali.filter_form.search_placeholder_with_fields`, and field labels resolve through `human_attribute_name`, so apps running in non-English locales no longer get a hardcoded "Search by ..." string (#539)
 - Fix Ruby 4.0 warnings: parenthesize double-splat in ERB templates, silence intentional method overrides, fix indentation
 - Fix pagination end alignment conflict between Rubocop and Ruby 4.0
 - **SimpleFilters** - Fix `simple_filter` DSL defaulting date/date_range predicate to `:eq` instead of `nil`, causing incorrect field names (`q[created_at_eq]` instead of `q[created_at]`)
-- **SideMenu** - Brand row uses fixed `h-14` (56px) + `border-b` so it aligns horizontally with `Bali::Topbar`, forming one continuous chrome divider across the top of the app shell
+- **SideMenu** / **Topbar** - Brand row and Topbar both derive their height from the shared `--bali-chrome-height` variable (defaults to 3.5rem) so the bottom-border divider stays aligned across the seam if the value changes (#544)
 - **SideMenu** - Replace `shadow-lg` on the fixed variant with a 1px right border on desktop (shadow stays on mobile overlay) — eliminates the shadow seam where sidebar meets the topbar
 - **SideMenu** - `menu_switcher` dropdown now uses `<details><summary>` instead of focus-based dropdown — fixes mobile-tap reliability (focus pattern is fragile on iOS Safari)
 - **SideMenu** - When sidebar is collapsed, the `menu_switcher` stays visible as an icon-only button (was hidden) with a tooltip on hover and a right-side popout for switching modules
@@ -24,7 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Topbar** - New component for the top-of-content bar inside `Bali::AppLayout`'s `with_topbar` slot. Slots: `brand`, `search`, `actions` (many), `user_menu`. Built-in mobile sidebar trigger via `mobile_trigger_id:` (defaults to `SideMenu::MOBILE_TRIGGER_ID`)
 - **Command** - New ⌘K-style command palette / launcher. Modal panel with search input, grouped results (`:searchable` / `:recent` / `:action` modes), keyboard navigation (↑/↓/⏎/Esc), substring highlighting, and a global ⌘K (Mac) / Ctrl+K (Windows/Linux) shortcut. Composable trigger slot, density variants (`:default` / `:compact`), and window events (`bali:command:open` / `close` / `toggle`)
 - **DocumentEditor / DocumentPage** - Forward `references_url`, `references_resolve_url`, and `references_config` to the inner `BlockEditor` so the `#` entity-reference picker and entity chip icons/colors work when the editor is used via `DocumentEditor` or `DocumentPage` (#541)
+- **Icon** - Numeric pixel sizes alongside the named presets: `Bali::Icon::Component.new('clapperboard', size: 24)` renders a 24×24 wrapper with a 24×24 SVG. Inline `style` + `--bali-icon-size` variable, no Tailwind safelist needed (#544)
+- **Command** - i18n keys (`bali.command.placeholder`, `no_results`, `navigate`, `open_action`, `close`) are now in the en/es locale files so consumers can override / translate without monkey-patching. Inline `default:` fallbacks remain (#544)
 - **SimpleFilters** - Configurable search input width via `search[:width]` option; widened defaults from `w-32 sm:w-80` to `w-48 sm:w-96`
+- **SlimSelect** - Search row redesign: magnifier icon prefix, no boxed background, no input border. Selected options use blue text plus a checkmark on the right with no background tint. Trigger focus outline unchanged
 - **SlimSelect** - Added 8px detached gap between input and dropdown menu for improved visual separation
 - **SlimSelect** - Matched focus ring style with DaisyUI native selects (2px outline with 2px offset)
 - **SlimSelect** - Added support for placing search box at the bottom when dropdown opens upwards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breadcrumb** - DaisyUI's `.breadcrumbs { padding-block: .5rem }` was beating the component's `pt-0` utility in host apps where the daisyUI plugin layer ends up after `@layer utilities` (Tailwind v4 + daisyUI plugin ordering varies per host). Move the override into the component's unlayered `index.css` so it wins regardless of layer ordering and drop the now-redundant `pt-0` utility (#530)
 - **FormBuilder** - `translate_attribute` routes through `ActiveModel::Translation#human_attribute_name` so labels resolve from `activemodel.attributes.*` (form objects) as well as `activerecord.attributes.*`. Previously the `activerecord.*` namespace was hardcoded and form-object translations silently fell back to humanize (#538)
 - **FormBuilder** - `select_group`, `text_area_group`, `time_zone_select_group`, and `slim_select_field` now apply DaisyUI's element-specific error classes (`select-error` / `textarea-error`) instead of always using `input-error`. Validation errors on these fields actually paint the field red now (#545)
 - **FilterForm** - Default search placeholder is localized via `bali.filter_form.search_placeholder_with_fields`, and field labels resolve through `human_attribute_name`, so apps running in non-English locales no longer get a hardcoded "Search by ..." string (#539)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FormBuilder** - `translate_attribute` routes through `ActiveModel::Translation#human_attribute_name` so labels resolve from `activemodel.attributes.*` (form objects) as well as `activerecord.attributes.*`. Previously the `activerecord.*` namespace was hardcoded and form-object translations silently fell back to humanize (#538)
 - **FormBuilder** - `select_group`, `text_area_group`, `time_zone_select_group`, and `slim_select_field` now apply DaisyUI's element-specific error classes (`select-error` / `textarea-error`) instead of always using `input-error`. Validation errors on these fields actually paint the field red now (#545)
 - **FilterForm** - Default search placeholder is localized via `bali.filter_form.search_placeholder_with_fields`, and field labels resolve through `human_attribute_name`, so apps running in non-English locales no longer get a hardcoded "Search by ..." string (#539)
 - Fix Ruby 4.0 warnings: parenthesize double-splat in ERB templates, silence intentional method overrides, fix indentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AppLayout** - Auto-render a mobile-only topbar (hamburger + optional `app_name:` title) when `fixed_sidebar: true`, a sidebar is present, and no custom `topbar` slot was provided. Without this fallback the sidebar was unreachable on mobile, forcing every consuming app to copy/paste the same `lg:hidden` trigger row. Custom topbars still take precedence (#506)
 - **AppLayout** - New `viewport_locked:` parameter that locks the body to 100vh and scrolls only the inner `<main>`, matching the Linear/Notion app-shell pattern. Defaults to the value of `fixed_sidebar` so existing pages keep working; pass explicitly to decouple (e.g. `fixed_sidebar: true, viewport_locked: false` for a fixed sidebar with normal page scroll)
 - **SideMenu** - New `with_brand` slot for icon + text or arbitrary brand content (the existing `brand:` text param keeps working as a fallback)
 - **Topbar** - New component for the top-of-content bar inside `Bali::AppLayout`'s `with_topbar` slot. Slots: `brand`, `search`, `actions` (many), `user_menu`. Built-in mobile sidebar trigger via `mobile_trigger_id:` (defaults to `SideMenu::MOBILE_TRIGGER_ID`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ This project uses `.ai-sessions/` for session continuity between Docker sandbox 
 - Key decisions made
 - Any blockers or issues
 
+## Codebase Search (SocratiCode)
+
+This repo is indexed by SocratiCode (hybrid semantic + BM25 search, file watcher active). For exploratory questions ("where is X?", "how does Y work?", "find code that does Z"), reach for `codebase_search` **before** `Grep` or speculative `Read` calls — it returns ranked snippets across the whole repo in one tool call.
+
+**Workflow:**
+1. `codebase_search` to find relevant code
+2. `codebase_graph_query` for imports/dependents on JS/JSX (Ruby is mostly Zeitwerk-autoloaded, so the graph is less useful there)
+3. `Read` only after search has narrowed to 1–3 files
+
+**Skip search for:** known file paths (use `Read`), single-file symbol lookups (use `Grep`), edits/writes (search is read-only).
+
+**Cross-project:** pass `includeLinked: true` to search linked projects defined in `.socraticode.json` or `SOCRATICODE_LINKED_PROJECTS`.
+
 ## Browser Verification (MANDATORY)
 
 **ALWAYS verify UI/UX changes through the browser before claiming they work.** Curl-testing APIs and passing Ruby tests is NOT sufficient for frontend features.

--- a/app/assets/stylesheets/bali/components.css
+++ b/app/assets/stylesheets/bali/components.css
@@ -8,6 +8,7 @@
  */
 
 /* Navigation Components */
+@import "../../../components/bali/breadcrumb/index.css";
 @import "../../../components/bali/navbar/index.css";
 @import "../../../components/bali/side_menu/index.css";
 @import "../../../components/bali/command/index.css";

--- a/app/assets/stylesheets/bali/general.css
+++ b/app/assets/stylesheets/bali/general.css
@@ -47,6 +47,15 @@ a {
   @apply rounded-full;
 }
 
+/* Icon component — numeric sizes propagate to direct children (legacy and
+   kept SVGs that do not get explicit width/height from the Lucide gem).
+   The `[style*=...]` guard limits the cascade to wrappers that actually
+   set the variable, so named-size icons keep their `*:h-N *:w-N` classes. */
+.icon-component[style*="--bali-icon-size"] > * {
+  width: var(--bali-icon-size);
+  height: var(--bali-icon-size);
+}
+
 /* Notification animations */
 .slideInRight {
   animation: slideInRight 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) both;

--- a/app/assets/stylesheets/bali/general.css
+++ b/app/assets/stylesheets/bali/general.css
@@ -10,6 +10,16 @@
   --size-field: 0.25rem;
   --depth: 1;
   --noise: 0;
+
+  /* Shared height for the app shell chrome — SideMenu brand row + Topbar.
+     Both must derive from this so the bottom-border divider stays aligned
+     across the seam when the value changes. */
+  --bali-chrome-height: 3.5rem;
+}
+
+/* Utility for chrome-height alignment between SideMenu brand row + Topbar. */
+.bali-chrome-height {
+  height: var(--bali-chrome-height);
 }
 
 /* General utility styles */

--- a/app/assets/stylesheets/bali/slim_select.css
+++ b/app/assets/stylesheets/bali/slim_select.css
@@ -383,17 +383,32 @@
    Search Input
    ============================================================================= */
 .ss-content .ss-search {
+  position: relative;
   flex: 0 1 auto;
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: var(--ss-spacing-m);
+  padding: var(--ss-spacing-s) var(--ss-spacing-m);
   border-bottom: 1px solid oklch(0.278 0.033 256.8 / 0.1);
-  background-color: oklch(0.95 0 0 / 0.5);
-  /* Remove padding on sides and use negative margin to extend to container edges */
-  padding-left: 0;
-  padding-right: 0;
+  background-color: transparent;
   margin: 0;
+
+  /* Magnifier icon prefix */
+  &::before {
+    content: "";
+    position: absolute;
+    left: calc(var(--ss-spacing-m) + var(--ss-spacing-m));
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--ss-placeholder-color);
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E") no-repeat center;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E") no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    pointer-events: none;
+  }
 
   input {
     display: inline-flex;
@@ -401,18 +416,15 @@
     width: 100%;
     min-width: 0;
     height: var(--ss-search-height);
-    padding: 0 var(--ss-spacing-l);
-    margin: 0 var(--ss-spacing-m);
+    padding: 0 var(--ss-spacing-l) 0 calc(var(--ss-spacing-l) + 1.25rem);
+    margin: 0;
     font-size: 0.875rem;
     line-height: inherit;
     color: var(--ss-font-color);
-    background-color: var(--ss-bg-color);
-    border: 1px solid var(--ss-border-color);
-    border-radius: var(--ss-border-radius);
+    background-color: transparent;
+    border: none;
     outline: none;
     box-sizing: border-box;
-    transition: border-color var(--ss-animation-timing) ease,
-                outline var(--ss-animation-timing) ease;
 
     &::placeholder {
       color: var(--ss-placeholder-color);
@@ -420,7 +432,6 @@
 
     &:focus {
       outline: none;
-      border-color: var(--ss-primary-color);
     }
 
     /* Style the native search clear button (X) to match DaisyUI */
@@ -543,6 +554,7 @@
    Individual Option (.ss-option)
    ============================================================================= */
 .ss-content .ss-list .ss-option {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -569,14 +581,31 @@
     background-color: oklch(0.95 0 0);
   }
 
-  /* Selected state - subtle primary tint */
+  /* Selected state — blue text + checkmark, no background tint */
   &.ss-selected {
-    background-color: oklch(0.6569 0.196 275.75 / 0.1);
+    background-color: transparent;
     color: var(--ss-primary-color);
     font-weight: 500;
+    padding-right: calc(12px + 1.25rem);
 
     &:hover {
-      background-color: oklch(0.6569 0.196 275.75 / 0.15);
+      background-color: oklch(0.95 0 0);
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      right: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 1rem;
+      height: 1rem;
+      background-color: var(--ss-primary-color);
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E") no-repeat center;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E") no-repeat center;
+      -webkit-mask-size: contain;
+      mask-size: contain;
+      pointer-events: none;
     }
   }
 

--- a/app/components/bali/app_layout/component.html.erb
+++ b/app/components/bali/app_layout/component.html.erb
@@ -16,6 +16,17 @@
     <div class="app-layout-content flex-1 min-w-0 flex flex-col">
       <% if topbar? %>
         <div class="app-layout-topbar"><%= topbar %></div>
+      <% elsif render_default_mobile_topbar? %>
+        <div class="app-layout-topbar app-layout-topbar--default-mobile flex items-center gap-2 px-4 py-2 bg-base-100 border-b border-base-300 lg:hidden">
+          <label for="<%= default_mobile_trigger_id %>"
+                 class="btn btn-ghost btn-sm"
+                 aria-label="<%= toggle_mobile_label %>">
+            <%= render Bali::Icon::Component.new('menu', size: :small) %>
+          </label>
+          <% if @app_name.present? %>
+            <span class="font-semibold text-sm"><%= @app_name %></span>
+          <% end %>
+        </div>
       <% end %>
 
       <main class="flex-1" <%= tag.attributes(main_attributes) %>>

--- a/app/components/bali/app_layout/component.rb
+++ b/app/components/bali/app_layout/component.rb
@@ -24,10 +24,13 @@ module Bali
       #   When nil (default), follows `fixed_sidebar` — the typical app-shell wants both,
       #   but you can decouple them, e.g. `fixed_sidebar: true, viewport_locked: false`
       #   for a fixed sidebar with normal page scroll (long forms, marketing-style content).
+      # @param app_name [String, nil] Title shown next to the hamburger in the
+      #   auto-rendered mobile topbar. Only used when `fixed_sidebar:` is true,
+      #   a sidebar is present, and no `topbar` slot was provided.
       def initialize(fixed_sidebar: false, viewport_locked: nil,
                      flash: nil, modal: true, drawer: true,
                      modal_size: nil, drawer_size: nil,
-                     body_container: :wide, **options)
+                     body_container: :wide, app_name: nil, **options)
         @fixed_sidebar = fixed_sidebar
         @viewport_locked = viewport_locked.nil? ? fixed_sidebar : viewport_locked
         @flash = flash
@@ -36,10 +39,26 @@ module Bali
         @modal_size = modal_size
         @drawer_size = drawer_size
         @body_container = body_container
+        @app_name = app_name
         @options = options
       end
 
       private
+
+      # Auto-render a mobile-only topbar (hamburger + optional app name) when the
+      # consumer pinned the sidebar but didn't supply their own topbar — without
+      # this fallback, the sidebar is unreachable on mobile.
+      def render_default_mobile_topbar?
+        @fixed_sidebar && sidebar? && !topbar?
+      end
+
+      def default_mobile_trigger_id
+        Bali::SideMenu::Component::MOBILE_TRIGGER_ID
+      end
+
+      def toggle_mobile_label
+        I18n.t("bali.side_menu.toggle_mobile", default: "Toggle sidebar")
+      end
 
       def container_classes
         class_names(

--- a/app/components/bali/app_layout/preview.rb
+++ b/app/components/bali/app_layout/preview.rb
@@ -3,6 +3,7 @@
 module Bali
   module AppLayout
     class Preview < ApplicationViewComponentPreview
+      layout "app_layout_preview"
       # @label Sidebar + Content
       # Config A: Admin layout with sidebar and content area.
       # In production, use `fixed: true` on the SideMenu and `fixed_sidebar: true` on AppLayout.

--- a/app/components/bali/app_layout/preview.rb
+++ b/app/components/bali/app_layout/preview.rb
@@ -6,12 +6,16 @@ module Bali
       # @label Sidebar + Content
       # Config A: Admin layout with sidebar and content area.
       # In production, use `fixed: true` on the SideMenu and `fixed_sidebar: true` on AppLayout.
+      # On mobile (lg breakpoint), AppLayout auto-renders a hamburger topbar so the
+      # sidebar stays reachable — set `app_name:` to label it.
       # @param collapsible toggle
       # @param flash_notice text
       # @param modal toggle
       # @param drawer toggle
       # @param body_container select { choices: [wide, contained, narrow, full] }
-      def default(collapsible: true, flash_notice: "", modal: true, drawer: true, body_container: "wide")
+      # @param app_name text
+      def default(collapsible: true, flash_notice: "", modal: true, drawer: true,
+                  body_container: "wide", app_name: "MovieDB")
         render_with_template(
           template: "bali/app_layout/previews/default",
           locals: {
@@ -20,7 +24,8 @@ module Bali
             modal: modal,
             drawer: drawer,
             drawer_size: drawer ? :lg : nil,
-            body_container: body_container.to_sym
+            body_container: body_container.to_sym,
+            app_name: app_name.presence
           }
         )
       end

--- a/app/components/bali/app_layout/previews/content_only.html.erb
+++ b/app/components/bali/app_layout/previews/content_only.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
   modal: false,
@@ -48,4 +46,3 @@
     <% end %>
   <% end
 end %>
-</div>

--- a/app/components/bali/app_layout/previews/default.html.erb
+++ b/app/components/bali/app_layout/previews/default.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   fixed_sidebar: true,
   app_name: app_name,
@@ -64,4 +62,3 @@
     </div>
   <% end
 end %>
-</div>

--- a/app/components/bali/app_layout/previews/default.html.erb
+++ b/app/components/bali/app_layout/previews/default.html.erb
@@ -2,6 +2,7 @@
 <div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   fixed_sidebar: true,
+  app_name: app_name,
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
   modal: modal,
   drawer: drawer,

--- a/app/components/bali/app_layout/previews/login.html.erb
+++ b/app/components/bali/app_layout/previews/login.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
   modal: false,
@@ -54,4 +52,3 @@
     </div>
   <% end
 end %>
-</div>

--- a/app/components/bali/app_layout/previews/navbar_only.html.erb
+++ b/app/components/bali/app_layout/previews/navbar_only.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
   modal: false,
@@ -39,4 +37,3 @@
     </div>
   <% end
 end %>
-</div>

--- a/app/components/bali/app_layout/previews/register.html.erb
+++ b/app/components/bali/app_layout/previews/register.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
   modal: false,
@@ -67,4 +65,3 @@
     </div>
   <% end
 end %>
-</div>

--- a/app/components/bali/app_layout/previews/with_navbar.html.erb
+++ b/app/components/bali/app_layout/previews/with_navbar.html.erb
@@ -1,5 +1,3 @@
-<%# transform creates a containing block that traps position:fixed elements inside the preview pane %>
-<div style="transform: translateZ(0); position: relative; height: 100vh; overflow: hidden;">
 <%= render Bali::AppLayout::Component.new(
   fixed_sidebar: true,
   flash: flash_notice.present? ? { notice: flash_notice } : nil,
@@ -94,4 +92,3 @@
     </div>
   <% end
 end %>
-</div>

--- a/app/components/bali/breadcrumb/component.rb
+++ b/app/components/bali/breadcrumb/component.rb
@@ -21,7 +21,6 @@ module Bali
           "breadcrumbs",
           "text-sm",
           "overflow-x-auto",
-          "pt-0",
           @options[:class]
         )
       end

--- a/app/components/bali/breadcrumb/index.css
+++ b/app/components/bali/breadcrumb/index.css
@@ -1,0 +1,11 @@
+/* Breadcrumb Component
+ * DaisyUI sets `.breadcrumbs { padding-block: .5rem }` inside its utilities
+ * layer. In some host apps (Tailwind v4 + daisyUI plugin) that layer ends
+ * up ordered AFTER our @layer utilities, so a `pt-0` utility from the Ruby
+ * class list loses the cascade and breadcrumbs render with unwanted top
+ * padding. This unlayered rule beats both layered sources regardless of
+ * ordering. (#530)
+ */
+.breadcrumbs {
+  padding-block: 0;
+}

--- a/app/components/bali/form/select/preview.rb
+++ b/app/components/bali/form/select/preview.rb
@@ -15,7 +15,7 @@ module Bali
         end
 
         # @label With Errors
-        # Shows validation error styling with `input-error` class.
+        # Shows validation error styling with `select-error` class.
         def with_errors
           form_record.errors.add(:status, 'must be selected')
 

--- a/app/components/bali/form/slim_select/preview.rb
+++ b/app/components/bali/form/slim_select/preview.rb
@@ -49,6 +49,17 @@ module Bali
           )
         end
 
+        # @label With Errors
+        # Shows validation error styling with `select-error` class.
+        def with_errors
+          form_record.errors.add(:name, 'must be selected')
+
+          render_with_template(
+            template: 'bali/form/slim_select/previews/default',
+            locals: { model: form_record, options: OPTIONS }
+          )
+        end
+
         # @label Multiple
         # Multi-select with tags for selected values
         def multiple

--- a/app/components/bali/form/time_zone_select/preview.rb
+++ b/app/components/bali/form/time_zone_select/preview.rb
@@ -25,7 +25,7 @@ module Bali
         end
 
         # @label With Errors
-        # Shows validation error styling with `input-error` class.
+        # Shows validation error styling with `select-error` class.
         def with_errors
           form_record.errors.add(:time_zone, 'must be selected')
 

--- a/app/components/bali/icon/component.rb
+++ b/app/components/bali/icon/component.rb
@@ -16,6 +16,9 @@ module Bali
     # @example With size
     #   render Bali::Icon::Component.new('check', size: :large)
     #
+    # @example With numeric size (pixels)
+    #   render Bali::Icon::Component.new('check', size: 24)
+    #
     # @example With custom classes
     #   render Bali::Icon::Component.new('alert', class: 'text-error')
     #
@@ -43,12 +46,14 @@ module Bali
 
       # @param name [String, Symbol] Icon name (Bali name or Lucide name)
       # @param tag_name [Symbol] HTML tag to wrap the icon (:span, :div, etc.)
-      # @param size [Symbol] Icon size (:small, :medium, :large)
+      # @param size [Symbol, Numeric] Icon size — :small / :medium / :large or
+      #   an integer in pixels (e.g. 24)
       # @param options [Hash] Additional HTML attributes
       def initialize(name, tag_name: :span, size: nil, **options)
         @name = name.to_s
         @tag_name = tag_name
         @size = size
+        options = apply_size_style(options) if numeric_size?
         @options = prepend_class_name(options, component_classes)
       end
 
@@ -89,7 +94,6 @@ module Bali
       # @param lucide_name [String] the Lucide icon name
       # @return [String] SVG markup
       def render_lucide_icon(lucide_name)
-        pixel_size = LUCIDE_SIZES[@size] || 16
         svg_content = LucideRails::IconProvider.icon(lucide_name)
 
         tag.svg(
@@ -99,6 +103,22 @@ module Bali
           height: pixel_size,
           class: "lucide-icon"
         )
+      end
+
+      def numeric_size?
+        @size.is_a?(Numeric)
+      end
+
+      def pixel_size
+        return @size.to_i if numeric_size?
+
+        LUCIDE_SIZES[@size] || 16
+      end
+
+      def apply_size_style(options)
+        px = "#{@size.to_i}px"
+        sizing = "width: #{px}; height: #{px}; --bali-icon-size: #{px}"
+        options.merge(style: [ sizing, options[:style] ].compact.join("; "))
       end
 
       # Checks if a Lucide icon exists
@@ -164,12 +184,25 @@ module Bali
       end
 
       def component_classes
+        return numeric_component_classes if numeric_size?
+
         class_names(
           "icon-component",
           "inline-flex items-center justify-center",
           "*:inline-block *:h-4 *:w-4 *:overflow-visible",
           SIZES[@size],
           SIZE_SVG_CLASSES[@size]
+        )
+      end
+
+      # Numeric sizes drive the wrapper and direct children via inline style
+      # plus the `--bali-icon-size` CSS variable, so no Tailwind safelist is
+      # required and consumers can pass any pixel value.
+      def numeric_component_classes
+        class_names(
+          "icon-component",
+          "inline-flex items-center justify-center",
+          "*:inline-block *:overflow-visible"
         )
       end
     end

--- a/app/components/bali/side_menu/component.html.erb
+++ b/app/components/bali/side_menu/component.html.erb
@@ -14,11 +14,12 @@
 
 <%= tag.div(**container_options) do %>
   <%# Header with collapse toggle.
-      Height is fixed to h-14 (56px) so the row aligns horizontally with the
-      AppLayout topbar — both share one continuous border-b across the top. %>
+      Height comes from the shared `--bali-chrome-height` variable so the row
+      stays aligned horizontally with the AppLayout topbar — both share one
+      continuous border-b across the top. %>
   <% if collapsible? %>
     <%# Expanded state header - toggle on the right %>
-    <div class="side-menu-expanded flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
+    <div class="side-menu-expanded flex bali-chrome-height items-center gap-2 px-2.5 border-b border-base-300">
       <% if brand_present? %>
         <span class="side-menu-brand text-xl font-semibold grow flex items-center gap-2 min-w-0">
           <%= brand || @brand %>
@@ -43,7 +44,7 @@
       <% end %>
     </div>
     <%# Collapsed state header - toggle centered like menu items %>
-    <div class="side-menu-collapsed hidden h-14 items-center px-1 border-b border-base-300">
+    <div class="side-menu-collapsed hidden bali-chrome-height items-center px-1 border-b border-base-300">
       <label for="<%= collapse_checkbox_id %>"
              title="<%= expand_label %>"
              class="collapse-toggle menu-item justify-center cursor-pointer w-full">
@@ -52,7 +53,7 @@
       </label>
     </div>
   <% elsif brand_present? || fixed? %>
-    <div class="flex h-14 items-center gap-2 px-2.5 border-b border-base-300">
+    <div class="flex bali-chrome-height items-center gap-2 px-2.5 border-b border-base-300">
       <% if brand_present? %>
         <span class="side-menu-brand text-xl font-semibold grow flex items-center gap-2 min-w-0">
           <%= brand || @brand %>

--- a/app/components/bali/topbar/component.rb
+++ b/app/components/bali/topbar/component.rb
@@ -3,16 +3,17 @@
 module Bali
   module Topbar
     # Renders the topbar that sits inside the AppLayout's `with_topbar` slot.
-    # Designed to align horizontally with the SideMenu's brand row (both 56px,
-    # h-14) so the bottom border forms one continuous chrome divider.
+    # Designed to align horizontally with the SideMenu's brand row — both
+    # derive their height from the shared `--bali-chrome-height` variable so
+    # the bottom border forms one continuous chrome divider.
     #
     # Composes 4 zones — brand (left, optional), search (center), actions
     # (right, many icon buttons), user_menu (far right). Pair with a sidebar
     # by passing the sidebar's `mobile_trigger_id` to render the hamburger on
     # small screens.
     class Component < ApplicationViewComponent
-      BASE_CLASSES = "bali-topbar flex items-center gap-3 px-4 md:px-6 h-14 " \
-                     "bg-base-100 border-b border-base-300"
+      BASE_CLASSES = "bali-topbar flex items-center gap-3 px-4 md:px-6 " \
+                     "bali-chrome-height bg-base-100 border-b border-base-300"
 
       renders_one :brand
       renders_one :search

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -147,6 +147,10 @@ en:
         dismiss: "Dismiss error"
         remove_file: "Remove %{filename}"
 
+    # FilterForm — quick text search across multiple columns
+    filter_form:
+      search_placeholder_with_fields: "Search by %{fields}..."
+
     # Form builder
     form_builder:
       file:

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -104,6 +104,14 @@ en:
       expand: "Expand sidebar"
       toggle_item: "Toggle %{name}"
 
+    # Command palette (⌘K)
+    command:
+      placeholder: "Search…"
+      no_results: "No results"
+      navigate: "navigate"
+      open_action: "open"
+      close: "close"
+
     # Modal
     modal:
       close: "Close modal"

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -104,6 +104,14 @@ es:
       expand: "Expandir menú lateral"
       toggle_item: "Alternar %{name}"
 
+    # Paleta de comandos (⌘K)
+    command:
+      placeholder: "Buscar…"
+      no_results: "Sin resultados"
+      navigate: "navegar"
+      open_action: "abrir"
+      close: "cerrar"
+
     # Modal
     modal:
       close: "Cerrar modal"

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -147,6 +147,10 @@ es:
         dismiss: "Cerrar error"
         remove_file: "Eliminar %{filename}"
 
+    # FilterForm — búsqueda rápida en varias columnas
+    filter_form:
+      search_placeholder_with_fields: "Buscar por %{fields}..."
+
     # Form builder
     form_builder:
       file:

--- a/cypress/e2e/command-controller.cy.js
+++ b/cypress/e2e/command-controller.cy.js
@@ -1,0 +1,112 @@
+describe('CommandController', () => {
+  beforeEach(() => {
+    cy.visit('/bali/command/default')
+    cy.get('[data-controller="command"]', { timeout: 5000 }).should('exist')
+  })
+
+  context('opening and closing', () => {
+    it('opens via the trigger slot and focuses the input', () => {
+      cy.get('[data-action*="click->command#open"] button').click()
+
+      cy.get('[data-command-target="panel"]').should('not.have.class', 'hidden')
+      cy.get('[data-command-target="backdrop"]').should('not.have.class', 'hidden')
+      cy.get('[data-command-target="input"]').should('be.focused')
+    })
+
+    it('opens via Cmd/Ctrl+K and closes via the same chord when open', () => {
+      // Open
+      cy.get('body').type('{meta+k}')
+      cy.get('[data-command-target="panel"]').should('not.have.class', 'hidden')
+
+      // Close (controller handles both meta and ctrl)
+      cy.get('body').type('{meta+k}')
+      cy.get('[data-command-target="panel"]').should('have.class', 'hidden')
+    })
+
+    it('closes via Escape', () => {
+      cy.get('body').type('{meta+k}')
+      cy.get('[data-command-target="panel"]').should('not.have.class', 'hidden')
+
+      cy.get('[data-command-target="input"]').type('{esc}')
+      cy.get('[data-command-target="panel"]').should('have.class', 'hidden')
+    })
+
+    it('closes when the backdrop is clicked', () => {
+      cy.get('body').type('{meta+k}')
+      cy.get('[data-command-target="panel"]').should('not.have.class', 'hidden')
+
+      // The panel sits on top of the backdrop (higher z-index) so Cypress's
+      // visibility check refuses the click; force it to fire on the backdrop
+      // itself — the goal here is to verify the click handler closes the
+      // palette, not real-user reachability.
+      cy.get('[data-command-target="backdrop"]').click({ force: true })
+      cy.get('[data-command-target="panel"]').should('have.class', 'hidden')
+    })
+  })
+
+  context('searching and filtering', () => {
+    beforeEach(() => {
+      cy.get('body').type('{meta+k}')
+    })
+
+    it('shows recent items by default and hides them once a query is typed', () => {
+      // Recents (mode=recent) are visible while the query is empty
+      cy.contains('[data-command-target="group"]', 'Recents').should('be.visible')
+
+      cy.get('[data-command-target="input"]').type('policy')
+      cy.contains('[data-command-target="group"]', 'Recents').should('not.be.visible')
+    })
+
+    it('filters searchable rows to those that match the query', () => {
+      cy.get('[data-command-target="input"]').type('Anti-Money')
+
+      // Match
+      cy.contains('.cmd-row', 'Anti-Money Laundering Policy v3.2')
+        .should('not.have.class', 'hidden')
+
+      // Non-match in the same group
+      cy.contains('.cmd-row', 'Code of Ethics and Conduct')
+        .should('have.class', 'hidden')
+    })
+
+    it('always shows action-mode rows regardless of query', () => {
+      cy.get('[data-command-target="input"]').type('xyzzy-no-match')
+
+      cy.contains('.cmd-row', 'New document request')
+        .should('not.have.class', 'hidden')
+      cy.contains('[data-command-target="group"]', 'Actions').should('be.visible')
+    })
+  })
+
+  context('keyboard navigation', () => {
+    beforeEach(() => {
+      cy.get('body').type('{meta+k}')
+      cy.get('[data-command-target="input"]').type('Policy')
+    })
+
+    it('moves the active row with ArrowDown/ArrowUp', () => {
+      // First visible match starts active
+      cy.get('.cmd-row.is-active').should('have.length', 1)
+
+      cy.get('[data-command-target="input"]').type('{downarrow}')
+      cy.get('.cmd-row.is-active')
+        .should('have.length', 1)
+        .invoke('text')
+        .should('not.be.empty')
+
+      // ArrowUp wraps back to the first visible row
+      cy.get('[data-command-target="input"]').type('{uparrow}')
+      cy.get('.cmd-row.is-active').should('have.length', 1)
+    })
+
+    it('activates the highlighted row on Enter (Turbo navigation)', () => {
+      // Stub Turbo so we observe the navigation without actually leaving the page
+      cy.window().then(win => {
+        win.Turbo = { visit: cy.stub().as('turboVisit') }
+      })
+
+      cy.get('[data-command-target="input"]').type('{enter}')
+      cy.get('@turboVisit').should('have.been.calledWith', '/lookbook')
+    })
+  })
+})

--- a/cypress/e2e/side-menu-controller.cy.js
+++ b/cypress/e2e/side-menu-controller.cy.js
@@ -1,0 +1,96 @@
+describe('SideMenuComponent', () => {
+  // Use a desktop-width viewport so the `lg:` breakpoint applies and the
+  // collapse toggle button (hidden on mobile via `max-lg:!hidden`) is visible.
+  beforeEach(() => {
+    cy.viewport(1280, 800)
+  })
+
+  // Click the label tied to the (randomly-IDed) collapse-trigger checkbox.
+  // There are two labels — one inside `.side-menu-expanded`, one inside
+  // `.side-menu-collapsed` — only one is visible at a time, so pick that one.
+  const clickCollapseToggle = () => {
+    cy.get('input.side-menu-collapse-trigger')
+      .invoke('attr', 'id')
+      .then(id => cy.get(`label[for="${id}"]`).filter(':visible').first().click())
+  }
+
+  context('menu_switcher (details/summary)', () => {
+    beforeEach(() => {
+      cy.visit('/bali/side_menu/with_menu_switcher')
+      cy.get('.menu-switcher details').should('exist')
+    })
+
+    it('starts closed', () => {
+      cy.get('.menu-switcher details').should('not.have.attr', 'open')
+    })
+
+    it('opens when the summary is clicked', () => {
+      cy.get('.menu-switcher details summary').click()
+      cy.get('.menu-switcher details').should('have.attr', 'open')
+      cy.get('.menu-switcher .dropdown-content').should('be.visible')
+    })
+
+    it('closes when the summary is clicked a second time', () => {
+      cy.get('.menu-switcher details summary').click()
+      cy.get('.menu-switcher details summary').click()
+      cy.get('.menu-switcher details').should('not.have.attr', 'open')
+    })
+
+    it('shows every authorized menu in the dropdown', () => {
+      cy.get('.menu-switcher details summary').click()
+
+      cy.get('.menu-switcher .dropdown-content li')
+        .should('have.length.at.least', 3)
+        .and('contain', 'Logistics')
+        .and('contain', 'Accounting')
+    })
+  })
+
+  context('collapsible state', () => {
+    beforeEach(() => {
+      cy.visit('/bali/side_menu/collapsible')
+      cy.get('.side-menu-component', { timeout: 5000 }).should('exist')
+    })
+
+    it('starts expanded — the collapse-trigger checkbox is unchecked', () => {
+      cy.get('input.side-menu-collapse-trigger').should('not.be.checked')
+      cy.get('.side-menu-component').should('not.have.class', 'is-collapsed')
+    })
+
+    it('flips the checkbox when the collapse toggle is clicked', () => {
+      clickCollapseToggle()
+      cy.get('input.side-menu-collapse-trigger').should('be.checked')
+    })
+
+    it('returns to expanded when toggled again', () => {
+      clickCollapseToggle()
+      cy.get('input.side-menu-collapse-trigger').should('be.checked')
+
+      clickCollapseToggle()
+      cy.get('input.side-menu-collapse-trigger').should('not.be.checked')
+    })
+  })
+
+  context('menu_switcher when the sidebar is collapsed', () => {
+    beforeEach(() => {
+      cy.visit('/bali/side_menu/with_menu_switcher')
+      cy.get('.menu-switcher').should('exist')
+    })
+
+    it('keeps the menu_switcher trigger visible after collapsing the sidebar', () => {
+      // The with_menu_switcher preview does not include the collapse trigger,
+      // so toggle the wrapper class directly to simulate the collapsed state.
+      cy.get('.side-menu-component').then($el => $el.addClass('is-collapsed'))
+
+      cy.get('.menu-switcher-trigger').should('be.visible')
+    })
+
+    it('opens the dropdown beside the collapsed sidebar when clicked', () => {
+      cy.get('.side-menu-component').then($el => $el.addClass('is-collapsed'))
+
+      cy.get('.menu-switcher details summary').click()
+      cy.get('.menu-switcher details').should('have.attr', 'open')
+      cy.get('.menu-switcher .dropdown-content').should('be.visible')
+    })
+  })
+})

--- a/lib/bali/filter_form/search_configuration.rb
+++ b/lib/bali/filter_form/search_configuration.rb
@@ -125,13 +125,30 @@ module Bali
       # Generate a descriptive placeholder from search field names.
       # e.g., [:name] => "Search by name..."
       # e.g., [:name, :email] => "Search by name, email..."
+      #
+      # Field names go through `human_attribute_name` when the scope exposes a
+      # model class, so consumers' existing `activerecord.attributes.*`
+      # translations come through automatically.
       def default_search_placeholder
         unless search_enabled?
           return I18n.t("bali.filters.search_placeholder", default: "Search...")
         end
 
-        field_labels = search_fields.map { |f| f.to_s.humanize(capitalize: false) }
-        "Search by #{field_labels.join(', ')}..."
+        I18n.t(
+          "bali.filter_form.search_placeholder_with_fields",
+          fields: search_field_labels.join(", "),
+          default: "Search by %{fields}..."
+        )
+      end
+
+      def search_field_labels
+        search_fields.map { |f| search_field_label(f) }
+      end
+
+      def search_field_label(field)
+        @scope.model.human_attribute_name(field).downcase
+      rescue NoMethodError
+        field.to_s.humanize(capitalize: false)
       end
 
       # Extract quick search value from params based on configured search_fields

--- a/lib/bali/form_builder/html_utils.rb
+++ b/lib/bali/form_builder/html_utils.rb
@@ -101,8 +101,12 @@ module Bali
 
       def translate_attribute(method)
         if object.respond_to?(:model_name)
-          model_name = object.model_name.i18n_key
-          I18n.t("activerecord.attributes.#{model_name}.#{method}", default: method.to_s.humanize)
+          # `human_attribute_name` resolves through `activerecord.attributes.*`
+          # for AR models and `activemodel.attributes.*` for plain
+          # ActiveModel::Model form objects, falling back to humanize when
+          # neither namespace has the key. Hardcoding `activerecord.*` missed
+          # form-object translations entirely.
+          object.class.human_attribute_name(method)
         else
           method.to_s.humanize
         end

--- a/lib/bali/form_builder/html_utils.rb
+++ b/lib/bali/form_builder/html_utils.rb
@@ -28,7 +28,9 @@ module Bali
 
       def textarea_field_options(method, options, stimulus: false)
         base_class = "textarea textarea-bordered w-full"
-        options[:class] = field_class_name(method, "#{base_class} #{options[:class]}")
+        options[:class] = field_class_name(
+          method, "#{base_class} #{options[:class]}", error_class: "textarea-error"
+        )
 
         if stimulus
           options[:data] ||= {}
@@ -62,10 +64,10 @@ module Bali
         wrapped_field + help_message
       end
 
-      def field_class_name(method, class_name = "input")
+      def field_class_name(method, class_name = "input", error_class: "input-error")
         return class_name unless errors?(method)
 
-        "#{class_name} input-error"
+        "#{class_name} #{error_class}"
       end
 
       def errors?(method)

--- a/lib/bali/form_builder/select_fields.rb
+++ b/lib/bali/form_builder/select_fields.rb
@@ -23,7 +23,7 @@ module Bali
       private
 
       def select_classes(method, additional_classes = nil)
-        base = field_class_name(method, BASE_CLASSES)
+        base = field_class_name(method, BASE_CLASSES, error_class: "select-error")
         [ base, additional_classes ].compact.join(" ")
       end
 

--- a/lib/bali/form_builder/shared_date_utils.rb
+++ b/lib/bali/form_builder/shared_date_utils.rb
@@ -95,9 +95,7 @@ module Bali
 
       def alt_input_class(method, options)
         base_class = options[:alt_input_class] || "input input-bordered w-full"
-        return "#{base_class} input-error" if errors?(method)
-
-        base_class
+        field_class_name(method, base_class)
       end
 
       def previous_date_button

--- a/lib/bali/form_builder/slim_select_fields.rb
+++ b/lib/bali/form_builder/slim_select_fields.rb
@@ -33,7 +33,9 @@ module Bali
 
         select_class = merged_html.delete(:select_class)
         custom_class = merged_html[:class]
-        merged_html[:class] = class_names([ SELECT_CLASS, custom_class ].compact)
+        merged_html[:class] = field_class_name(
+          method, class_names([ SELECT_CLASS, custom_class ].compact), error_class: "select-error"
+        )
 
         field = build_wrapper(method, merged_options, merged_html, select_class) do
           build_select_content(method, values, merged_options, merged_html)

--- a/lib/bali/form_builder/time_zone_select_fields.rb
+++ b/lib/bali/form_builder/time_zone_select_fields.rb
@@ -23,7 +23,7 @@ module Bali
 
       def time_zone_html_options(method, html_options)
         custom_class = html_options[:class]
-        base = field_class_name(method, BASE_CLASSES)
+        base = field_class_name(method, BASE_CLASSES, error_class: "select-error")
 
         html_options.except(:class, :control_data, :control_class, :help).merge(
           class: [ base, custom_class ].compact.join(" ")

--- a/spec/dummy/app/views/layouts/app_layout_preview.html.erb
+++ b/spec/dummy/app/views/layouts/app_layout_preview.html.erb
@@ -1,0 +1,15 @@
+<%# Layout for Bali::AppLayout previews.
+    The AppLayout component renders its own `<body>` tag, so this layout
+    intentionally omits one — the HTML parser folds AppLayout's body into the
+    document body, matching how the component is used in production. %>
+<!DOCTYPE html>
+<html data-theme="light">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", media: 'all' %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  </head>
+  <%= yield %>
+</html>

--- a/test/bali/components/app_layout_test.rb
+++ b/test/bali/components/app_layout_test.rb
@@ -361,6 +361,60 @@ class BaliAppLayoutComponentTest < ComponentTestCase
     assert_selector("main #main-drawer")
   end
 
+  # --- default mobile topbar tests ---
+
+  def test_auto_renders_default_mobile_topbar_when_fixed_sidebar_and_no_topbar
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: true)) do |layout|
+      layout.with_sidebar { "Sidebar" }
+      layout.with_body { "Content" }
+    end
+    assert_selector(".app-layout-topbar--default-mobile.lg\\:hidden")
+    assert_selector(
+      ".app-layout-topbar--default-mobile label[for='#{Bali::SideMenu::Component::MOBILE_TRIGGER_ID}']"
+    )
+  end
+
+  def test_default_mobile_topbar_renders_app_name_when_provided
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: true, app_name: "MovieDB")) do |layout|
+      layout.with_sidebar { "Sidebar" }
+      layout.with_body { "Content" }
+    end
+    assert_selector(".app-layout-topbar--default-mobile", text: "MovieDB")
+  end
+
+  def test_default_mobile_topbar_omits_app_name_when_blank
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: true)) do |layout|
+      layout.with_sidebar { "Sidebar" }
+      layout.with_body { "Content" }
+    end
+    assert_no_selector(".app-layout-topbar--default-mobile span.font-semibold")
+  end
+
+  def test_default_mobile_topbar_skipped_when_custom_topbar_provided
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: true, app_name: "Ignored")) do |layout|
+      layout.with_sidebar { "Sidebar" }
+      layout.with_topbar { "Custom topbar" }
+      layout.with_body { "Content" }
+    end
+    assert_selector(".app-layout-topbar", text: "Custom topbar")
+    assert_no_selector(".app-layout-topbar--default-mobile")
+  end
+
+  def test_default_mobile_topbar_skipped_without_sidebar
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: true)) do |layout|
+      layout.with_body { "Content" }
+    end
+    assert_no_selector(".app-layout-topbar--default-mobile")
+  end
+
+  def test_default_mobile_topbar_skipped_when_fixed_sidebar_disabled
+    render_inline(Bali::AppLayout::Component.new(fixed_sidebar: false)) do |layout|
+      layout.with_sidebar { "Sidebar" }
+      layout.with_body { "Content" }
+    end
+    assert_no_selector(".app-layout-topbar--default-mobile")
+  end
+
   def test_main_tag_no_longer_has_p6_hardcoded
     render_inline(Bali::AppLayout::Component.new(modal: false, drawer: false)) do |layout|
       layout.with_body { "Content" }

--- a/test/bali/components/command_test.rb
+++ b/test/bali/components/command_test.rb
@@ -26,6 +26,16 @@ class BaliCommandComponentTest < ComponentTestCase
     assert_selector("input[placeholder='Search…']")
   end
 
+  def test_default_strings_resolve_through_locale_files
+    I18n.with_locale(:es) do
+      render_inline(Bali::Command::Component.new)
+    end
+    assert_selector("input[placeholder='Buscar…']")
+    assert_text("navegar")
+    assert_text("abrir")
+    assert_text("cerrar")
+  end
+
   def test_uses_custom_placeholder
     render_inline(Bali::Command::Component.new(placeholder: "Find anything"))
     assert_selector("input[placeholder='Find anything']")

--- a/test/bali/components/icon_test.rb
+++ b/test/bali/components/icon_test.rb
@@ -30,6 +30,30 @@ class BaliIconComponentTest < ComponentTestCase
     assert_selector("span.icon-component.size-12")
   end
 
+  def test_sizes_numeric_size_renders_inline_style_with_pixel_dimensions
+    render_inline(Bali::Icon::Component.new("snowflake", size: 24))
+    assert_selector("span.icon-component[style*='width: 24px'][style*='height: 24px']")
+    assert_selector("span.icon-component[style*='--bali-icon-size: 24px']")
+  end
+
+  def test_sizes_numeric_size_passes_pixel_size_to_lucide_svg
+    render_inline(Bali::Icon::Component.new("user", size: 24))
+    assert_selector("svg[width='24'][height='24']")
+  end
+
+  def test_sizes_numeric_size_drops_named_size_classes
+    render_inline(Bali::Icon::Component.new("snowflake", size: 24))
+    refute_selector("span.size-4")
+    refute_selector("span.size-8")
+    refute_selector("span.size-12")
+  end
+
+  def test_sizes_numeric_size_preserves_user_supplied_inline_style
+    render_inline(Bali::Icon::Component.new("snowflake", size: 24, style: "color: red"))
+    assert_selector("span.icon-component[style*='color: red']")
+    assert_selector("span.icon-component[style*='--bali-icon-size: 24px']")
+  end
+
   def test_resolution_pipeline_with_lucide_mapped_icons_renders_mapped_icons_through_lucide
     # "user" is mapped to Lucide"s "user' icon
     render_inline(Bali::Icon::Component.new("user"))

--- a/test/bali/components/side_menu_test.rb
+++ b/test/bali/components/side_menu_test.rb
@@ -23,6 +23,12 @@ class BaliSideMenuComponentTest < ComponentTestCase
     assert_selector("a[href='/movies']", text: "Item 1")
   end
 
+  def test_brand_row_uses_shared_chrome_height_for_alignment_with_topbar
+    @options = @options.merge(brand: "ACME")
+    render_inline(component)
+    assert_selector("div.bali-chrome-height", text: "ACME")
+  end
+
   def test_renders_the_side_menu_with_icon
     render_inline(component) do |c|
       c.with_list(title: "Section title") do |list|

--- a/test/bali/components/topbar_test.rb
+++ b/test/bali/components/topbar_test.rb
@@ -8,6 +8,11 @@ class BaliTopbarComponentTest < ComponentTestCase
     assert_selector(".bali-topbar")
   end
 
+  def test_uses_shared_chrome_height_for_alignment_with_side_menu_brand_row
+    render_inline(Bali::Topbar::Component.new)
+    assert_selector(".bali-topbar.bali-chrome-height")
+  end
+
   def test_renders_brand_when_provided
     render_inline(Bali::Topbar::Component.new) do |topbar|
       topbar.with_brand { "ACME" }

--- a/test/bali/filter_form_test.rb
+++ b/test/bali/filter_form_test.rb
@@ -324,6 +324,13 @@ class BaliFilterFormTest < ActiveSupport::TestCase
     assert_equal("Search by name, genre, tenant name...", config[:placeholder])
   end
 
+  def test_search_config_default_placeholder_is_localized
+    @form = SearchableMovieFilterForm.new(Movie.all, params({}))
+    I18n.with_locale(:es) do
+      assert_equal("Buscar por name, genre, tenant name...", @form.search_config[:placeholder])
+    end
+  end
+
   def test_search_config_returns_nil_when_search_not_enabled
     @form = MovieFilterForm.new(@tenant.movies, params({}))
     assert_nil(@form.search_config)

--- a/test/bali/form_builder/html_utils_test.rb
+++ b/test/bali/form_builder/html_utils_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliFormBuilderHtmlUtilsTest < FormBuilderTestCase
+  def test_translate_attribute_humanizes_when_no_translation_exists
+    assert_equal "Synopsis", builder.translate_attribute(:synopsis)
+  end
+
+  def test_translate_attribute_resolves_activerecord_attributes_namespace
+    with_translations(activerecord: { attributes: { movie: { synopsis: "Plot summary" } } }) do
+      assert_equal "Plot summary", builder.translate_attribute(:synopsis)
+    end
+  end
+
+  def test_translate_attribute_resolves_activemodel_attributes_namespace_for_form_objects
+    form_class = Class.new do
+      include ActiveModel::Model
+      attr_accessor :name
+
+      def self.name
+        "ContactForm"
+      end
+    end
+
+    with_translations(activemodel: { attributes: { contact_form: { name: "Full name" } } }) do
+      form_builder = build_form_builder("contact_form", form_class.new)
+      assert_equal "Full name", form_builder.translate_attribute(:name)
+    end
+  end
+
+  def test_translate_attribute_falls_back_to_humanize_when_object_has_no_model_name
+    plain_object = Object.new
+    form_builder = build_form_builder("plain", plain_object)
+
+    assert_equal "First name", form_builder.translate_attribute(:first_name)
+  end
+
+  private
+
+  def build_form_builder(name, object)
+    view_context = ActionController::Base.new.view_context
+    Bali::FormBuilder.new(name, object, view_context, {})
+  end
+
+  def with_translations(translations)
+    I18n.backend.store_translations(:en, translations)
+    yield
+  ensure
+    I18n.backend.reload!
+  end
+end

--- a/test/bali/form_builder/select_fields_test.rb
+++ b/test/bali/form_builder/select_fields_test.rb
@@ -54,7 +54,7 @@ class BaliFormBuilderSelectFieldsTest < FormBuilderTestCase
   def test_select_field_with_validation_errors_renders_select_with_error_class
     resource.errors.add(:status, :invalid)
     result = builder.select_field(:status, Movie.statuses.to_a)
-    assert_html(result, "select.select.select-bordered.w-full.input-error")
+    assert_html(result, "select.select.select-bordered.w-full.select-error")
   end
 
   def test_select_field_with_validation_errors_displays_error_message

--- a/test/bali/form_builder/slim_select_fields_test.rb
+++ b/test/bali/form_builder/slim_select_fields_test.rb
@@ -98,6 +98,20 @@ class BaliFormBuilderSlimSelectFieldsTest < FormBuilderTestCase
     assert_html(result, "div.slim-select.wrapper-class")
   end
 
+  # validation errors
+
+  def test_slim_select_field_with_validation_errors_renders_select_with_error_class
+    resource.errors.add(:status, :invalid)
+    result = builder.slim_select_field(:status, Movie.statuses.to_a)
+    assert_html(result, "select.select.select-bordered.select-error")
+  end
+
+  def test_slim_select_field_with_validation_errors_displays_error_message
+    resource.errors.add(:status, :invalid)
+    result = builder.slim_select_field(:status, Movie.statuses.to_a)
+    assert_html(result, "p.text-error")
+  end
+
   # custom data attributes
 
   def test_slim_select_field_custom_data_attributes_merges_custom_data_attributes_with_slim_select_target

--- a/test/bali/form_builder/text_area_fields_test.rb
+++ b/test/bali/form_builder/text_area_fields_test.rb
@@ -50,7 +50,7 @@ class BaliFormBuilderTextAreaFieldsTest < FormBuilderTestCase
   def test_text_area_with_validation_errors_applies_error_class
     resource.errors.add(:synopsis, "is required")
     result = builder.text_area(:synopsis)
-    assert_html(result, "textarea.input-error")
+    assert_html(result, "textarea.textarea-error")
   end
 
   def test_text_area_with_validation_errors_displays_error_message

--- a/test/bali/form_builder/time_zone_select_fields_test.rb
+++ b/test/bali/form_builder/time_zone_select_fields_test.rb
@@ -52,10 +52,10 @@ class BaliFormBuilderTimeZoneSelectFieldsTest < FormBuilderTestCase
     assert_html(result, "p.label-text-alt", text: "Select your time zone")
   end
 
-  def test_time_zone_select_with_errors_renders_input_error_class
+  def test_time_zone_select_with_errors_renders_select_error_class
     resource.errors.add(:release_date, "is invalid")
     result = builder.time_zone_select(:release_date)
-    assert_html(result, "select.input-error")
+    assert_html(result, "select.select-error")
   end
 
   def test_time_zone_select_with_errors_renders_error_message


### PR DESCRIPTION
## Summary

Branch collects related fixes — one commit per fix.

### Form-builder error classes (closes #545)

1. `fix(form_builder): apply DaisyUI element-specific error classes` — `field_class_name` accepts `error_class:` so select / textarea / time-zone select pick up `select-error` / `textarea-error` instead of `input-error`. Validation errors actually paint the field red.
2. `fix(form_builder): apply select-error class to slim_select_field` — routes SlimSelect's hidden `<select>` through the same helper.
3. `chore(form_builder): add with_errors preview for slim_select` — fills the gap that hid this bug.
4. `style(slim_select): clean search bar and selected option chrome` — magnifier-prefixed search row, bare-blue-text + checkmark for selected option.

### App-shell follow-ups (closes #544)

5. `feat(icon): support numeric pixel sizes alongside named presets` — `Bali::Icon::Component.new('clapperboard', size: 24)`.
6. `feat(app-shell): share chrome height between SideMenu and Topbar` — `--bali-chrome-height: 3.5rem` + `.bali-chrome-height` utility.
7. `feat(command): add bali.command.* keys to en/es locale files`.
8. `test(cypress): cover Command palette + SideMenu collapsible behavior`.

### FilterForm i18n (closes #539)

9. `fix(filter_form): localize default search placeholder` — wrapper through `bali.filter_form.search_placeholder_with_fields`, field labels through `human_attribute_name`.

### FormBuilder i18n (closes #538)

10. `fix(form_builder): resolve labels via human_attribute_name` — replaces hardcoded `activerecord.attributes.*` lookup so `ActiveModel::Model` form objects pick up `activemodel.attributes.*` translations.

### AppLayout mobile fallback (closes #506)

11. `feat(app_layout): auto-render mobile sidebar trigger when fixed_sidebar` — when `fixed_sidebar: true` and a sidebar is present but no `topbar` slot is supplied, AppLayout now renders a `lg:hidden` topbar with a hamburger label (wired to `SideMenu::MOBILE_TRIGGER_ID`) and an optional `app_name:` title. Custom topbars still take precedence.
12. `fix(app_layout): use dedicated Lookbook layout for previews` — Lookbook's preview layout already renders `<body>`, and AppLayout renders its own `<body>`; the parser dropped the inner tag and lost the `.app-layout--has-fixed-sidebar` class. Added `app_layout_preview.html.erb` (head only) and wired it via `layout "app_layout_preview"` so AppLayout's body becomes the document body, matching production. The `transform: translateZ(0)` wrappers on each preview template are no longer needed and were removed.

### Breadcrumb padding-block (closes #530)

13. `fix(breadcrumb): override padding-block in unlayered component CSS` — DaisyUI's `.breadcrumbs { padding-block: .5rem }` was beating the component's `pt-0` utility in host apps with different Tailwind v4 + daisyUI plugin layer ordering. Override moved into a new `breadcrumb/index.css` (unlayered, beats both layered sources), `pt-0` dropped from the Ruby class list.

### Maintenance

- `chore(socraticode): ignore .socraticode.json and document workflow`.
- `docs(changelog): note error-class fixes, chrome variable, icon sizes, locale keys`.

## Test plan

- [x] `bundle exec rails test` (full suite, 0 failures — 2576 runs)
- [x] `yarn run cy:run` (34 specs, 0 failures)
- [x] `bundle exec rubocop` clean on every modified Ruby file
- [x] Visual verification of slim_select previews (`default`, `team_member_selector`, `with_errors`)
- [x] Manual visual check that AppLayout chrome divider stays aligned after the variable swap
- [x] Lookbook AppLayout previews render correctly on desktop with fixed sidebar offset (single `<body>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)