### PR TITLE
fix(document_editor): don't clobber saved content when previewing versions back-to-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **DocumentEditor** - "Back to current" now restores the real document after previewing several versions in a row. `previewVersion` captured the editor state on every call, so a second preview overwrote the saved current document with the first previewed version — exiting preview then restored that version read-only, and saving in that state could overwrite the document with old content.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/app/components/bali/document_editor/index.js
+++ b/app/components/bali/document_editor/index.js
@@ -255,8 +255,14 @@ export class DocumentEditorController extends Controller {
       }
 
       const editor = blockEditor.blockNoteEditor
-      this._savedContent = editor._tiptapEditor.getJSON()
-      this._savedEditable = editor.isEditable
+      // Only capture the current document on the first preview: previewing
+      // another version while already previewing would otherwise overwrite
+      // the saved content with the previewed version, and "Back to current"
+      // would restore that version (read-only) instead of the real document.
+      if (this._savedContent == null) {
+        this._savedContent = editor._tiptapEditor.getJSON()
+        this._savedEditable = editor.isEditable
+      }
 
       // Load version content into the editor (read-only)
       const content = typeof version.content === 'string' ? JSON.parse(version.content) : version.content

--- a/cypress/e2e/document-editor.cy.js
+++ b/cypress/e2e/document-editor.cy.js
@@ -1,0 +1,66 @@
+describe('DocumentEditor version preview', () => {
+  beforeEach(() => {
+    // Stub version payloads so previewed content is distinguishable from the
+    // current document regardless of DB state
+    cy.intercept('GET', /\/documents\/\d+\/versions\/\d+$/, req => {
+      const id = req.url.split('/').pop()
+      req.reply({
+        id: Number(id),
+        version_number: Number(id),
+        content: [
+          {
+            id: `stub-${id}`,
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: `STUB VERSION ${id}`, styles: {} }],
+            children: []
+          }
+        ]
+      })
+    }).as('showVersion')
+
+    cy.visit('http://localhost:3001/documents/1')
+    cy.contains('button', 'Edit').click()
+    cy.get('[data-action*="document-editor#toggleHistory"]:visible').first().click()
+    cy.get('[data-action*="previewVersion"]:visible').should('have.length.at.least', 2)
+
+    editor()
+      .invoke('text')
+      .then(text => cy.wrap(text.slice(0, 40)).as('currentText'))
+  })
+
+  const editor = () => cy.get('[data-document-editor-target="editorArea"]:visible .bn-editor')
+
+  const previewNth = n =>
+    cy.get('[data-action*="previewVersion"]:visible').eq(n).then($btn => {
+      const stubText = `STUB VERSION ${$btn.data('versionId')}`
+      cy.wrap($btn).click()
+      cy.wait('@showVersion')
+      editor().should('contain.text', stubText)
+    })
+
+  const backToCurrent = () => cy.get('[data-action*="exitPreview"]:visible').click()
+
+  const assertBackOnCurrent = () => {
+    editor().should('not.contain.text', 'STUB VERSION')
+    cy.get('@currentText').then(currentText => {
+      editor().invoke('text').should(text => {
+        expect(text.slice(0, 40)).to.eq(currentText)
+      })
+    })
+    editor().should('have.attr', 'contenteditable', 'true')
+  }
+
+  it('returns to the current version after a single preview', () => {
+    previewNth(0)
+    backToCurrent()
+    assertBackOnCurrent()
+  })
+
+  it('returns to the current version after previewing several versions in a row', () => {
+    previewNth(0)
+    previewNth(1)
+    backToCurrent()
+    assertBackOnCurrent()
+  })
+})

--- a/cypress/e2e/document-editor.cy.js
+++ b/cypress/e2e/document-editor.cy.js
@@ -1,8 +1,22 @@
+// Uses the Lookbook preview (no DB dependency): the default preview renders
+// the editor overlay with versions_url "/lookbook", so both the versions
+// index and each version payload are stubbed with cy.intercept.
+const stubVersions = [1, 2].map(id => ({
+  id,
+  version_number: id,
+  summary: `Change ${id}`,
+  author_name: 'Demo User',
+  created_at: '2026-07-01T12:00:00Z'
+}))
+
 describe('DocumentEditor version preview', () => {
   beforeEach(() => {
-    // Stub version payloads so previewed content is distinguishable from the
-    // current document regardless of DB state
-    cy.intercept('GET', /\/documents\/\d+\/versions\/\d+$/, req => {
+    cy.intercept('GET', /\/lookbook$/, {
+      headers: { 'Content-Type': 'application/json' },
+      body: stubVersions
+    }).as('versionsIndex')
+
+    cy.intercept('GET', /\/lookbook\/\d+$/, req => {
       const id = req.url.split('/').pop()
       req.reply({
         id: Number(id),
@@ -19,47 +33,38 @@ describe('DocumentEditor version preview', () => {
       })
     }).as('showVersion')
 
-    cy.visit('http://localhost:3001/documents/1')
-    cy.contains('button', 'Edit').click()
+    cy.visit('/bali/document_editor/default')
+    editor().should('contain.text', 'Project Overview')
     cy.get('[data-action*="document-editor#toggleHistory"]:visible').first().click()
-    cy.get('[data-action*="previewVersion"]:visible').should('have.length.at.least', 2)
-
-    editor()
-      .invoke('text')
-      .then(text => cy.wrap(text.slice(0, 40)).as('currentText'))
+    cy.wait('@versionsIndex')
+    cy.get('[data-action*="previewVersion"]:visible').should('have.length', 2)
   })
 
   const editor = () => cy.get('[data-document-editor-target="editorArea"]:visible .bn-editor')
 
-  const previewNth = n =>
-    cy.get('[data-action*="previewVersion"]:visible').eq(n).then($btn => {
-      const stubText = `STUB VERSION ${$btn.data('versionId')}`
-      cy.wrap($btn).click()
-      cy.wait('@showVersion')
-      editor().should('contain.text', stubText)
-    })
+  const previewVersion = id => {
+    cy.get(`[data-action*="previewVersion"][data-version-id="${id}"]:visible`).click()
+    cy.wait('@showVersion')
+    editor().should('contain.text', `STUB VERSION ${id}`)
+  }
 
   const backToCurrent = () => cy.get('[data-action*="exitPreview"]:visible').click()
 
   const assertBackOnCurrent = () => {
     editor().should('not.contain.text', 'STUB VERSION')
-    cy.get('@currentText').then(currentText => {
-      editor().invoke('text').should(text => {
-        expect(text.slice(0, 40)).to.eq(currentText)
-      })
-    })
+    editor().should('contain.text', 'Project Overview')
     editor().should('have.attr', 'contenteditable', 'true')
   }
 
   it('returns to the current version after a single preview', () => {
-    previewNth(0)
+    previewVersion(1)
     backToCurrent()
     assertBackOnCurrent()
   })
 
   it('returns to the current version after previewing several versions in a row', () => {
-    previewNth(0)
-    previewNth(1)
+    previewVersion(1)
+    previewVersion(2)
     backToCurrent()
     assertBackOnCurrent()
   })


### PR DESCRIPTION
## Qué

`previewVersion` capturaba el estado del editor en `_savedContent`/`_savedEditable` en **cada** llamada. Al previewar la versión A y luego la B (sin salir), el "documento actual" guardado se sobrescribía con el contenido de A, así que **Back to current** restauraba la versión A — en read-only y sin banner. Peor: en ese estado el editor marca "Unsaved changes", y un Save sobrescribiría silenciosamente el documento real con contenido viejo (lo reproduje: perdí el contenido actual del doc de prueba en el dummy).

Fix mínimo: capturar el documento actual solo en el **primer** preview de la sesión de preview (`_savedContent == null`); `exitPreview` ya lo resetea a null.

Fixes #510

## Causa raíz (debugging sistemático)

1. Reproducido en navegador con contenido de versión distinguible: preview v1 → preview v3 → Back to current ⇒ el editor muestra **v1** (no el actual), `contenteditable=false`, banner oculto.
2. Con un solo preview el flujo siempre funcionó — por eso el bug se percibía intermitente.

## Verificación

- TDD (Cypress): nuevo `document-editor.cy.js` con 2 tests — el de previews consecutivos estaba en rojo antes del fix; ambos en verde después. Los payloads de versión van stubbeados con `cy.intercept` para que el contenido previewado sea distinguible del actual sin depender del estado de la BD.
- Cypress completo: **44/44**. Minitest: 2596 runs, 0 failures. `standard` sin ofensas.

## Nota (fuera de alcance)

Durante un preview, el indicador "Unsaved changes" se enciende y el botón Save queda activo — guardar en ese estado escribiría el contenido de la versión previewada como actual. Este fix elimina el caso en que eso pasa *creyendo* estar en el actual, pero valdría un guard explícito de `save()` durante preview como hardening aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)