### PR TITLE
feat(kanban): add optional footer slot to Kanban::Column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Kanban** - `Kanban::Column` accepts an optional `footer` slot rendered after the card list and outside the `SortableList`, for non-draggable per-column actions like "+ add card". Columns without a footer render unchanged.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/app/components/bali/kanban/column/component.html.erb
+++ b/app/components/bali/kanban/column/component.html.erb
@@ -12,4 +12,10 @@
       <%= card %>
     <% end %>
   <% end %>
+
+  <% if footer? %>
+    <div class="kanban-column-footer mt-2 pt-2 border-t border-base-200">
+      <%= footer %>
+    </div>
+  <% end %>
 </div>

--- a/app/components/bali/kanban/column/component.rb
+++ b/app/components/bali/kanban/column/component.rb
@@ -6,6 +6,10 @@ module Bali
       class Component < ApplicationViewComponent
         renders_many :cards, Card::Component
 
+        # Rendered after the SortableList so its content is never draggable —
+        # the "+ add card" pattern at the foot of a column.
+        renders_one :footer
+
         BADGE_COLORS = {
           primary: "badge-primary",
           secondary: "badge-secondary",

--- a/app/components/bali/kanban/preview.rb
+++ b/app/components/bali/kanban/preview.rb
@@ -22,6 +22,15 @@ module Bali
       def with_colors
         render_with_template
       end
+
+      # @label With Footer
+      # Columns accept an optional `footer` slot rendered after the card list —
+      # the classic "+ add card" action. The footer lives outside the
+      # SortableList, so it is never draggable and doesn't interfere with
+      # dragging cards between columns.
+      def with_footer
+        render_with_template
+      end
     end
   end
 end

--- a/app/components/bali/kanban/previews/with_footer.html.erb
+++ b/app/components/bali/kanban/previews/with_footer.html.erb
@@ -1,0 +1,28 @@
+<%= render Bali::Kanban::Component.new(resource_name: "task", group_name: "kanban") do |k| %>
+  <% k.with_column(title: "To Do", status: "todo", color: :ghost) do |col| %>
+    <% col.with_card do %>
+      <p class="font-medium text-sm">Design landing page</p>
+    <% end %>
+    <% col.with_card do %>
+      <p class="font-medium text-sm">Write API docs</p>
+    <% end %>
+    <% col.with_footer do %>
+      <%= render Bali::Link::Component.new(name: "+ Add card", href: "/lookbook", class: "text-sm w-full justify-start") %>
+    <% end %>
+  <% end %>
+
+  <% k.with_column(title: "In Progress", status: "in_progress", color: :info) do |col| %>
+    <% col.with_card do %>
+      <p class="font-medium text-sm">Implement auth flow</p>
+    <% end %>
+    <% col.with_footer do %>
+      <%= render Bali::Link::Component.new(name: "+ Add card", href: "/lookbook", class: "text-sm w-full justify-start") %>
+    <% end %>
+  <% end %>
+
+  <% k.with_column(title: "Done", status: "done", color: :success) do |col| %>
+    <% col.with_card do %>
+      <p class="font-medium text-sm">Project setup</p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/bali/components/kanban_test.rb
+++ b/test/bali/components/kanban_test.rb
@@ -119,6 +119,38 @@ class BaliKanbanComponentTest < ComponentTestCase
     assert_selector("[data-sortable-list-resource-name-value='task']")
   end
 
+  def test_column_footer_renders_its_content
+    render_inline(Bali::Kanban::Component.new) do |k|
+      k.with_column(title: "Todo", status: "todo") do |col|
+        col.with_card { "A" }
+        col.with_footer { "+ Agregar tarjeta" }
+      end
+    end
+
+    assert_text("+ Agregar tarjeta")
+  end
+
+  def test_column_footer_renders_outside_the_sortable_list
+    render_inline(Bali::Kanban::Component.new) do |k|
+      k.with_column(title: "Todo", status: "todo") do |col|
+        col.with_card { "A" }
+        col.with_footer { "+ Agregar tarjeta" }
+      end
+    end
+
+    assert_no_selector("[data-controller='sortable-list']", text: "+ Agregar tarjeta")
+  end
+
+  def test_column_without_footer_renders_no_footer_wrapper
+    render_inline(Bali::Kanban::Component.new) do |k|
+      k.with_column(title: "Todo", status: "todo") do |col|
+        col.with_card { "A" }
+      end
+    end
+
+    assert_no_selector(".kanban-column-footer")
+  end
+
   def test_column_renders_sortable_list
     render_inline(Bali::Kanban::Component.new) do |k|
       k.with_column(title: "Todo", status: "todo") do |col|


### PR DESCRIPTION
## Qué

`Bali::Kanban::Column` gana un slot opcional `renders_one :footer`, renderizado **después** del `SortableList` (fuera de él → no arrastrable). Se expone vía el bloque de `with_column`:

```erb
<% k.with_column(title:, status:) do |col| %>
  <% col.with_card { ... } %>
  <% col.with_footer do %>
    <%= render Bali::Link::Component.new(name: "+ Agregar tarjeta", href: new_thing_path) %>
  <% end %>
<% end %>
```

Closes #581

## Criterios de aceptación del issue

- ✅ Slot opcional: columnas sin `footer` renderizan igual que hoy (test de no-regresión).
- ✅ Footer fuera del `SortableList` (test: el texto del footer no existe dentro de `[data-controller='sortable-list']`).
- ✅ Ejemplo en preview de Lookbook (`kanban/with_footer`).

## Verificación

- TDD: 3 tests nuevos (2 en rojo antes de implementar).
- Suite completa: 2599 runs, 0 failures. Rubocop limpio.
- Browser (Lookbook `/bali/kanban/with_footer`): 2 footers renderizados fuera del SortableList, columna sin footer intacta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)