### PR TITLE
feat(image_grid): add expandable lightbox option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ImageGrid** - New `expandable:` option on `Bali::ImageGrid::Component` and `Bali::ImageGrid::Image::Component`. When enabled, clicking an image opens it in a fullscreen lightbox with backdrop fade-in, image fade + scale-in, and a CSS spinner while the full-size image preloads. Pass `full_src:` to load a higher-resolution image; otherwise the thumbnail's `src` is reused. Closes on ESC, backdrop click, or close button; restores focus to the trigger. The grid-level `expandable:` propagates to every image but can be overridden per-image (#550)
 - **AppLayout** - Auto-render a mobile-only topbar (hamburger + optional `app_name:` title) when `fixed_sidebar: true`, a sidebar is present, and no custom `topbar` slot was provided. Without this fallback the sidebar was unreachable on mobile, forcing every consuming app to copy/paste the same `lg:hidden` trigger row. Custom topbars still take precedence (#506)
 - **AppLayout** - New `viewport_locked:` parameter that locks the body to 100vh and scrolls only the inner `<main>`, matching the Linear/Notion app-shell pattern. Defaults to the value of `fixed_sidebar` so existing pages keep working; pass explicitly to decouple (e.g. `fixed_sidebar: true, viewport_locked: false` for a fixed sidebar with normal page scroll)
 - **SideMenu** - New `with_brand` slot for icon + text or arbitrary brand content (the existing `brand:` text param keeps working as a fallback)

--- a/app/assets/stylesheets/bali/components.css
+++ b/app/assets/stylesheets/bali/components.css
@@ -29,3 +29,4 @@
 /* Layout Components */
 @import "../../../components/bali/app_layout/index.css";
 @import "../../../components/bali/drawer/index.css";
+@import "../../../components/bali/image_grid/index.css";

--- a/app/components/bali/image_grid/component.rb
+++ b/app/components/bali/image_grid/component.rb
@@ -18,11 +18,14 @@ module Bali
         lg: "gap-6"
       }.freeze
 
-      renders_many :images, Image::Component
+      renders_many :images, ->(**opts) {
+        Image::Component.new(**{ expandable: @expandable }.merge(opts))
+      }
 
-      def initialize(columns: 4, gap: :md, **options)
+      def initialize(columns: 4, gap: :md, expandable: false, **options)
         @columns = columns
         @gap = gap.to_sym
+        @expandable = expandable
         @options = options
       end
 

--- a/app/components/bali/image_grid/image/component.html.erb
+++ b/app/components/bali/image_grid/image/component.html.erb
@@ -1,7 +1,16 @@
 <%= tag.div class: card_classes, **card_attributes do %>
-  <figure class="<%= figure_classes %>">
-    <%= content %>
-  </figure>
+  <% if expandable %>
+    <%= tag.button type: "button",
+                   class: expand_button_classes,
+                   aria: { label: expand_label },
+                   data: expand_button_data do %>
+      <%= content %>
+    <% end %>
+  <% else %>
+    <figure class="<%= figure_classes %>">
+      <%= content %>
+    </figure>
+  <% end %>
 
   <% if footer? %>
     <%= footer %>

--- a/app/components/bali/image_grid/image/component.rb
+++ b/app/components/bali/image_grid/image/component.rb
@@ -3,24 +3,6 @@
 module Bali
   module ImageGrid
     module Image
-      class FooterComponent < ApplicationViewComponent
-        def initialize(**options)
-          @options = options
-        end
-
-        def call
-          tag.div(**footer_options) { content }
-        end
-
-        private
-
-        attr_reader :options
-
-        def footer_options
-          options.merge(class: class_names("card-body", "p-3", options[:class]))
-        end
-      end
-
       class Component < ApplicationViewComponent
         ASPECT_RATIOS = {
           square: "aspect-square",
@@ -33,14 +15,16 @@ module Bali
 
         renders_one :footer, FooterComponent
 
-        def initialize(aspect_ratio: :'3/2', **options)
+        def initialize(aspect_ratio: :'3/2', expandable: false, full_src: nil, **options)
           @aspect_ratio = aspect_ratio.to_sym
+          @expandable = expandable
+          @full_src = full_src
           @options = options
         end
 
         private
 
-        attr_reader :options
+        attr_reader :options, :expandable, :full_src
 
         def aspect_class
           ASPECT_RATIOS[@aspect_ratio] || "aspect-#{@aspect_ratio}"
@@ -61,6 +45,24 @@ module Bali
 
         def card_attributes
           options.except(:class)
+        end
+
+        def expand_label
+          I18n.t("bali.image_grid.expand", default: "Expand image")
+        end
+
+        def expand_button_classes
+          class_names(
+            figure_classes,
+            "block w-full p-0 cursor-zoom-in",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          )
+        end
+
+        def expand_button_data
+          { controller: "image-expander", action: "click->image-expander#open" }.tap do |data|
+            data[:image_expander_src_value] = full_src if full_src
+          end
         end
       end
     end

--- a/app/components/bali/image_grid/image/footer_component.rb
+++ b/app/components/bali/image_grid/image/footer_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Bali
+  module ImageGrid
+    module Image
+      class FooterComponent < ApplicationViewComponent
+        def initialize(**options)
+          @options = options
+        end
+
+        def call
+          tag.div(**footer_options) { content }
+        end
+
+        private
+
+        attr_reader :options
+
+        def footer_options
+          options.merge(class: class_names("card-body", "p-3", options[:class]))
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/image_grid/index.css
+++ b/app/components/bali/image_grid/index.css
@@ -1,0 +1,42 @@
+/* Image Grid - Lightbox overlay */
+
+@keyframes bali-image-expander-spin {
+  to { transform: rotate(360deg); }
+}
+
+.bali-image-expander-overlay {
+  @apply fixed inset-0 z-[100] flex items-center justify-center;
+  @apply bg-black/80 p-4 cursor-zoom-out;
+  @apply opacity-0 transition-opacity duration-200 ease-out;
+
+  &.is-open {
+    @apply opacity-100;
+  }
+}
+
+.bali-image-expander-image {
+  @apply max-w-full max-h-full object-contain cursor-default;
+  @apply opacity-0 transition duration-200 ease-out;
+  transform: scale(0.96);
+
+  &.is-loaded {
+    @apply opacity-100;
+    transform: scale(1);
+  }
+}
+
+.bali-image-expander-spinner {
+  @apply size-12 rounded-full;
+  border: 3px solid rgba(255, 255, 255, 0.25);
+  border-top-color: white;
+  animation: bali-image-expander-spin 0.8s linear infinite;
+}
+
+.bali-image-expander-close {
+  @apply btn btn-sm btn-circle btn-ghost absolute right-4 top-4;
+  @apply text-white hover:bg-white/20;
+}
+
+.bali-image-expander-error {
+  @apply text-white text-sm;
+}

--- a/app/components/bali/image_grid/index.js
+++ b/app/components/bali/image_grid/index.js
@@ -1,0 +1,128 @@
+import { Controller } from '@hotwired/stimulus'
+
+const TRANSITION_MS = 200
+
+/**
+ * Opens an image in a fullscreen lightbox overlay when the trigger is clicked.
+ *
+ * Attach to the trigger (a <button> wrapping the image). The full-size source
+ * comes from `data-image-expander-src-value`; if absent, falls back to the
+ * inner <img>'s `src`. Closes on ESC, backdrop click, or close button.
+ *
+ * Usage:
+ *   <button data-controller="image-expander"
+ *           data-action="click->image-expander#open"
+ *           data-image-expander-src-value="/path/to/full.jpg">
+ *     <img src="/path/to/thumb.jpg" alt="Sunset">
+ *   </button>
+ */
+export class ImageExpanderController extends Controller {
+  static values = { src: String }
+
+  open (event) {
+    event.preventDefault()
+    if (this.overlay) return
+
+    this.previouslyFocusedElement = document.activeElement
+
+    const innerImg = this.element.querySelector('img')
+    const src = this.srcValue || innerImg?.src
+    if (!src) return
+
+    const alt = innerImg?.alt || ''
+    const closeLabel = this.element.getAttribute('aria-label') || 'Close'
+
+    this.overlay = this._buildOverlay(closeLabel)
+    document.body.appendChild(this.overlay)
+    document.body.style.overflow = 'hidden'
+
+    window.requestAnimationFrame(() => this.overlay.classList.add('is-open'))
+
+    this._loadImage(src, alt)
+
+    this.overlay.querySelector('.bali-image-expander-close').focus()
+
+    this._onKeydown = this._onKeydown.bind(this)
+    document.addEventListener('keydown', this._onKeydown)
+  }
+
+  close () {
+    if (!this.overlay) return
+
+    document.removeEventListener('keydown', this._onKeydown)
+    const overlay = this.overlay
+    this.overlay = null
+
+    overlay.classList.remove('is-open')
+    const cleanup = () => {
+      overlay.remove()
+      document.body.style.overflow = ''
+      this.previouslyFocusedElement?.focus()
+      this.previouslyFocusedElement = null
+    }
+    overlay.addEventListener('transitionend', cleanup, { once: true })
+    setTimeout(cleanup, TRANSITION_MS + 50)
+  }
+
+  disconnect () {
+    if (this.overlay) {
+      document.removeEventListener('keydown', this._onKeydown)
+      this.overlay.remove()
+      this.overlay = null
+      document.body.style.overflow = ''
+    }
+  }
+
+  _onKeydown (event) {
+    if (event.key === 'Escape') this.close()
+  }
+
+  _loadImage (src, alt) {
+    const spinner = this.overlay.querySelector('.bali-image-expander-spinner')
+    const img = new window.Image()
+    img.onload = () => {
+      if (!this.overlay) return
+      const visibleImg = document.createElement('img')
+      visibleImg.src = src
+      visibleImg.alt = alt
+      visibleImg.className = 'bali-image-expander-image'
+      visibleImg.addEventListener('click', (event) => event.stopPropagation())
+      spinner.replaceWith(visibleImg)
+      window.requestAnimationFrame(() => visibleImg.classList.add('is-loaded'))
+    }
+    img.onerror = () => {
+      if (!spinner.parentNode) return
+      const error = document.createElement('div')
+      error.className = 'bali-image-expander-error'
+      error.textContent = 'Could not load image'
+      spinner.replaceWith(error)
+    }
+    img.src = src
+  }
+
+  _buildOverlay (closeLabel) {
+    const overlay = document.createElement('div')
+    overlay.className = 'bali-image-expander-overlay'
+    overlay.setAttribute('role', 'dialog')
+    overlay.setAttribute('aria-modal', 'true')
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) this.close()
+    })
+
+    const spinner = document.createElement('div')
+    spinner.className = 'bali-image-expander-spinner'
+    spinner.setAttribute('role', 'status')
+    spinner.setAttribute('aria-label', 'Loading')
+
+    const closeBtn = document.createElement('button')
+    closeBtn.type = 'button'
+    closeBtn.className = 'bali-image-expander-close'
+    closeBtn.setAttribute('aria-label', closeLabel)
+    closeBtn.textContent = '✕'
+    closeBtn.addEventListener('click', () => this.close())
+
+    overlay.appendChild(spinner)
+    overlay.appendChild(closeBtn)
+    return overlay
+  }
+}

--- a/app/components/bali/image_grid/preview.rb
+++ b/app/components/bali/image_grid/preview.rb
@@ -9,8 +9,9 @@ module Bali
       # @param gap select { choices: [none, sm, md, lg] }
       # @param aspect_ratio select { choices: [square, video, 3/2, 4/3, 4/5, 16/9] }
       # @param image_count number
-      def default(columns: 4, gap: :md, aspect_ratio: :'3/2', image_count: 9)
-        render(ImageGrid::Component.new(columns: columns.to_i, gap: gap.to_sym)) do |c|
+      # @param expandable toggle
+      def default(columns: 4, gap: :md, aspect_ratio: :'3/2', image_count: 9, expandable: false)
+        render(ImageGrid::Component.new(columns: columns.to_i, gap: gap.to_sym, expandable: expandable)) do |c|
           image_count.to_i.times do
             c.with_image(aspect_ratio: aspect_ratio.to_sym) { tag.img src: PLACEHOLDER_URL }
           end
@@ -22,6 +23,33 @@ module Bali
       # Each image card can have a footer slot for captions or metadata.
       def with_footer
         render_with_template
+      end
+
+      # Expandable images
+      # -----------------
+      # Click any image to open it in a fullscreen lightbox. Pass `full_src:`
+      # to load a higher-resolution image in the lightbox; otherwise the
+      # thumbnail's `src` is reused.
+      #
+      # ```erb
+      # <%= render Bali::ImageGrid::Component.new(expandable: true) do |c| %>
+      #   <% c.with_image(full_src: '/path/to/full.jpg') do %>
+      #     <%= image_tag '/path/to/thumb.jpg' %>
+      #   <% end %>
+      # <% end %>
+      # ```
+      def expandable
+        render(ImageGrid::Component.new(columns: 3, gap: :md, expandable: true)) do |c|
+          6.times do |i|
+            c.with_image(
+              aspect_ratio: :'3/2',
+              full_src: "https://placehold.co/1600x1067?text=Full+#{i + 1}"
+            ) do
+              tag.img(src: "https://placehold.co/480x320?text=Image+#{i + 1}",
+                      alt: "Sample image #{i + 1}")
+            end
+          end
+        end
       end
     end
   end

--- a/app/frontend/bali/components/index.js
+++ b/app/frontend/bali/components/index.js
@@ -34,6 +34,7 @@ import { RevealController } from '../../../components/bali/reveal/index'
 import { SortableListController } from '../../../components/bali/sortable_list/index'
 import { TooltipController } from '../../../components/bali/tooltip/index'
 import { ImageFieldController } from '../../../components/bali/image_field/index'
+import { ImageExpanderController } from '../../../components/bali/image_grid/index'
 import { DirectUploadController } from '../../../components/bali/direct_upload/index'
 import { RecurrentEventRuleController } from '../../../components/bali/recurrent_event_rule_form/index'
 import { NotificationController } from '../../../components/bali/notification/index'
@@ -76,6 +77,7 @@ export { TooltipController } from '../../../components/bali/tooltip/index'
 
 // Form components
 export { ImageFieldController } from '../../../components/bali/image_field/index'
+export { ImageExpanderController } from '../../../components/bali/image_grid/index'
 export { DirectUploadController } from '../../../components/bali/direct_upload/index'
 export { RecurrentEventRuleController } from '../../../components/bali/recurrent_event_rule_form/index'
 
@@ -146,6 +148,7 @@ export function registerAll (application) {
 
   // Form
   application.register('image-field', ImageFieldController)
+  application.register('image-expander', ImageExpanderController)
   application.register('direct-upload', DirectUploadController)
   application.register('recurrent-event-rule', RecurrentEventRuleController)
 

--- a/app/frontend/bali/index.js
+++ b/app/frontend/bali/index.js
@@ -99,6 +99,7 @@ export {
   DropdownController,
   FilterGroupController,
   HovercardController,
+  ImageExpanderController,
   ImageFieldController,
   LocationsMapController,
   ModalController,

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -116,6 +116,10 @@ en:
     modal:
       close: "Close modal"
 
+    # Image grid
+    image_grid:
+      expand: "Expand image"
+
     # Breadcrumb
     breadcrumb:
       aria_label: "Breadcrumb"

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -116,6 +116,10 @@ es:
     modal:
       close: "Cerrar modal"
 
+    # Image grid
+    image_grid:
+      expand: "Ampliar imagen"
+
     # Breadcrumb
     breadcrumb:
       aria_label: "Navegación de migas de pan"

--- a/test/bali/components/image_grid_test.rb
+++ b/test/bali/components/image_grid_test.rb
@@ -101,6 +101,21 @@ class BaliImageGridComponentTest < ComponentTestCase
     end
     assert_no_selector(".card-body")
   end
+
+  def test_expandable_grid_propagates_expandable_to_all_images
+    render_inline(Bali::ImageGrid::Component.new(expandable: true)) do |c|
+      3.times { c.with_image { '<img src="test.jpg">'.html_safe } }
+    end
+    assert_selector('button[data-controller="image-expander"]', count: 3)
+  end
+
+  def test_expandable_grid_image_can_override_to_disable_expand
+    render_inline(Bali::ImageGrid::Component.new(expandable: true)) do |c|
+      c.with_image(expandable: false) { '<img src="test.jpg">'.html_safe }
+    end
+    assert_selector("figure")
+    assert_no_selector('button[data-controller="image-expander"]')
+  end
 end
 
 class BaliImageGridImageComponentTest < ComponentTestCase
@@ -154,6 +169,35 @@ class BaliImageGridImageComponentTest < ComponentTestCase
   def test_wraps_content_in_figure_with_overflow_hidden
     render_inline(Bali::ImageGrid::Image::Component.new) { '<img src="test.jpg">'.html_safe }
     assert_selector("figure.overflow-hidden")
+  end
+
+  def test_expandable_renders_button_instead_of_figure
+    render_inline(Bali::ImageGrid::Image::Component.new(expandable: true)) { '<img src="test.jpg">'.html_safe }
+    assert_selector('button[type="button"][data-controller="image-expander"]')
+    assert_no_selector("figure")
+  end
+
+  def test_expandable_button_has_accessible_label
+    render_inline(Bali::ImageGrid::Image::Component.new(expandable: true)) { '<img src="test.jpg">'.html_safe }
+    assert_selector('button[aria-label="Expand image"]')
+  end
+
+  def test_expandable_passes_full_src_to_stimulus_value
+    render_inline(Bali::ImageGrid::Image::Component.new(expandable: true, full_src: "/full.jpg")) do
+      '<img src="thumb.jpg">'.html_safe
+    end
+    assert_selector('button[data-image-expander-src-value="/full.jpg"]')
+  end
+
+  def test_expandable_omits_src_value_when_full_src_not_provided
+    render_inline(Bali::ImageGrid::Image::Component.new(expandable: true)) { '<img src="test.jpg">'.html_safe }
+    assert_no_selector("button[data-image-expander-src-value]")
+  end
+
+  def test_non_expandable_still_renders_figure
+    render_inline(Bali::ImageGrid::Image::Component.new(expandable: false)) { '<img src="test.jpg">'.html_safe }
+    assert_selector("figure")
+    assert_no_selector("button[data-controller='image-expander']")
   end
 end
 


### PR DESCRIPTION
## Summary

- Adds `expandable:` option to `Bali::ImageGrid` and `Bali::ImageGrid::Image` — clicking an image opens it in a fullscreen lightbox with a higher-resolution `full_src:` (falls back to the thumbnail's `src`).
- New `image-expander` Stimulus controller with sidecar `index.css`. Overlay opens immediately with a spinner while the full-size image preloads, then animates in (backdrop fade, image fade + scale).
- Closes on ESC, backdrop click, or close button. Restores focus to the trigger.

## Usage

\`\`\`erb
<%= render Bali::ImageGrid::Component.new(expandable: true) do |c| %>
  <% @photos.each do |photo| %>
    <% c.with_image(full_src: photo.original_url) do %>
      <%= image_tag photo.thumbnail_url, alt: photo.caption %>
    <% end %>
  <% end %>
<% end %>
\`\`\`

The grid-level \`expandable:\` propagates to every image but can be overridden per-image. \`Bali::ImageGrid::Image::Component\` also works standalone (without a grid) for single expandable images.

## Implementation notes

- Extracted \`FooterComponent\` to its own file so Zeitwerk can autoload it independently — required because the grid now uses a lambda slot builder, which no longer eagerly loads the parent \`Image::Component\` file.
- Lightbox styles live in the sidecar \`index.css\` (imported via \`bali/components.css\`) following the same pattern as \`tooltip\`, \`drawer\`, etc. Tailwind scans CSS sources, so \`@apply bg-black/80\` resolves correctly even though the overlay DOM is created in JS.

## Test plan

- [x] \`bundle exec rails test test/bali/components/image_grid_test.rb\` — 41 runs, 0 failures
- [x] Full suite: 2585 runs, 0 failures, 0 errors
- [x] Browser: Lookbook preview \`Image Grid > Expandable\`
  - [x] Overlay appears immediately on click with spinner
  - [x] Full-size image fades in once loaded
  - [x] ESC, backdrop click, and ✕ button all close the lightbox
  - [x] Focus restored to the trigger button on close
- [ ] Manual verification in a consuming app (post-release)