### PR TITLE
fix(SimpleFilters): opt out of password-manager autofill on search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.9.2] - 2026-06-19
+
+### Fixed
+
+- **SimpleFilters** - el buscador de texto del DataTable ahora sale del autofill de gestores de contraseñas (`autocomplete="off"` + `data-1p-ignore`/`data-lpignore`/`data-form-type="other"`). Un buscador no es un campo de credenciales, pero su `name` puede contener tokens como `name`/`email` (p. ej. `q[name_or_email_cont]` cuando se buscan esas columnas), lo que hacía que 1Password/LastPass/Dashlane ofrecieran login al enfocarlo. Aplica a todos los consumidores sin configuración.
+
 ## [v2.9.1] - 2026-05-10
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    bali_view_components (2.9.1)
+    bali_view_components (2.9.2)
       caxlsx
       lucide-rails (>= 0.3.0)
       rails (>= 7.0, < 9.0)
@@ -424,7 +424,7 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bali_view_components (2.9.1)
+  bali_view_components (2.9.2)
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f

--- a/app/components/bali/data_table/simple_filters/component.html.erb
+++ b/app/components/bali/data_table/simple_filters/component.html.erb
@@ -5,11 +5,18 @@
         <div class="w-full <%= 'join' if search_icon %>">
           <%= icon_addon(search_icon) %>
 
+          <%# Un buscador de texto no es un campo de credenciales: optamos por
+              salir del autofill para que los gestores de contraseñas (1Password,
+              LastPass, Dashlane) no ofrezcan login al enfocarlo. Aplica a todos
+              los buscadores del DataTable; el name puede contener tokens como
+              "name"/"email" (p. ej. q[name_or_email_cont]) que disparan su heurística. %>
           <%= tag.input(
                 type: "text",
                 name: @search[:field_name],
                 value: @search[:value],
                 placeholder: @search[:placeholder],
+                autocomplete: "off",
+                data: { "1p-ignore": "", lpignore: "true", "form-type": "other" },
                 class: "input input-bordered input-sm w-full #{'join-item rounded-l-none border-l-0' if search_icon}"
               ) %>
         </div>

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = "2.9.1"
+  VERSION = "2.9.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bali-view-components",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Bali ViewComponents",
   "type": "module",
   "main": "./app/frontend/bali/index.js",

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -147,6 +147,14 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
     assert_selector("input[placeholder='Search by name...']")
   end
 
+  def test_search_input_opts_out_of_password_manager_autofill
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, search: @search))
+    # Un buscador no es un campo de login; salimos del autofill para que 1Password
+    # y otros no ofrezcan credenciales al enfocarlo.
+    assert_selector("input[type='text'][autocomplete='off'][data-1p-ignore]")
+    assert_selector("input[type='text'][data-lpignore='true'][data-form-type='other']")
+  end
+
   def test_search_input_uses_default_width_classes
     render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, search: @search))
     assert_selector("div.w-48.sm\\:w-96.shrink-0")


### PR DESCRIPTION
## Qué

El buscador de texto del `DataTable` (SimpleFilters) ahora sale del autofill de gestores de contraseñas: se renderiza con `autocomplete="off"` + `data-1p-ignore` / `data-lpignore` / `data-form-type="other"`.

## Por qué

Un buscador no es un campo de credenciales, pero su `name` lo arma el componente a partir de los `search_fields`. Cuando esos campos incluyen columnas como `name`/`email`, el input queda `q[name_or_email_cont]` — y esos tokens hacen que **1Password/LastPass/Dashlane ofrezcan login** al enfocarlo (reportado en una app consumidora, en el index de Usuarios).

`autocomplete="off"` por sí solo no frena a 1Password; por eso se agregan también los `data-*-ignore`. Aplica a **todos los consumidores sin configuración** — un buscador nunca es un login, así que el opt-out es un default seguro.

## Cambios

- `simple_filters/component.html.erb`: atributos en el `tag.input` del buscador.
- Test en `simple_filters_test.rb` que afirma los atributos.
- Bump **2.9.1 → 2.9.2** (`version.rb` + `package.json`) + entrada de CHANGELOG.

## Verificación

- `bin/rails test test/bali/components/data_table/simple_filters_test.rb` → 39 runs, 0 fallos.
- Rubocop limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
