### PR TITLE
fix(modal/drawer): apply turbo_stream responses on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Modal/Drawer** - the shared `submit` handler now detects `text/vnd.turbo-stream.html` responses and applies them with `Turbo.renderStreamMessage` (closing the modal/drawer on success) instead of injecting the raw `<turbo-stream>` markup as inert HTML. Enables the standard partial-update pattern (close drawer + refresh sections + toast) for forms submitted with `data-turbo="true"`; redirect and HTML-error responses behave as before.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/app/components/bali/drawer/preview.rb
+++ b/app/components/bali/drawer/preview.rb
@@ -42,6 +42,16 @@ module Bali
         end
       end
 
+      # Turbo Stream Form
+      # ---
+      # Forms submitted with `drawer#submit` and `data-turbo="true"` accept
+      # `text/vnd.turbo-stream.html` responses: the streams are applied to the
+      # page and the drawer closes, instead of injecting the raw
+      # `<turbo-stream>` markup as inert HTML. Used by the Cypress suite.
+      def turbo_stream_form
+        render_with_template
+      end
+
       # Left Position
       # ---
       # Drawer opens from the left side.

--- a/app/components/bali/drawer/previews/turbo_stream_form.html.erb
+++ b/app/components/bali/drawer/previews/turbo_stream_form.html.erb
@@ -1,0 +1,11 @@
+<div id="stream-target" class="p-4"></div>
+
+<%= render Bali::Drawer::Component.new(active: true, title: 'Turbo Stream Form') do %>
+  <form action="/fake/submit" method="post" data-turbo="true" class="space-y-4">
+    <div class="form-control">
+      <label class="label" for="name">Name</label>
+      <input type="text" id="name" name="name" class="input input-bordered w-full">
+    </div>
+    <%= render Bali::Button::Component.new(name: 'Save', variant: :primary, data: { action: 'drawer#submit' }) %>
+  </form>
+<% end %>

--- a/app/components/bali/modal/index.js
+++ b/app/components/bali/modal/index.js
@@ -313,13 +313,16 @@ export class ModalController extends Controller {
    * submit
    *
    * This action is called when a form within a modal is submitted. There
-   * are 2 scenarios we need to handle:
+   * are 3 scenarios we need to handle:
    *
    * 1. When Form is submitted successfully, the server redirects to a new page.
    * 2. When Form has an error, the server returns the form with the errors.
+   * 3. When the form has data-turbo="true" and the server responds with
+   *    text/vnd.turbo-stream.html, the streams are applied to the page and
+   *    the modal/drawer closes (on success), enabling partial page updates.
    *
-   * On a successful scenario we get a full HTML page and we then proceed to extract
-   * the <body> tag from the page and replace the existing body tag.
+   * On a successful redirect scenario we get a full HTML page and we then proceed
+   * to extract the <body> tag from the page and replace the existing body tag.
    *
    * On a error scenario we just replace the modal contents with the response, since we
    * are already only getting the contents inside the modal.
@@ -362,6 +365,7 @@ export class ModalController extends Controller {
     let redirected = false
     let redirectURL = null
     let responseOk = null
+    let turboStreamResponse = false
     const redirectData = this.extraProps || {}
 
     fetch(url, options)
@@ -375,6 +379,8 @@ export class ModalController extends Controller {
         })
 
         responseOk = response.ok
+        turboStreamResponse = (response.headers.get('Content-Type') || '')
+          .includes('text/vnd.turbo-stream.html')
         return response.text()
       })
       .then(responseText => {
@@ -388,6 +394,14 @@ export class ModalController extends Controller {
           } else {
             this._replaceBodyAndURL(responseText, redirectURL)
           }
+        } else if (turboStreamResponse && window.Turbo) {
+          if (responseOk) { document.dispatchEvent(event) }
+
+          // Apply the streams to the page instead of injecting the raw
+          // <turbo-stream> markup as inert HTML. Close only on success: an
+          // error stream may re-render the form inside the modal/drawer.
+          window.Turbo.renderStreamMessage(responseText)
+          if (responseOk) { this._closeModal() }
         } else {
           if (responseOk) { document.dispatchEvent(event) }
 

--- a/cypress/e2e/drawer-controller.cy.js
+++ b/cypress/e2e/drawer-controller.cy.js
@@ -1,0 +1,44 @@
+describe('DrawerController', () => {
+  context('turbo_stream form submit', () => {
+    beforeEach(() => {
+      cy.visit('/bali/drawer/turbo_stream_form')
+    })
+
+    it('applies the turbo stream response and closes the drawer', () => {
+      cy.intercept('POST', '/fake/submit*', {
+        headers: { 'Content-Type': 'text/vnd.turbo-stream.html' },
+        body: `
+          <turbo-stream action="append" target="stream-target">
+            <template><p id="stream-result">It worked</p></template>
+          </turbo-stream>
+        `
+      }).as('submit')
+
+      cy.get('.drawer-open').should('exist')
+      cy.get('[data-action="drawer#submit"]').click()
+      cy.wait('@submit')
+
+      // The stream is applied to the page...
+      cy.get('#stream-result').should('have.text', 'It worked')
+      // ...not injected as inert markup inside the drawer
+      cy.get('turbo-stream').should('not.exist')
+      // ...and the drawer closes
+      cy.get('.drawer-open').should('not.exist')
+    })
+
+    it('keeps HTML error responses inside the drawer (unchanged behavior)', () => {
+      cy.intercept('POST', '/fake/submit*', {
+        statusCode: 422,
+        headers: { 'Content-Type': 'text/html' },
+        body: '<form action="/fake/submit" data-turbo="true"><p id="form-error">Name is required</p></form>'
+      }).as('submit')
+
+      cy.get('[data-action="drawer#submit"]').click()
+      cy.wait('@submit')
+
+      // Error form re-renders inside the drawer, which stays open
+      cy.get('.drawer-open').should('exist')
+      cy.get('.drawer-open #form-error').should('have.text', 'Name is required')
+    })
+  })
+})


### PR DESCRIPTION
## Qué

El handler `submit` compartido (`ModalController`, heredado por `DrawerController`) ahora detecta respuestas `Content-Type: text/vnd.turbo-stream.html` y las pasa a `Turbo.renderStreamMessage` en vez de inyectarlas como HTML inerte en el content target. Cierra el modal/drawer **solo en 2xx** — un stream de error puede re-renderizar el form adentro.

Fixes #584

## Por qué

Todo form dentro de un Drawer estaba obligado a terminar en redirect de página completa. El patrón turbo_stream estándar (cerrar drawer + refrescar secciones específicas + toast) era imposible: el `<turbo-stream>` llegaba como texto inerte. Detectado en gobierno-corporativo (`epic/mdm-workbench`).

## Comportamiento

| Respuesta | Antes | Ahora |
|---|---|---|
| Redirect | replace body / close | igual |
| HTML (errores de form) | re-render dentro del drawer | igual |
| turbo_stream 2xx | markup inerte | streams aplicados + drawer cerrado |
| turbo_stream error | markup inerte | streams aplicados, drawer abierto |

## Verificación

- TDD (Cypress): nuevo `drawer-controller.cy.js` con preview `drawer/turbo_stream_form` — el test de turbo-stream estaba en rojo antes del fix; el de re-render HTML pasa antes y después (sin regresión).
- Cypress completo: **44/44**. Minitest: 2596 runs, 0 failures. `standard` sin ofensas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)