### PR TITLE
feat(stepper): support sublabel and free content block per step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stepper** - steps accept a `sublabel:` option rendered as a smaller muted line under the title (event date, actor, status note), or a free content block via `with_step(title:) { ... }` for arbitrary markup. Works in both orientations; steps without sublabel render unchanged.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/app/components/bali/stepper/preview.rb
+++ b/app/components/bali/stepper/preview.rb
@@ -31,6 +31,21 @@ module Bali
         end
       end
 
+      # With sublabels
+      # --------------
+      # Each step accepts an optional `sublabel:` (event date, actor, status note)
+      # rendered as a smaller second line. For arbitrary markup, pass a content
+      # block to `with_step` instead.
+      # @param orientation select [horizontal, vertical]
+      def with_sublabels(orientation: :horizontal)
+        render Bali::Stepper::Component.new(current: 2, orientation: orientation.to_sym) do |c|
+          c.with_step(title: 'Propuesto', sublabel: '01/07 · Luis Pérez')
+          c.with_step(title: 'Aprobado', sublabel: '03/07 · Ana Gutiérrez')
+          c.with_step(title: 'Publicado', sublabel: 'publicación #12')
+          c.with_step(title: 'Vigente')
+        end
+      end
+
       # Color variants
       # --------------
       # Different color schemes for different contexts

--- a/app/components/bali/stepper/step/component.html.erb
+++ b/app/components/bali/stepper/step/component.html.erb
@@ -1,3 +1,13 @@
 <%= tag.li(**step_options) do %>
-  <%= title %>
+  <% if sublabel.present? || content? %>
+    <div>
+      <div><%= title %></div>
+      <% if sublabel.present? %>
+        <div class="step-sublabel text-xs opacity-60"><%= sublabel %></div>
+      <% end %>
+      <%= content %>
+    </div>
+  <% else %>
+    <%= title %>
+  <% end %>
 <% end %>

--- a/app/components/bali/stepper/step/component.rb
+++ b/app/components/bali/stepper/step/component.rb
@@ -19,10 +19,11 @@ module Bali
         # Unicode checkmark for completed steps
         CHECKMARK = "\u2713"
 
-        attr_reader :title
+        attr_reader :title, :sublabel
 
-        def initialize(title:, current:, index:, color: :primary, **options)
+        def initialize(title:, current:, index:, color: :primary, sublabel: nil, **options)
           @title = title
+          @sublabel = sublabel
           @current = current
           @index = index
           @color = color

--- a/test/bali/components/stepper_test.rb
+++ b/test/bali/components/stepper_test.rb
@@ -93,6 +93,33 @@ class BaliStepperComponentTest < ComponentTestCase
     end
     assert_selector('ul.steps[data-testid="stepper"]')
   end
+
+  def test_step_sublabel_renders_below_title
+    render_inline(Bali::Stepper::Component.new(current: 1)) do |c|
+      c.with_step(title: "Aprobado", sublabel: "03/07 · Ana Gutiérrez")
+      c.with_step(title: "Publicado")
+    end
+
+    assert_selector("li.step .step-sublabel", text: "03/07 · Ana Gutiérrez")
+    assert_selector("li.step", text: "Aprobado")
+  end
+
+  def test_step_without_sublabel_renders_no_sublabel_element
+    render_inline(Bali::Stepper::Component.new) do |c|
+      c.with_step(title: "Step One")
+    end
+
+    assert_no_selector(".step-sublabel")
+  end
+
+  def test_step_renders_free_content_block
+    render_inline(Bali::Stepper::Component.new) do |c|
+      c.with_step(title: "Publicado") { "publicación #12" }
+    end
+
+    assert_selector("li.step", text: "Publicado")
+    assert_selector("li.step", text: "publicación #12")
+  end
 end
 
 class BaliStepperStepComponentTest < ComponentTestCase


### PR DESCRIPTION
## Qué

`Bali::Stepper` ahora soporta un segundo renglón por paso:

```erb
<%= render Bali::Stepper::Component.new(current: 2) do |s| %>
  <% s.with_step(title: "Aprobado", sublabel: "03/07 · Ana Gutiérrez") %>
  <%# o slot de contenido libre: %>
  <% s.with_step(title: "Publicado") do %>
    <span class="text-xs opacity-60">publicación #12</span>
  <% end %>
<% end %>
```

- `sublabel:` renderiza una línea menor y atenuada (`.step-sublabel text-xs opacity-60`) bajo el título.
- El bloque de contenido de `with_step` se renderiza dentro del `.step` después del título (markup libre).
- Pasos sin sublabel/bloque renderizan idéntico que antes.

Closes #583

## Verificación

- TDD: 3 tests nuevos (2 en rojo antes de implementar).
- Suite completa: 2599 runs, 0 failures. Rubocop limpio.
- Browser (Lookbook `/bali/stepper/with_sublabels`): verificado en horizontal (sublabel centrado bajo el título, igual al mockup del issue "03/07 · Ana Gutiérrez") y vertical (sublabel junto al marcador). El paso sin sublabel ("Vigente") alinea igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)