### PR TITLE
fix(simple_filters): preserve slim_select value after submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.9.1] - 2026-05-10
+
+### Fixed
+
+- **SimpleFilters** - `:slim_select` filters now preserve their value after submission. The `slim_select_field` branch of the template wasn't passing `filter[:value]` (or `filter[:default]`), so the `<option>` rendered without `selected`. SlimSelect reads `option.selected` from the DOM, so the dropdown showed the placeholder text instead of the chosen option even though the URL carried the param. The `:select` branch already handled this via `options_for_select`; this brings `:slim_select` in line (#553)
+
 ## [v2.9.0] - 2026-05-10
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    bali_view_components (2.9.0)
+    bali_view_components (2.9.1)
       caxlsx
       lucide-rails (>= 0.3.0)
       rails (>= 7.0, < 9.0)
@@ -424,7 +424,7 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bali_view_components (2.9.0)
+  bali_view_components (2.9.1)
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f

--- a/app/components/bali/data_table/simple_filters/component.html.erb
+++ b/app/components/bali/data_table/simple_filters/component.html.erb
@@ -99,6 +99,7 @@
                 filter[:collection],
                 {
                   include_blank: filter[:blank],
+                  selected: (filter[:value] || filter[:default]),
                   size: :sm,
                   content_width: SLIM_SELECT_CONTENT_WIDTH,
                   addon_left: (render Bali::Icon::Component.new(filter[:icon], class: 'w-4 h-4') if filter[:icon])

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = "2.9.0"
+  VERSION = "2.9.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Bali ViewComponents",
   "type": "module",
   "main": "./app/frontend/bali/index.js",

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -83,6 +83,37 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
     assert_selector("option[selected]", text: "Inactive")
   end
 
+  def test_slim_select_filter_selects_the_current_value
+    slim_select_filter = [
+      {
+        attribute: :status,
+        type: :slim_select,
+        collection: [ %w[Active active], %w[Inactive inactive] ],
+        blank: "All",
+        label: "Status",
+        value: "active"
+      }
+    ]
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: slim_select_filter))
+    assert_selector("option[selected]", text: "Active")
+  end
+
+  def test_slim_select_filter_selects_the_default_value_when_no_current_value
+    slim_select_filter = [
+      {
+        attribute: :status,
+        type: :slim_select,
+        collection: [ %w[Active active], %w[Inactive inactive] ],
+        blank: "All",
+        label: "Status",
+        value: nil,
+        default: "inactive"
+      }
+    ]
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: slim_select_filter))
+    assert_selector("option[selected]", text: "Inactive")
+  end
+
   def test_renders_multiple_filters
     multi_filters = [
       {


### PR DESCRIPTION
## Summary
- `Bali::DataTable::SimpleFilters` template wasn't passing `filter[:value]` to `slim_select_field`, so the underlying `<option>` rendered without `selected`. SlimSelect (the JS wrapper) reads `option.selected` from the DOM, so the dropdown looked blank after the user submitted a filter — the URL had the param but the UI didn't reflect it.
- The regular `:select` branch already passes `filter[:value]` via `options_for_select`. This change brings `:slim_select` in line.

## Repro
Any `simple_filter :foo, type: :slim_select, collection: ...` rendered via `Bali::DataTable::SimpleFilters`. After submitting the form, the URL contains `?q[foo_eq]=X` but the dropdown shows the placeholder text instead of the selected option.

## Fix
One line in `app/components/bali/data_table/simple_filters/component.html.erb`:

```erb
selected: (filter[:value] || filter[:default]),
```

## Test plan
- [x] Added `test_slim_select_filter_selects_the_current_value` covering the value case.
- [x] Added `test_slim_select_filter_selects_the_default_value_when_no_current_value` covering the default fallback.
- [x] Full simple_filters_test suite green (38 runs, 77 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)