### PR TITLE
feat(feedback-widget): claim name opcional en el token de embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **FeedbackWidget** - `TokenGenerator`/`Component` now accept an optional `user_name:` kwarg that adds a `name` claim to the embed JWT (e.g. `"Ana López"`). Omitted entirely from the payload when not given, so existing integrations are unaffected.
+
 ## [v2.10.0] - 2026-06-30
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       reline (>= 0.4.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.3)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -454,7 +454,7 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/app/components/bali/feedback_widget/component.rb
+++ b/app/components/bali/feedback_widget/component.rb
@@ -9,14 +9,15 @@ module Bali
       # @param secret [String, nil] Opina shared secret to generate the token automatically
       # @param user_id [String, nil] User ID for token generation (required when using secret)
       # @param email [String, nil] User email for token generation (required when using secret)
+      # @param user_name [String, nil] User display name for token generation (optional)
       # @param title [String] Drawer header title (default: "Feedback")
       # @param token_expires_in [Integer] Token expiry in seconds (default: 3600 = 1 hour)
       # @param badge_interval [Integer] Polling interval in ms for badge count (default: 300000 = 5 min)
       def initialize(project_slug:, opina_url:, token: nil, secret: nil, user_id: nil, email: nil,
-                     title: nil, token_expires_in: 3600, badge_interval: 300_000, **options)
+                     user_name: nil, title: nil, token_expires_in: 3600, badge_interval: 300_000, **options)
         @project_slug = project_slug
         @opina_url = opina_url.chomp("/")
-        @token = token || generate_token(secret, user_id, email, token_expires_in)
+        @token = token || generate_token(secret, user_id, email, user_name, token_expires_in)
         @title = title
         @badge_interval = badge_interval
         @options = options
@@ -38,7 +39,7 @@ module Bali
         I18n.t("bali.feedback_widget.close", default: "Close")
       end
 
-      def generate_token(secret, user_id, email, expires_in)
+      def generate_token(secret, user_id, email, user_name, expires_in)
         raise ArgumentError, "Either token: or secret: (with user_id: and email:) is required" unless secret
 
         TokenGenerator.call(
@@ -46,6 +47,7 @@ module Bali
           project_slug: project_slug,
           user_id: user_id,
           email: email,
+          user_name: user_name,
           expires_in: expires_in
         )
       end

--- a/app/components/bali/feedback_widget/token_generator.rb
+++ b/app/components/bali/feedback_widget/token_generator.rb
@@ -5,16 +5,17 @@ module Bali
     # Generates HS256 JWT tokens for Opina embed authentication.
     # Compatible with Opina's embed/base_controller token verification.
     class TokenGenerator
-      def self.call(secret:, project_slug:, user_id:, email:, expires_in: 3600)
-        new(secret:, project_slug:, user_id:, email:, expires_in:).call
+      def self.call(secret:, project_slug:, user_id:, email:, expires_in: 3600, user_name: nil)
+        new(secret:, project_slug:, user_id:, email:, expires_in:, user_name:).call
       end
 
-      def initialize(secret:, project_slug:, user_id:, email:, expires_in:)
+      def initialize(secret:, project_slug:, user_id:, email:, expires_in:, user_name: nil)
         @secret = secret
         @project_slug = project_slug
         @user_id = user_id
         @email = email
         @expires_in = expires_in
+        @user_name = user_name
       end
 
       def call
@@ -37,7 +38,7 @@ module Bali
           email: @email,
           project_slug: @project_slug,
           exp: (Time.current + @expires_in).to_i
-        }
+        }.merge({ name: @user_name }.compact)
       end
 
       def encode_segment(data)

--- a/test/bali/components/feedback_widget_test.rb
+++ b/test/bali/components/feedback_widget_test.rb
@@ -119,4 +119,21 @@ class BaliFeedbackWidgetComponentTest < ComponentTestCase
 
     assert_selector("#feedback-widget-title", text: "Send us feedback")
   end
+
+  def test_threads_user_name_into_generated_token
+    render_inline(Bali::FeedbackWidget::Component.new(
+      project_slug: "test-project",
+      opina_url: "https://opina.example.com",
+      secret: "test-secret",
+      user_id: 1,
+      email: "user@example.com",
+      user_name: "Ana López"
+    ))
+
+    el = page.find("[data-feedback-widget-embed-url-value]")
+    token = el[:"data-feedback-widget-embed-url-value"][/token=(.+)\z/, 1]
+    payload = JSON.parse(Base64.urlsafe_decode64(token.split(".")[1]))
+
+    assert_equal "Ana López", payload["name"]
+  end
 end

--- a/test/bali/feedback_widget/token_generator_test.rb
+++ b/test/bali/feedback_widget/token_generator_test.rb
@@ -56,15 +56,31 @@ class BaliFeedbackWidgetTokenGeneratorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_payload_contains_name_when_user_name_given
+    token = generate_token(user_name: "Ana López")
+    payload = decode_segment(token, 1)
+
+    assert_equal "Ana López", payload["name"]
+  end
+
+  def test_payload_omits_name_when_user_name_not_given
+    token = generate_token
+    payload = decode_segment(token, 1)
+
+    assert_not payload.key?("name")
+  end
+
   private
 
-  def generate_token(secret: "test-secret", project_slug: "test", user_id: 1, email: "a@b.com", expires_in: 3600)
+  def generate_token(secret: "test-secret", project_slug: "test", user_id: 1, email: "a@b.com", expires_in: 3600,
+                      user_name: nil)
     Bali::FeedbackWidget::TokenGenerator.call(
       secret: secret,
       project_slug: project_slug,
       user_id: user_id,
       email: email,
-      expires_in: expires_in
+      expires_in: expires_in,
+      user_name: user_name
     )
   end
 


### PR DESCRIPTION
## Qué hace

Agrega el parámetro opcional `user_name:` a `Bali::FeedbackWidget::Component` y el claim `name` al JWT del `TokenGenerator`. Opina lo usa para auto-aprovisionar usuarios del embed con nombre real (sin él, deriva el nombre del prefijo del email).

- `user_name` omitido → el payload NO lleva llave `name` (nunca `name: nil`); `.compact` dirigido solo a esa llave para no tirar `sub`/`email`/`exp`.
- Backward-compatible: kwarg opcional con default nil.

## Contexto

Primera pieza de la integración Opina ↔ TDFlow vía Garita (feedback de usuarios con seguimiento). Diseño completo en `afal-apps` → `docs/plans/2026-07-05-opina-tdflow-feedback-design.md` (PR de TDFlow).

## Pruebas

- TDD: token decodificado (segmento medio), claim presente cuando se pasa / ausente cuando no.
- Tests focalizados 20 runs/29 asserts verdes; suite completa del gem verde (el hook pre-push la corre completa).
- Rubocop limpio en los 4 archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
