### PR TITLE
fix(form_builder): honor input_name/input_id in select_group and slim_select_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **FormBuilder** - `select_group`/`select_field` and `slim_select_group`/`slim_select_field` now honor `input_name:` and `input_id:` options instead of silently dropping them, so non-model forms can namespace the rendered `<select>` under a param key (e.g. `thing[approver_id]`). Explicit `name:`/`id:` in html options still win.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/lib/bali/form_builder/html_utils.rb
+++ b/lib/bali/form_builder/html_utils.rb
@@ -41,6 +41,15 @@ module Bali
         options
       end
 
+      # Escape hatch for non-model forms (issue #547): `input_name:` / `input_id:`
+      # in the options hash override the name/id Rails derives from the form
+      # object. Explicit `name:` / `id:` in html_options still win.
+      def apply_input_name_options(options, html_options)
+        html_options[:name] ||= options[:input_name] if options[:input_name]
+        html_options[:id] ||= options[:input_id] if options[:input_id]
+        html_options
+      end
+
       def field_helper(method, field, options = {})
         if errors?(method)
           help_message = content_tag(:p, full_errors(method), class: "label-text-alt text-error")

--- a/lib/bali/form_builder/select_fields.rb
+++ b/lib/bali/form_builder/select_fields.rb
@@ -15,6 +15,7 @@ module Bali
       # Uses the native HTML <select> element with DaisyUI styling.
       def select_field(method, values, options = {}, html_options = {})
         html_options[:class] = select_classes(method, html_options[:class])
+        apply_input_name_options(options, html_options)
 
         field = select(method, values, options, html_options.except(:control_data, :control_class))
         field_helper(method, field, select_field_options(method, html_options))

--- a/lib/bali/form_builder/slim_select_fields.rb
+++ b/lib/bali/form_builder/slim_select_fields.rb
@@ -30,7 +30,7 @@ module Bali
 
       def slim_select_field(method, values, options = {}, html_options = {})
         merged_options = build_options(options)
-        merged_html = build_html_options(html_options)
+        merged_html = apply_input_name_options(options, build_html_options(html_options))
 
         select_class = merged_html.delete(:select_class)
         custom_class = merged_html[:class]

--- a/test/bali/form_builder/select_fields_test.rb
+++ b/test/bali/form_builder/select_fields_test.rb
@@ -68,6 +68,28 @@ class BaliFormBuilderSelectFieldsTest < FormBuilderTestCase
     assert_html(result, "p.label-text-alt", text: "Select a status")
   end
 
+  # input_name / input_id options (issue #547)
+
+  def test_select_group_honors_input_name_option
+    result = builder.select_group(:status, Movie.statuses.to_a, input_name: "thing[status]")
+    assert_html(result, 'select[name="thing[status]"]')
+  end
+
+  def test_select_group_honors_input_id_option
+    result = builder.select_group(:status, Movie.statuses.to_a, input_id: "thing_status")
+    assert_html(result, "select#thing_status")
+  end
+
+  def test_select_field_honors_input_name_option
+    result = builder.select_field(:status, Movie.statuses.to_a, input_name: "thing[status]")
+    assert_html(result, 'select[name="thing[status]"]')
+  end
+
+  def test_select_field_explicit_html_name_wins_over_input_name
+    result = builder.select_field(:status, Movie.statuses.to_a, { input_name: "a[b]" }, name: "c[d]")
+    assert_html(result, 'select[name="c[d]"]')
+  end
+
   # BASE_CLASSES constant
 
   def test_base_classes_constant_is_frozen

--- a/test/bali/form_builder/slim_select_fields_test.rb
+++ b/test/bali/form_builder/slim_select_fields_test.rb
@@ -28,6 +28,18 @@ class BaliFormBuilderSlimSelectFieldsTest < FormBuilderTestCase
     end
   end
 
+  # input_name / input_id options (issue #547)
+
+  def test_slim_select_group_honors_input_name_option
+    result = builder.slim_select_group(:status, Movie.statuses.to_a, input_name: "thing[status]")
+    assert_html(result, 'select[name="thing[status]"]')
+  end
+
+  def test_slim_select_group_honors_input_id_option
+    result = builder.slim_select_group(:status, Movie.statuses.to_a, input_id: "thing_status")
+    assert_html(result, "select#thing_status")
+  end
+
   # #slim_select_field
 
   def test_slim_select_field_renders_a_div_with_control_class


### PR DESCRIPTION
## Qué

`select_group`/`select_field` y `slim_select_group`/`slim_select_field` ahora respetan `input_name:` e `input_id:` del hash de opciones (helper compartido `apply_input_name_options` en `HtmlUtils`). Un `name:`/`id:` explícito en `html_options` sigue teniendo precedencia.

Fixes #547

## Por qué

En forms sin modelo, los callers pasaban `input_name: "scope[field]"` esperando el input namespaced bajo esa key — la opción se descartaba silenciosamente y el controller con `params.require(:scope)` tronaba con `ActionController::ParameterMissing` en runtime.

## Auditoría de otros helpers (pedida en el issue)

- `text_field_group`, `text_area_group`, etc.: su hash de opciones ES el de html options, así que `name:`/`id:` ya funcionan nativo — no necesitan `input_name:`.
- `time_zone_select_group`: firma distinta y sin callers reportados usando `input_name:`; fuera de alcance.

## Verificación

- TDD: 6 tests nuevos (5 en rojo antes del fix, todos en verde después).
- Suite completa: 2602 runs, 0 failures, 0 errors.
- Rubocop: sin ofensas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)