### PR TITLE
fix(forms): let .control shrink so selects truncate inside grid columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Forms** - `.control` field wrappers now shrink inside CSS grid columns (`min-width: 0`), so a select/slim-select holding a long selected option truncates with ellipsis instead of overflowing `minmax(0, 1fr)` columns. `.ss-main` also gets a defensive `max-width: 100%`.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/app/assets/stylesheets/bali/forms.css
+++ b/app/assets/stylesheets/bali/forms.css
@@ -32,6 +32,14 @@
   }
 }
 
+/* DaisyUI 5's .fieldset is a flex column, so .control is a flex item with
+   min-width: auto — it refuses to shrink below its content's min-content width.
+   A select/slim-select holding a long option then overflows grid columns
+   (minmax(0, 1fr)) instead of truncating. Allow the control to shrink. */
+.control {
+  min-width: 0;
+}
+
 .control.is-small {
   @apply w-40;
 }

--- a/app/assets/stylesheets/bali/slim_select.css
+++ b/app/assets/stylesheets/bali/slim_select.css
@@ -107,6 +107,9 @@
    The clickable element that looks like an input/select
    ============================================================================= */
 .ss-main {
+  /* Never grow past the container, even when a selected option is wider
+     than the column that holds it (see .control { min-width: 0 } in forms.css) */
+  max-width: 100%;
   @apply flex flex-row items-center relative select-none w-full h-10 min-h-[40px] p-0 cursor-pointer text-[14px];
   @apply bg-base-100 border border-base-content/20;
   border-radius: 4px;


### PR DESCRIPTION
## Qué

Agrega `.control { min-width: 0 }` en `forms.css` y un defensivo `.ss-main { max-width: 100% }` en `slim_select.css`.

Fixes #570

## Por qué

DaisyUI 5 hace del `.fieldset` un contenedor grid/flex, así que el `.control` es un item con mínimo automático (`min-width: auto`): no encoge por debajo del min-content de su contenido. Un slim-select con una opción larga seleccionada desborda columnas `minmax(0, 1fr)` en lugar de truncar con elipsis.

## Verificación

- CSS compilado contiene `.control{min-width:0}` y `.ss-main{max-width:100%...}` (`rails app:tailwindcss:build`).
- En navegador (dummy app, `/movies/new`): slim-select con opción larga dentro de un grid `grid-cols-2` de 640px —
  - **sin** la regla: `.control`/`.fieldset` miden **706px** (desborde reproducido);
  - **con** la regla: **314px** = ancho de columna, con elipsis.
- Minitest: 2596 runs, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)