### PR TITLE
docs: refresh documentation to match v2.11.0 reality

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,12 +85,12 @@ Reference documentation is maintained in `docs/` for use by both Claude Code and
 
 ## Project Overview
 
-**Bali** is AFAL's open-source ViewComponent library providing 40+ reusable UI components for Rails applications.
+**Bali** is AFAL's open-source ViewComponent library providing 75+ reusable UI components for Rails applications.
 
 | Aspect | Details |
 |--------|---------|
 | **Type** | Ruby gem (Rails engine) |
-| **Components** | 40+ ViewComponents |
+| **Components** | 75+ ViewComponents |
 | **CSS** | Tailwind + DaisyUI |
 | **JavaScript** | Stimulus controllers |
 | **Testing** | Minitest + Cypress |
@@ -749,6 +749,8 @@ Use the correct component based on **what the element does**, not how it looks:
 | `FormBuilder` select | `select_field_group` | `select_group` |
 | `FormBuilder` textarea | `text_area_field_group` | `text_area_group` |
 | `SlimSelect` HTML | inline HTML | `data-inner-html` attribute on options |
+| Non-model form select param key | expecting `name:` to namespace | `input_name:`/`input_id:` in `select_group`/`slim_select_group` options |
+| Drawer/Modal form partial updates | full-page redirect only | respond with `text/vnd.turbo-stream.html` + `data-turbo="true"` on the form — streams are applied and the drawer/modal closes on success |
 
 ## Icons
 
@@ -859,6 +861,14 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::Level` | Horizontal layout | `flex items-center justify-between` | Tailwind flex |
 | `Bali::Modal` | Dialog/modal | `modal modal-box modal-action` | daisyUI modal |
 | `Bali::PageHeader` | Page header | Custom Tailwind | `nexus/layouts/page-title/` |
+| `Bali::AppLayout` | App shell (banner/navbar/sidebar/topbar/body slots) | Custom Tailwind | `nexus/layouts/` |
+| `Bali::Footer` | Page footer | `footer` | daisyUI footer |
+| `Bali::Topbar` | Admin top bar | Custom Tailwind | `nexus/layouts/topbar/` |
+| `Bali::DashboardPage` | Dashboard page template | Composition | — |
+| `Bali::IndexPage` | Index page template (DataTable + filters) | Composition | — |
+| `Bali::ShowPage` | Show page template | Composition | — |
+| `Bali::FormPage` | Form page template | Composition | — |
+| `Bali::DocumentPage` | Document view/edit page template | Composition | — |
 
 ### Navigation Components
 
@@ -869,7 +879,10 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::NavBar` | Navigation bar | `navbar navbar-start/center/end` | `nexus/layouts/topbar/` |
 | `Bali::SideMenu` | Sidebar menu | `menu` | `nexus/layouts/sidebar/` |
 | `Bali::Tabs` | Tab navigation | `tabs tabs-box tab` | daisyUI tabs |
-| `Bali::Stepper` | Step indicator | `steps step step-*` | daisyUI steps |
+| `Bali::Stepper` | Step indicator (supports `sublabel:` and content block per step) | `steps step step-*` | daisyUI steps |
+| `Bali::Command` | Command palette (⌘K) | `modal` + custom | — |
+| `Bali::Pagination` | Pagy-based pagination | `join btn` | daisyUI pagination |
+| `Bali::PaginationFooter` | Pagination + per-page + count footer | `join btn select` | — |
 
 ### Data Display Components
 
@@ -882,7 +895,7 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::GanttChart` | Gantt chart | Custom | — |
 | `Bali::Heatmap` | Heatmap display | Custom | — |
 | `Bali::Icon` | Icon display | `iconify lucide--*` | Iconify Lucide |
-| `Bali::ImageGrid` | Image gallery | Grid layout | — |
+| `Bali::ImageGrid` | Image gallery (optional `empty_state` slot when no images) | Grid layout | — |
 | `Bali::InfoLevel` | Info display | Custom | — |
 | `Bali::LabelValue` | Label/value pair | Custom Tailwind | — |
 | `Bali::List` | List display | `list list-row` | daisyUI list |
@@ -892,6 +905,8 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::Table` | Basic table | `table` | daisyUI table |
 | `Bali::Timeline` | Timeline | `timeline timeline-*` | daisyUI timeline |
 | `Bali::TreeView` | Tree structure | Custom | — |
+| `Bali::Skeleton` | Loading skeleton | `skeleton` | daisyUI skeleton |
+| `Bali::StatCard` | Metric/stat card | `stats stat` | `nexus/blocks/stats/` |
 
 ### Interactive Components
 
@@ -910,6 +925,8 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::Reveal` | Show/hide content | Custom + Stimulus | — |
 | `Bali::SearchInput` | Search field | `input` | `nexus/layouts/search/` |
 | `Bali::SortableList` | Drag-drop list | Custom + SortableJS | `nexus/interactions/sortable/` |
+| `Bali::Kanban` | Kanban board (drag between columns; columns accept a non-draggable `footer` slot) | Composition + SortableList | — |
+| `Bali::ConfirmDialog` | DaisyUI confirm replacing `window.confirm` (auto-installed via `registerAll`) | `modal` | — |
 | `Bali::Tooltip` | Tooltip | `tooltip tooltip-*` | daisyUI tooltip |
 
 ### Feedback Components
@@ -920,6 +937,7 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::Loader` | Loading indicator | `loading loading-*` | daisyUI loading |
 | `Bali::Message` | Message display | `alert` | daisyUI alert |
 | `Bali::Notification` | Notification | `alert alert-*` | daisyUI alert |
+| `Bali::FeedbackWidget` | Embeddable feedback widget (JWT token; optional `user_name:` claim) | Custom | — |
 
 ### Form Components
 
@@ -928,6 +946,10 @@ Document show pages may render multiple overlays (editor + viewer), each with th
 | `Bali::Form::*` | Form elements | `input select textarea checkbox radio` | daisyUI form elements |
 | `Bali::ImageField` | Image upload | Custom | `nexus/interactions/file-upload/` |
 | `Bali::RichTextEditor` | Rich text | (Trix) | `nexus/interactions/text-editor/` |
+| `Bali::DirectUpload` | Drag-and-drop multi-file upload (ActiveStorage) | Custom + Stimulus | `nexus/interactions/file-upload/` |
+| `Bali::RecurrentEventRuleForm` | RRULE recurrence editor | Form composition | — |
+| `Bali::BlockEditor` | BlockNote block editor (React via islands) | Custom | — |
+| `Bali::DocumentEditor` | Full-screen document editor (versions, comments, export) | Custom + BlockEditor | — |
 
 ### Utility Components
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs** - documentation refresh: component counts corrected (75+ components), README categories and status table now list every component (Kanban, ConfirmDialog, DocumentEditor, DirectUpload, page templates, etc.), the components guide gains sections for Stepper sublabels, ImageGrid empty state, Kanban and ConfirmDialog plus the Modal/Drawer turbo_stream submit pattern, the form-builder guide documents `input_name:`/`input_id:` for non-model forms, the AI dev guide catalog (.claude/CLAUDE.md) covers the full component set, and MIGRATION_STATUS.md is marked complete (historical).
+
 ## [v2.11.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Docs** - documentation refresh: component counts corrected (75+ components), README categories and status table now list every component (Kanban, ConfirmDialog, DocumentEditor, DirectUpload, page templates, etc.), the components guide gains sections for Stepper sublabels, ImageGrid empty state, Kanban and ConfirmDialog plus the Modal/Drawer turbo_stream submit pattern, the form-builder guide documents `input_name:`/`input_id:` for non-model forms, the AI dev guide catalog (.claude/CLAUDE.md) covers the full component set, and MIGRATION_STATUS.md is marked complete (historical).
+- **Docs** - documentation refresh: component counts corrected (75+ components), README categories and status table now list every component (Kanban, ConfirmDialog, DocumentEditor, DirectUpload, page templates, etc.), the components guide now documents all 74 components with per-component sections (usage example + options verified against each initialize signature), organized into categories including new Documents & Editors, Page Templates and Utilities sections, plus the Modal/Drawer turbo_stream submit pattern, the form-builder guide documents `input_name:`/`input_id:` for non-model forms, the AI dev guide catalog (.claude/CLAUDE.md) covers the full component set, and MIGRATION_STATUS.md is marked complete (historical).
 
 ## [v2.11.0] - 2026-07-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working in this repository.
 
 ## Project Overview
 
-**Bali** is AFAL's open-source ViewComponent library providing 40+ reusable UI components for Rails applications, styled with Tailwind CSS and DaisyUI.
+**Bali** is AFAL's open-source ViewComponent library providing 75+ reusable UI components for Rails applications, styled with Tailwind CSS and DaisyUI.
 
 ## Session Memory
 

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -1,9 +1,10 @@
 # Bali Tailwind/DaisyUI Migration Status
 
-This is the **single source of truth** for the Bulma → Tailwind/DaisyUI migration.
-
-> **Detailed Logs**: See [.claude/migration-log.md](.claude/migration-log.md) for per-component migration details.
-> **Autonomous Workflow**: See [docs/migration/AUTONOMOUS_MIGRATION_WORKFLOW.md](docs/migration/AUTONOMOUS_MIGRATION_WORKFLOW.md) for `/ultrawork` instructions.
+> **✅ MIGRATION COMPLETE (2026-01).** The Bulma → Tailwind/DaisyUI migration
+> finished in January 2026; every component ships on Tailwind CSS 4 + DaisyUI 5.
+> This file is kept as a historical record and is no longer updated — see
+> `CHANGELOG.md` for ongoing changes. The detailed per-component log and the
+> autonomous workflow docs referenced below were removed after completion.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Bali ViewComponents
 
-A collection of 48+ UI components built with [ViewComponent](https://viewcomponent.org/) for Rails applications. Styled with [Tailwind CSS](https://tailwindcss.com/) and [DaisyUI](https://daisyui.com/), powered by [Stimulus](https://stimulus.hotwired.dev/) controllers.
+A collection of 75+ UI components built with [ViewComponent](https://viewcomponent.org/) for Rails applications. Styled with [Tailwind CSS](https://tailwindcss.com/) and [DaisyUI](https://daisyui.com/), powered by [Stimulus](https://stimulus.hotwired.dev/) controllers.
 
 ## Features
 
-- **48+ Production-Ready Components** - Buttons, cards, modals, forms, tables, navigation, and more
+- **75+ Production-Ready Components** - Buttons, cards, modals, forms, tables, navigation, and more
 - **DaisyUI Styling** - Beautiful, consistent styling with theme support (light/dark)
 - **Stimulus Controllers** - Interactive behaviors without writing JavaScript
 - **FormBuilder Extensions** - Enhanced form helpers with validation and addons
@@ -98,22 +98,28 @@ In your CSS entry point (e.g., `app/assets/tailwind/application.css`):
 ## Component Categories
 
 ### Layout
-`Card`, `Columns`, `Drawer`, `Hero`, `Level`, `Modal`, `PageHeader`
+`AppLayout`, `Card`, `Columns`, `Drawer`, `Footer`, `Hero`, `Level`, `Modal`, `PageHeader`, `Topbar`
 
 ### Navigation
-`Breadcrumb`, `Dropdown`, `NavBar`, `SideMenu`, `Tabs`, `Stepper`
+`Breadcrumb`, `Command`, `Dropdown`, `Navbar`, `Pagination`, `PaginationFooter`, `SideMenu`, `Stepper`, `Tabs`
 
 ### Data Display
-`Avatar`, `DataTable`, `Icon`, `List`, `Progress`, `Table`, `Tag`, `Timeline`, `TreeView`
+`Avatar`, `BooleanIcon`, `Chart`, `DataTable`, `GanttChart`, `Heatmap`, `Icon`, `ImageGrid`, `InfoLevel`, `LabelValue`, `List`, `LocationsMap`, `Progress`, `PropertiesTable`, `Rate`, `Skeleton`, `StatCard`, `Table`, `Tag`, `Tags`, `Timeago`, `Timeline`, `TreeView`
 
 ### Interactive
-`ActionsDropdown`, `Filters`, `Button`, `Carousel`, `Clipboard`, `DeleteLink`, `HoverCard`, `Link`, `Reveal`, `SearchInput`, `SortableList`, `Tooltip`
+`ActionsDropdown`, `BulkActions`, `Button`, `Carousel`, `Clipboard`, `ConfirmDialog`, `DeleteLink`, `Filters`, `HoverCard`, `Kanban`, `Link`, `Reveal`, `SearchInput`, `SortableList`, `Tooltip`
 
 ### Feedback
-`FlashNotifications`, `Loader`, `Message`, `Notification`
+`FeedbackWidget`, `FlashNotifications`, `Loader`, `Message`, `Notification`
 
 ### Forms
-`Calendar`, `ImageField`, `RichTextEditor`, plus 25+ FormBuilder extensions
+`Calendar`, `DirectUpload`, `ImageField`, `RecurrentEventRuleForm`, `RichTextEditor`, plus 25+ FormBuilder extensions
+
+### Documents & Editors
+`BlockEditor`, `DocumentEditor`, `DocumentPage`
+
+### Page Templates
+`DashboardPage`, `IndexPage`, `ShowPage`, `FormPage`
 
 ## FormBuilder Extensions
 
@@ -192,10 +198,12 @@ The gem is available as open source under the terms of the [MIT License](https:/
 | Component | Preview | Docs | Tests |
 |-----------|:-------:|:----:|:-----:|
 | ActionsDropdown | ✓ | ✓ | ✓ |
-| Filters | ✓ | ✓ | ✓ |
+| AppLayout | ✓ | ✓ | ✓ |
 | Avatar | ✓ | ✓ | ✓ |
-| Breadcrumb | ✓ | ✓ | ✓ |
+| BlockEditor | ✓ | ✓ | ✓ |
 | BooleanIcon | ✓ | ✓ | ✓ |
+| Breadcrumb | ✓ | ✓ | ✓ |
+| BulkActions | ✓ | - | ✓ |
 | Button | ✓ | ✓ | ✓ |
 | Calendar | ✓ | ✓ | ✓ |
 | Card | ✓ | ✓ | ✓ |
@@ -203,41 +211,66 @@ The gem is available as open source under the terms of the [MIT License](https:/
 | Chart | ✓ | ~ | ✓ |
 | Clipboard | ✓ | ✓ | ✓ |
 | Columns | ✓ | ✓ | ✓ |
+| Command | ✓ | ✓ | ✓ |
+| ConfirmDialog | ✓ | - | - |
+| DashboardPage | ✓ | - | ✓ |
 | DataTable | ✓ | ✓ | ✓ |
 | DeleteLink | ✓ | ✓ | ✓ |
+| DirectUpload | ✓ | ✓ | - |
+| DocumentEditor | ✓ | - | ✓ |
+| DocumentPage | ✓ | - | ✓ |
 | Drawer | ✓ | ✓ | ✓ |
 | Dropdown | ✓ | ✓ | ✓ |
+| FeedbackWidget | ✓ | - | ✓ |
 | Filters | ✓ | ✓ | ✓ |
+| FlashNotifications | ✓ | - | ✓ |
+| Footer | ✓ | - | ✓ |
+| FormPage | ✓ | - | ✓ |
 | GanttChart | ✓ | ✓ | - |
 | Heatmap | ✓ | ✓ | ✓ |
 | Hero | ✓ | ✓ | ✓ |
 | HoverCard | ✓ | ✓ | ✓ |
 | Icon | ✓ | ✓ | ✓ |
+| ImageField | ✓ | - | ✓ |
 | ImageGrid | ✓ | ✓ | ✓ |
+| IndexPage | ✓ | - | ✓ |
 | InfoLevel | ✓ | ✓ | ✓ |
+| Kanban | ✓ | - | ✓ |
 | LabelValue | ✓ | ✓ | ✓ |
 | Level | ✓ | ✓ | ✓ |
 | Link | ✓ | ✓ | ✓ |
 | List | ✓ | ✓ | ✓ |
 | Loader | ✓ | ✓ | ✓ |
+| LocationsMap | ✓ | ✓ | ✓ |
+| Message | ✓ | - | ✓ |
 | Modal | ✓ | ✓ | ✓ |
 | NavBar | ✓ | ✓ | ✓ |
 | Notification | ✓ | ✓ | ✓ |
 | PageHeader | ✓ | ~ | ✓ |
+| Pagination | ✓ | - | ✓ |
+| PaginationFooter | ✓ | - | ✓ |
 | Progress | ✓ | ✓ | ✓ |
 | PropertiesTable | ✓ | ✓ | ✓ |
 | Rate | ✓ | ✓ | ✓ |
+| RecurrentEventRuleForm | ✓ | - | ✓ |
 | Reveal | ✓ | ✓ | ✓ |
 | RichTextEditor | ✓ | - | - |
 | SearchInput | ✓ | ✓ | ✓ |
+| ShowPage | ✓ | - | ✓ |
 | SideMenu | ✓ | ✓ | ✓ |
+| Skeleton | ✓ | - | ✓ |
 | SortableList | ✓ | ✓ | ✓ |
+| StatCard | ✓ | - | - |
 | Stepper | ✓ | ✓ | ✓ |
 | Table | ✓ | ✓ | ✓ |
 | Tabs | ✓ | ✓ | ✓ |
+| Tag | ✓ | - | ✓ |
+| Tags | ✓ | - | ✓ |
+| ThemeSampler | ✓ | - | - |
 | Timeago | ✓ | ✓ | ✓ |
 | Timeline | ✓ | ✓ | ✓ |
 | Tooltip | ✓ | ✓ | ✓ |
+| Topbar | ✓ | ✓ | ✓ |
 | TreeView | ✓ | ✓ | ✓ |
 
 **Legend:** ✓ Complete | ~ Partial | - Missing

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -255,6 +255,32 @@ Slide-in panel from edge of screen.
 <% end %>
 ```
 
+**Turbo Stream form submits** (Modal and Drawer): forms submitted with the
+`modal#submit`/`drawer#submit` action and `data-turbo="true"` accept
+`text/vnd.turbo-stream.html` responses — the streams are applied to the page
+and the modal/drawer closes on success (an error stream keeps it open so the
+form can re-render inside). Redirect and HTML responses behave as before.
+
+```erb
+<%# In the drawer content %>
+<%= form_with model: @tag, data: { turbo: true } do |f| %>
+  ...
+  <%= render Bali::Button::Component.new(name: 'Save', data: { action: 'drawer#submit' }) %>
+<% end %>
+```
+
+```ruby
+# Controller — partial update instead of full-page redirect
+respond_to do |format|
+  format.turbo_stream do
+    render turbo_stream: [
+      turbo_stream.replace('systems-card', partial: 'systems_card'),
+      turbo_stream.append('toast-notifications', partial: 'toast')
+    ]
+  end
+end
+```
+
 ---
 
 ### Navigation Components
@@ -386,6 +412,28 @@ Action menu that opens on click/hover.
 <% end %>
 ```
 
+#### Stepper
+
+Step indicator for multi-stage flows. Steps accept an optional `sublabel:`
+(event date, actor, status note) rendered as a smaller muted line under the
+title, or a free content block for arbitrary markup.
+
+```erb
+<%= render Bali::Stepper::Component.new(current: 2) do |s| %>
+  <% s.with_step(title: "Proposed", sublabel: "07/01 · Luis Pérez") %>
+  <% s.with_step(title: "Approved", sublabel: "07/03 · Ana Gutiérrez") %>
+  <% s.with_step(title: "Published") do %>
+    <span class="text-xs opacity-60">release #12</span>
+  <% end %>
+  <% s.with_step(title: "Active") %>
+<% end %>
+```
+
+**Options:**
+- `current` - Zero-based index of the active step
+- `orientation` - `:horizontal` (default) or `:vertical`
+- `color` - DaisyUI step color for completed/active steps
+
 ---
 
 ### Data Display Components
@@ -439,6 +487,27 @@ Progress bar indicator.
 ```erb
 <%= render Bali::Progress::Component.new(value: 75, max: 100, color: :primary) %>
 ```
+
+#### ImageGrid
+
+Responsive image gallery with optional lightbox and empty state.
+
+```erb
+<%= render Bali::ImageGrid::Component.new(columns: 4, expandable: true) do |grid| %>
+  <% grid.with_empty_state do %>
+    <p class="text-sm text-base-content/60"><%= t('bali.image_grid.empty_state.title') %></p>
+    <%= render Bali::Link::Component.new(name: t('bali.image_grid.empty_state.add_image'),
+          href: new_image_path, type: :primary) %>
+  <% end %>
+  <% @images.each do |image| %>
+    <% grid.with_image(full_src: image.full_url) { image_tag image.thumb_url } %>
+  <% end %>
+<% end %>
+```
+
+The `empty_state` slot renders inside a dashed-border centered box instead of
+the grid when there are no images; it is ignored when images are present.
+i18n keys `bali.image_grid.empty_state.{title,add_image}` ship in en/es.
 
 ---
 
@@ -502,6 +571,48 @@ Contextual information on hover.
   Hover over me
 <% end %>
 ```
+
+#### Kanban
+
+Kanban board built on SortableList with drag-and-drop between columns. Each
+column maps to a status value sent to the server on drop. Columns accept an
+optional `footer` slot rendered outside the sortable list (never draggable) —
+the classic "+ add card" action.
+
+```erb
+<%= render Bali::Kanban::Component.new(resource_name: "task", group_name: "board") do |k| %>
+  <% k.with_column(title: "To Do", status: "todo", color: :ghost) do |col| %>
+    <% col.with_card(update_url: task_path(task)) { render TaskCard.new(task:) } %>
+    <% col.with_footer do %>
+      <%= link_to "+ Add card", new_task_path(status: :todo) %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+#### ConfirmDialog
+
+DaisyUI-styled `<dialog>` that replaces Turbo's native `window.confirm` for
+every `data-turbo-confirm` (including `DeleteLink` and `ActionsDropdown`
+delete items). Auto-installed via `registerAll` — no per-app code needed.
+
+```erb
+<%# Any turbo confirm gets the styled dialog automatically %>
+<%= button_to "Delete", thing_path(thing), method: :delete,
+      data: { turbo_confirm: "Delete this thing?" } %>
+
+<%# Per-trigger customization %>
+<%= button_to "Close project", close_project_path(project),
+      data: {
+        turbo_confirm: "Close this project?",
+        bali_confirm_title: "Close project",
+        bali_confirm_variant: "warning",
+        bali_confirm_accept: "Close it"
+      } %>
+```
+
+Opt out globally with `window.BALI_DISABLE_CONFIRM_DIALOG = true` before
+`registerAll` runs.
 
 ---
 

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -281,6 +281,112 @@ respond_to do |format|
 end
 ```
 
+#### Columns
+
+Responsive column layout that stacks on mobile and sits side-by-side on `md+`; pass `cols:` to switch to CSS Grid auto-flow mode (no `with_column` wrappers needed).
+
+```erb
+<%= render Bali::Columns::Component.new(gap: :lg) do |c| %>
+  <% c.with_column(size: :one_third) do %>
+    Sidebar content
+  <% end %>
+  <% c.with_column do %>
+    Main content fills remaining space
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `gap` - Space between columns: `:none`, `:px`, `:xs`, `:sm`, `:md`, `:lg`, `:xl`, `:'2xl'` (default: `:md`)
+- `cols` - Grid columns 1-12; enables grid auto-flow mode where children render directly (default: `nil`)
+- `cols_md` - Grid columns at the `md` breakpoint, 768px+ (default: `nil`)
+- `cols_lg` - Grid columns at the `lg` breakpoint, 1024px+ (default: `nil`)
+- `cols_xl` - Grid columns at the `xl` breakpoint, 1280px+ (default: `nil`)
+- `wrap` - Allow columns to wrap to multiple lines (default: `false`)
+- `center` - Center columns horizontally (default: `false`)
+- `middle` - Center columns vertically (default: `false`)
+- `mobile` - Keep columns horizontal on mobile instead of stacking (default: `false`)
+
+#### Hero
+
+Full-width hero section (DaisyUI `hero`) with title, subtitle, and action slots.
+
+```erb
+<%= render Bali::Hero::Component.new(size: :md, color: :primary) do |c| %>
+  <% c.with_title('Hello there') %>
+  <% c.with_subtitle('Provident cupiditate voluptatem et in.') %>
+  <% c.with_actions do %>
+    <%= render Bali::Button::Component.new(name: 'Get Started', variant: :secondary) %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `size` - Minimum height: `:sm`, `:md`, `:lg` (full screen) (default: `:md`)
+- `color` - Background color: `:base`, `:primary`, `:secondary`, `:accent`, `:neutral` (default: `:base`)
+- `centered` - Center-align the hero content (default: `true`)
+
+#### Level
+
+Horizontal bar that spreads content between left and right sides, wrapping on small screens; use `with_item` directly when positioning is not needed.
+
+```erb
+<%= render Bali::Level::Component.new(align: :center) do |c| %>
+  <% c.with_left do |l| %>
+    <% l.with_item(text: 'Left Item 1') %>
+    <% l.with_item(text: 'Left Item 2') %>
+  <% end %>
+  <% c.with_right do |r| %>
+    <% r.with_item(text: 'Right Item 1') %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `align` - Vertical alignment of items: `:start`, `:center`, `:end` (default: `:center`)
+
+#### PageHeader
+
+Page-level header with title, subtitle, optional back button, and right-aligned content (the block).
+
+```erb
+<%= render Bali::PageHeader::Component.new(
+  title: 'Movies',
+  subtitle: 'Manage your catalog',
+  back: { href: movies_path }
+) do %>
+  <%= render Bali::Link::Component.new(name: 'New Movie', href: new_movie_path, type: :primary) %>
+<% end %>
+```
+
+**Options:**
+- `title` - Title text; use the `with_title` slot for a custom tag or classes (default: `nil`)
+- `subtitle` - Subtitle text; use the `with_subtitle` slot for a custom tag or classes (default: `nil`)
+- `align` - Vertical alignment of left/right content: `:top`, `:center`, `:bottom` (default: `:center`)
+- `back` - Back button options hash, requires `href` (e.g. `{ href: path }`) (default: `nil`)
+- `responsive` - Apply tighter spacing on small screens (default: `true`)
+
+#### Footer
+
+Responsive site footer (DaisyUI `footer`) with brand, link sections, and bottom copyright slots.
+
+```erb
+<%= render Bali::Footer::Component.new(color: :neutral) do |footer| %>
+  <% footer.with_brand(name: 'ACME Industries', description: 'Providing reliable tech since 1992.') %>
+  <% footer.with_section(title: 'Company') do |section| %>
+    <% section.with_link(name: 'About us', href: '/about') %>
+    <% section.with_link(name: 'Contact', href: '/contact') %>
+  <% end %>
+  <% footer.with_bottom do %>
+    <p>Copyright 2026 - All rights reserved</p>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `color` - Background color preset: `:neutral`, `:base`, `:primary`, `:secondary` (default: `:neutral`)
+- `center` - Center-align footer content (default: `false`)
+
 ---
 
 ### Navigation Components
@@ -434,6 +540,34 @@ title, or a free content block for arbitrary markup.
 - `orientation` - `:horizontal` (default) or `:vertical`
 - `color` - DaisyUI step color for completed/active steps
 
+#### Pagination
+
+Pagination controls (DaisyUI `join` buttons) built from a Pagy object; renders nothing when there is only one page.
+
+```erb
+<%= render Bali::Pagination::Component.new(pagy: @pagy, size: :sm, variant: :outline) %>
+```
+
+**Options:**
+- `pagy` - The Pagy pagination object (required)
+- `size` - Button size: `:xs`, `:sm`, `:md`, `:lg` (default: `:md`)
+- `variant` - Button variant: `:default`, `:outline`, `:ghost` (default: `:default`)
+- `url` - Base URL for pagination links (default: `nil`, uses the request path)
+
+#### PaginationFooter
+
+Footer row combining a "Showing X-Y of Z items" summary with `Pagination` controls; renders nothing without a Pagy object.
+
+```erb
+<%= render Bali::PaginationFooter::Component.new(pagy: @pagy, item_name: 'movies') %>
+```
+
+**Options:**
+- `pagy` - Pagy object for pagination (required)
+- `item_name` - Name for items in the summary text (default: `nil`, falls back to "items")
+- `show_summary` - Whether to show the summary text (default: `true`)
+- `show_pagination` - Whether to show pagination controls (default: `true`)
+
 ---
 
 ### Data Display Components
@@ -508,6 +642,388 @@ Responsive image gallery with optional lightbox and empty state.
 The `empty_state` slot renders inside a dashed-border centered box instead of
 the grid when there are no images; it is ignored when images are present.
 i18n keys `bali.image_grid.empty_state.{title,add_image}` ship in en/es.
+
+#### BooleanIcon
+
+Displays a boolean value as a colored icon — a green check for true, a red cross for false (nil is treated as false). Useful in table cells and lists.
+
+```erb
+<%= render Bali::BooleanIcon::Component.new(value: movie.indie?) %>
+```
+
+**Options:**
+- `value` - Boolean value to display; nil is coerced to false (required)
+- `**options` - Additional HTML attributes for the wrapper div
+
+#### Chart
+
+Renders a Chart.js chart (bar, line, pie, doughnut, polarArea) with theme-aware colors, optionally wrapped in a DaisyUI card.
+
+```erb
+<%= render Bali::Chart::Component.new(
+  data: {
+    labels: %w[Mon Tue Wed Thu Fri],
+    datasets: [
+      { label: 'Sales', data: [120, 190, 300, 250, 420] },
+      { label: 'Returns', data: [20, 30, 25, 35, 40] }
+    ]
+  },
+  type: :bar,
+  title: 'Weekly Sales Report',
+  legend: true,
+  card_style: :default
+) %>
+```
+
+**Options:**
+- `type` - Chart type or array of types for mixed charts: `:bar`, `:line`, `:pie`, `:doughnut`, `:polarArea` (default: `:bar`)
+- `data` - Simple hash `{ "Mon" => 10 }` or multi-series `{ labels: [...], datasets: [...] }` (default: `{}`)
+- `title` - Chart title shown in the card header (default: nil)
+- `legend` - Show the legend (default: false)
+- `display_percent` - Display values as percentages (default: false)
+- `order` - Dataset draw order, one entry per dataset (default: `[]`)
+- `y_axis_ids` - Y-axis IDs per dataset for multi-axis charts (default: `[]`)
+- `options` - Custom Chart.js options, deep-merged over defaults (default: `{}`)
+- `card_style` - Card wrapper: `:default`, `:bordered`, `:compact`, `:none` (default: `:none`)
+- `height` - Height preset: `:sm`, `:md`, `:lg`, `:xl` (default: `:md`)
+- `use_theme_colors` - Use DaisyUI theme colors for series, grid, and tooltips (default: true)
+
+#### DataTable
+
+Complete data table wrapper with filters, quick search, summary, and pagination. Integrates with `Bali::FilterForm` — when a `filter_form` is given, `with_filters_panel` auto-configures attributes, filter groups, and search.
+
+```erb
+<%= render Bali::DataTable::Component.new(filter_form: @filter_form, url: movies_path, pagy: @pagy) do |dt| %>
+  <% dt.with_filters_panel(search: { placeholder: 'Search movies...' }) %>
+  <% dt.with_table do %>
+    <%= render Bali::Table::Component.new(form: @filter_form) do |t| %>
+      <% t.with_header(name: 'Name', sort: :name) %>
+      ...
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `url` - Base URL for filtering/sorting links (required)
+- `filter_form` - `Bali::FilterForm` instance for Ransack integration (default: nil)
+- `pagy` - Pagy object for pagination (default: nil)
+- `show_summary` - Show record summary (default: true when pagy present)
+- `summary_position` - `:top` or `:bottom` (default: `:bottom`)
+- `item_name` - Item name used in the summary text (default: i18n)
+- `table_class` - CSS class for the table wrapper (default: `"overflow-x-auto"`)
+- `display_mode` - `:table` or `:grid` (default: `:table`)
+
+Slots: `with_filters_panel`, `with_simple_filters`, `with_table`, `with_grid`, `with_summary`, `with_toolbar_button`, `with_column_selector`, `with_export`, `with_actions_panel`, `with_custom_pagy_nav`.
+
+#### GanttChart
+
+Interactive Gantt chart with nested tasks, dependencies, milestones, drag/resize editing, and day/week/month zoom levels.
+
+```erb
+<%= render Bali::GanttChart::Component.new(tasks: [
+  { id: 1, name: 'Task 1', start_date: Date.current, end_date: Date.current + 16.days, update_url: '/tasks/1' },
+  { id: 2, name: 'Task 1.1', start_date: Date.current, end_date: Date.current + 10.days, parent_id: 1, update_url: '/tasks/2' }
+], zoom: :day) do |c| %>
+  <% c.with_view_mode_button(label: 'Day', zoom: :day, active: true) %>
+  <% c.with_view_mode_button(label: 'Week', zoom: :week, active: false) %>
+  <% c.with_footer { 'This is a footer' } %>
+<% end %>
+```
+
+**Options:**
+- `tasks` - Array of task hashes (`id`, `name`, `start_date`, `end_date`, `update_url`, plus optional `parent_id`, `dependent_on_id`, `progress`, `milestone`, `critical`, `href`, `actions`) (default: `[]`)
+- `row_height` - Row height in pixels (default: 35)
+- `col_width` - Column width in pixels (default: 25 for day zoom, 100 for week/month)
+- `zoom` - `:day`, `:week`, or `:month` (default: `:day`)
+- `readonly` - Disable drag/resize editing (default: false)
+- `offset` - Initial horizontal scroll offset in pixels (default: scrolls near today)
+- `resource_name` - Resource name sent with update requests (default: nil)
+- `list_param_name` - Param name used when reordering tasks (default: `"list_id"`)
+- `start_date` - Chart start date string; computed from tasks when nil (default: nil)
+- `colors` - Hash with `:default` and `:completed` task bar colors (via `**options`)
+
+Slots: `with_view_mode_button`, `with_footer`, `with_list_footer`.
+
+#### Heatmap
+
+Grid visualization that shows magnitude as color intensity across two dimensions, e.g. activity by day and hour.
+
+```erb
+<%= render Bali::Heatmap::Component.new(
+  data: {
+    Mon: { 9 => 5, 10 => 8, 11 => 3 },
+    Tue: { 9 => 3, 10 => 6, 11 => 9 }
+  },
+  color: :primary
+) do |c| %>
+  <% c.with_x_axis_title('Days') %>
+  <% c.with_y_axis_title('Hours') %>
+  <% c.with_hovercard_title('Clicks by hour of day') %>
+  <% c.with_legend_title('Clicks') %>
+<% end %>
+```
+
+**Options:**
+- `data` - Hash of `{ x_label => { y_label => value } }` (required)
+- `color` - DaisyUI preset (`:primary`, `:secondary`, `:accent`, `:success`, `:info`, `:warning`, `:error`) or hex string (default: `:primary`)
+- `cell_size` - Cell size in pixels (default: 28)
+- `responsive` - Stretch to fill container width (default: true)
+
+Slots: `with_x_axis_title`, `with_y_axis_title`, `with_legend_title`, `with_hovercard_title`.
+
+#### Icon
+
+Renders an icon by name, resolving Lucide icons first (1,600+ available), then kept brand/regional icons, then legacy Bali icons.
+
+```erb
+<%= render Bali::Icon::Component.new('check', size: :large) %>
+<%= render Bali::Icon::Component.new('alert', class: 'text-error') %>
+```
+
+**Options:**
+- `name` - Icon name: Bali name, Lucide name, or kept brand/regional icon (required, positional)
+- `tag_name` - Wrapper HTML tag (default: `:span`)
+- `size` - `:small`, `:medium`, `:large`, or an integer in pixels (default: nil, renders at 16px)
+- `**options` - Additional HTML attributes (e.g. `class`)
+
+#### InfoLevel
+
+Horizontal row of heading/title stat items, useful for profile counts or summary metrics.
+
+```erb
+<%= render Bali::InfoLevel::Component.new(align: :center) do |c| %>
+  <% c.with_item do |i| %>
+    <% i.with_heading('Posts') %>
+    <% i.with_title('128') %>
+  <% end %>
+  <% c.with_item do |i| %>
+    <% i.with_heading('Followers') %>
+    <% i.with_title('12.3K') %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `align` - Item alignment: `:start`, `:center`, `:end`, `:between` (default: `:center`)
+- `**options` - Additional HTML attributes
+
+Slots: `with_item` (each item takes `with_heading` and `with_title`, as text or block).
+
+#### LabelValue
+
+Displays a small bold label above its value — a common pattern on show pages.
+
+```erb
+<%= render Bali::LabelValue::Component.new(label: 'Name', value: 'Juan Perez') %>
+
+<%# Block content is used when value: is nil %>
+<%= render Bali::LabelValue::Component.new(label: 'URL') do %>
+  <a href="#" class="link link-primary">Download link</a>
+<% end %>
+```
+
+**Options:**
+- `label` - Label text shown above the value (required)
+- `value` - Value to display; when nil, block content is rendered instead (default: nil)
+- `**options` - Additional HTML attributes
+
+#### List
+
+Vertical list of rows (DaisyUI `list`) where each item has a title, subtitle, optional actions, and extra content.
+
+```erb
+<%= render Bali::List::Component.new do |c| %>
+  <% c.with_item do |i| %>
+    <% i.with_title('First item') %>
+    <% i.with_subtitle('Description of the first item') %>
+    <% i.with_action do %>
+      <%= render Bali::Button::Component.new(name: 'Delete', variant: :error, size: :sm, icon: 'trash') %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `borderless` - Remove the outer border and rounded box (default: false)
+- `relaxed_spacing` - Add extra vertical padding to rows (default: false)
+- `**options` - Additional HTML attributes
+
+Slots: `with_item` (each item takes `with_title`, `with_subtitle`, and repeatable `with_action`; extra block content renders in the middle column).
+
+#### LocationsMap
+
+Interactive Google Map with location markers, optional info views, clustering, and linked location cards. Requires the `GOOGLE_MAPS_KEY` environment variable to be set with a Google Maps JavaScript API key.
+
+```erb
+<%= render Bali::LocationsMap::Component.new(zoom: 12, clustered: false) do |c| %>
+  <% c.with_location(latitude: 32.5253, longitude: -117.0166) %>
+  <% c.with_location(latitude: 32.5284, longitude: -117.0197, color: 'green') %>
+  <% c.with_location(latitude: 32.5162, longitude: -117.0129) do |location| %>
+    <% location.with_info_view { tag.p('This is an info view') } %>
+  <% end %>
+  <% c.with_card(latitude: 32.5253, longitude: -117.0166) { tag.p('Card 1') } %>
+<% end %>
+```
+
+**Options:**
+- `center_latitude` - Map center latitude (default: 32.5036383, Tijuana)
+- `center_longitude` - Map center longitude (default: -117.0308968)
+- `zoom` - Initial map zoom level (default: 12)
+- `clustered` - Enable marker clustering (default: false)
+
+**Slots:** `with_location` (markers, support `color`, `label`, `icon_url`, and a nested `with_info_view`), `with_card` (cards rendered beside the map that highlight when their marker is clicked).
+
+#### PropertiesTable
+
+Displays key-value pairs in a zebra-striped table — useful for showing object attributes on detail pages.
+
+```erb
+<%= render Bali::PropertiesTable::Component.new do |c| %>
+  <% c.with_property(label: 'Name', value: 'John Doe') %>
+  <% c.with_property(label: 'Email', value: 'john@example.com') %>
+  <% c.with_property(label: 'Member Since', value: 'January 2024') %>
+<% end %>
+```
+
+**Options:**
+- `**options` - Additional HTML attributes for the table (e.g. `class`)
+
+**Slots:** `with_property(label:, value:)` — properties also accept block content for rich values like tags or links.
+
+#### Rate
+
+Star rating built on DaisyUI's rating classes, with Rails form integration, auto-submit, and readonly display modes.
+
+```erb
+<%# Form input %>
+<%= render Bali::Rate::Component.new(form: f, method: :rating, value: 3) %>
+
+<%# Readonly display %>
+<%= render Bali::Rate::Component.new(value: 4, readonly: true) %>
+```
+
+**Options:**
+- `value` - Current rating value (required)
+- `form` - Rails form builder for form integration (default: nil)
+- `method` - Model attribute name for the input (default: nil)
+- `scale` - Range of selectable ratings (default: 1..5)
+- `size` - Star size: `:xs`, `:sm`, `:md`, `:lg` (default: :md)
+- `color` - Star color: `:warning`, `:primary`, `:secondary`, `:accent`, `:success`, `:error`, `:info` (default: :warning)
+- `auto_submit` - Submit the form immediately when a star is clicked (default: false)
+- `readonly` - Display-only mode with disabled inputs (default: false)
+
+#### Skeleton
+
+Loading placeholder with preset patterns for common layouts (text, paragraphs, cards, avatars, buttons, modals, lists).
+
+```erb
+<%= render Bali::Skeleton::Component.new(variant: :paragraph, lines: 3) %>
+<%= render Bali::Skeleton::Component.new(variant: :list, lines: 4) %>
+```
+
+**Options:**
+- `variant` - Preset pattern: `:text`, `:paragraph`, `:card`, `:avatar`, `:button`, `:modal`, `:list` (default: :text)
+- `size` - Line height / avatar size: `:xs`, `:sm`, `:md`, `:lg` (default: :sm)
+- `lines` - Number of lines/items for `:paragraph` and `:list` variants (default: 3)
+
+#### StatCard
+
+Metric card showing a title, value, and colored icon — ideal for dashboard KPI rows.
+
+```erb
+<%= render Bali::StatCard::Component.new(
+  title: 'Total Users',
+  value: '1,234',
+  icon_name: 'users',
+  color: :primary
+) do |c| %>
+  <% c.with_footer { tag.span('+12% from last month', class: 'text-success') } %>
+<% end %>
+```
+
+**Options:**
+- `title` - Metric label (required)
+- `value` - Metric value to display (required)
+- `icon_name` - Bali/Lucide icon name (required)
+- `color` - Icon accent: `:primary`, `:secondary`, `:accent`, `:success`, `:warning`, `:error`, `:info` (default: :primary)
+
+**Slots:** `with_footer` — optional footer for trends or status text.
+
+#### Tags
+
+Groups multiple Tag components in a wrapping flex container with configurable gap spacing. Renders nothing when no items are given.
+
+```erb
+<%= render Bali::Tags::Component.new(gap: :sm) do |c| %>
+  <% c.with_item(text: 'Ruby', color: :primary) %>
+  <% c.with_item(text: 'Rails', color: :success, style: :outline) %>
+  <% c.with_item(text: 'Docs', href: '/docs', color: :info) %>
+<% end %>
+```
+
+**Options:**
+- `gap` - Spacing between tags: `:none`, `:xs`, `:sm`, `:md`, `:lg` (default: :sm)
+
+**Slots:** `with_item(text:, href:, **options)` — each item accepts any `Bali::Tag` option (`color`, `style`, `size`, `rounded`); `href` renders it as a link.
+
+#### Timeago
+
+Displays relative time ("5 minutes ago") using date-fns for localized formatting, with optional auto-refresh.
+
+```erb
+<%= render Bali::Timeago::Component.new(article.created_at, add_suffix: true) %>
+
+<%# Live-updating timestamp %>
+<%= render Bali::Timeago::Component.new(user.last_seen_at, add_suffix: true, refresh_interval: 30000) %>
+```
+
+**Options:**
+- `datetime` - The time to display, passed as the first positional argument (required)
+- `add_suffix` - Append "ago"/"in" to the output (default: false)
+- `refresh_interval` - Auto-refresh interval in milliseconds, `nil` disables (default: nil)
+- `include_seconds` - Include seconds for distances under a minute (default: true)
+
+#### Timeline
+
+Vertical timeline for chronological sequences of events, using DaisyUI's timeline with headers, icons, and color variants.
+
+```erb
+<%= render Bali::Timeline::Component.new(position: :left) do |c| %>
+  <% c.with_tag_header(text: 'Start', color: :primary) %>
+  <% c.with_tag_item(heading: 'January 2022', icon: 'check', color: :success) do %>
+    <p>Timeline event 1</p>
+  <% end %>
+  <% c.with_tag_item(heading: 'February 2022') do %>
+    <p>Timeline event 2</p>
+  <% end %>
+  <% c.with_tag_header(text: 'End') %>
+<% end %>
+```
+
+**Options:**
+- `position` - Timeline layout: `:left`, `:center`, `:right` (default: :left)
+
+**Slots:** `with_tag_header(text:, color:)` (badge separators) and `with_tag_item(heading:, icon:, color:)` with block content.
+
+#### TreeView
+
+File/folder-style navigation tree with expandable nested sections. Branches containing the `current_path` expand automatically and the active item is highlighted.
+
+```erb
+<%= render Bali::TreeView::Component.new(current_path: request.path) do |c| %>
+  <% c.with_item(name: 'Home', path: '/') %>
+  <% c.with_item(name: 'Documentation', path: '/docs') do |docs| %>
+    <% docs.with_item(name: 'Introduction', path: '/docs/introduction') %>
+    <% docs.with_item(name: 'Installation', path: '/docs/installation') %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `current_path` - Path of the active item, used for highlighting and auto-expanding branches (default: nil)
+
+**Slots:** `with_item(name:, path:)` — items nest recursively via a block to build sub-trees.
 
 ---
 
@@ -614,6 +1130,178 @@ delete items). Auto-installed via `registerAll` — no per-app code needed.
 Opt out globally with `window.BALI_DISABLE_CONFIRM_DIALOG = true` before
 `registerAll` runs.
 
+#### ActionsDropdown
+
+Dropdown menu for row-level actions with an ellipsis icon trigger. Items with `method: :delete` automatically render a DeleteLink with confirmation.
+
+```erb
+<%= render Bali::ActionsDropdown::Component.new(align: :end) do |c| %>
+  <% c.with_item(name: 'Edit', icon_name: 'edit', href: edit_movie_path(movie)) %>
+  <% c.with_item(name: 'Export', icon_name: 'file-export', href: export_movie_path(movie)) %>
+  <% c.with_item(name: 'Delete', icon_name: 'trash', href: movie_path(movie), method: :delete) %>
+<% end %>
+```
+
+**Options:**
+- `align` - Horizontal alignment: `:start`, `:center`, `:end` (default: `:start`)
+- `direction` - Menu direction: `:top`, `:bottom`, `:left`, `:right` (default: `nil`)
+- `icon` - Trigger icon name (default: `"ellipsis-h"`)
+- `width` - Menu width: `:sm`, `:md`, `:lg`, `:xl` (default: `:md`)
+- `popover` - Use Tippy.js popover to escape overflow containers like scrollable tables (default: `false`)
+
+Use `with_trigger` to replace the default icon button with a custom trigger element.
+
+#### BulkActions
+
+Selectable item list with a floating action bar that appears when items are selected, showing a counter and bulk action buttons.
+
+```erb
+<%= render Bali::BulkActions::Component.new do |c| %>
+  <% c.with_action(label: 'Archive', href: bulk_archive_users_path, variant: :info) %>
+  <% c.with_action(label: 'Delete', href: bulk_delete_users_path, variant: :error) %>
+
+  <% @users.each do |user| %>
+    <% c.with_item(record_id: user.id, class: 'flex items-center gap-3 p-3') do %>
+      <input type="checkbox" class="checkbox checkbox-sm">
+      <p><%= user.name %></p>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `**options` - HTML attributes for the wrapper (e.g. `class`, `data`)
+
+#### Carousel
+
+Image/content carousel powered by Glide.js with optional arrows, bullets, autoplay, and multi-slide layouts.
+
+```erb
+<%= render Bali::Carousel::Component.new(slides_per_view: 3, gap: 16, autoplay: :slow) do |c| %>
+  <% c.with_arrows %>
+  <% c.with_bullets %>
+
+  <% @images.each do |image| %>
+    <% c.with_item do %>
+      <%= image_tag image, class: 'w-full rounded-lg' %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `slides_per_view` - Number of slides visible at once (default: `1`)
+- `start_at` - Index of the initial slide (default: `0`)
+- `autoplay` - `:disabled`, `:slow` (5s), `:medium` (3s), `:fast` (1.5s), or milliseconds (default: `:disabled`)
+- `gap` - Space between slides in pixels (default: `0`)
+- `focus_at` - Which slide to focus: `:center` or an index (default: `:center`)
+- `breakpoints` - Hash of responsive settings passed to Glide.js (default: `nil`)
+- `peek` - Pixels of adjacent slides to show at the edges (default: `nil`)
+
+#### Clipboard
+
+Copy-to-clipboard button with visual success feedback (shown for 2 seconds after copying).
+
+```erb
+<%= render Bali::Clipboard::Component.new do |c| %>
+  <% c.with_trigger('Copy') %>
+  <% c.with_success_content('Copied!') %>
+  <% c.with_source('https://example.com/api/v1/token/abc123xyz') %>
+<% end %>
+```
+
+**Options:**
+- `**options` - HTML attributes for the wrapper; customize feedback duration with `data: { clipboard_success_duration_value: 3000 }`
+
+#### DeleteLink
+
+Delete button that submits a DELETE request and automatically triggers the styled ConfirmDialog (danger variant) before submitting.
+
+```erb
+<%= render Bali::DeleteLink::Component.new(model: @movie) %>
+<%= render Bali::DeleteLink::Component.new(href: movie_path(@movie), name: 'Remove', size: :sm, icon: true) %>
+```
+
+**Options:**
+- `model` - Record used to build the URL and the confirmation message (default: `nil`)
+- `href` - Explicit URL; either `model` or `href` is required (default: `nil`)
+- `name` - Button label (default: translated "Delete")
+- `confirm` - Custom confirmation message (default: `nil`, generated from model)
+- `size` - `:xs`, `:sm`, `:md`, `:lg` (default: `nil`)
+- `disabled` - Disable the button (default: `false`)
+- `disabled_hover_url` - URL for a hover card explaining why deletion is disabled (default: `nil`)
+- `skip_confirm` - Skip the confirmation dialog (default: `false`)
+- `icon` - Show a trash icon (default: `false`)
+- `icon_name` - Custom icon name (default: `nil`)
+- `authorized` - When `false`, the component does not render (default: `true`)
+- `plain` - Render as a plain text link instead of a button (default: `false`)
+- `form_class` - Extra classes for the wrapping form (default: `nil`)
+
+#### HoverCard
+
+Popup card that displays content on hover (or click), positioned with Tippy.js. Content can be inline or lazy-loaded from a URL.
+
+```erb
+<%= render Bali::HoverCard::Component.new(placement: 'top', hover_url: user_summary_path(@user)) do |c| %>
+  <% c.with_trigger do %>
+    <button class="btn btn-primary">Hover me!</button>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `hover_url` - URL to fetch content from asynchronously (default: `nil`)
+- `placement` - Tippy.js placement, e.g. `auto`, `top`, `bottom-start`, `right-end` (default: `"auto"`)
+- `open_on_click` - Open on click instead of hover (default: `false`)
+- `append_to` - Where to append the popup: `'body'`, `'parent'`, or CSS selector (default: `"body"`)
+- `z_index` - Z-index for the popup (default: `9999`)
+- `content_padding` - Add padding around the content (default: `true`)
+- `arrow` - Show an arrow pointing to the trigger (default: `true`)
+
+#### Reveal
+
+Collapsible content section toggled by a trigger with a rotating chevron indicator.
+
+```erb
+<%= render Bali::Reveal::Component.new(opened: false) do |c| %>
+  <% c.with_trigger do |trigger| %>
+    <% trigger.with_title do %>
+      <span class="text-lg font-semibold">Click to see contents</span>
+    <% end %>
+  <% end %>
+
+  <p>This content is hidden until you click the trigger above.</p>
+<% end %>
+```
+
+**Options:**
+- `opened` - Render with the content revealed initially (default: `false`)
+
+#### SortableList
+
+Drag-and-drop sortable list using SortableJS; supports handles, nested lists, and cross-list moves — this component powers the Kanban board. Dropping an item sends a PATCH to that item's `update_url` with its new `position` (and `list_id` for cross-list moves).
+
+```erb
+<%= render Bali::SortableList::Component.new(group_name: 'tasks', list_id: list.id) do |s| %>
+  <% @tasks.each do |task| %>
+    <% s.with_item(update_url: task_path(task)) do %>
+      <%= task.name %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `resource_name` - Resource name to namespace params, e.g. `'task'` sends `task[position]` (default: `nil`)
+- `position_param_name` - Name of the position param sent to the server (default: `"position"`)
+- `list_param_name` - Name of the list param sent to the server (default: `"list_id"`)
+- `group_name` - Group name linking multiple lists so items can move between them (default: `nil`)
+- `list_id` - Identifier for this list in cross-list moves (default: `nil`)
+- `response_kind` - `:html` or `:turbo_stream` (default: `:html`)
+- `handle` - CSS selector for the drag handle; without one, whole items are draggable (default: `nil`)
+- `disabled` - Disable dragging (default: `false`)
+- `animation` - Drag animation duration in milliseconds (default: `150`)
+
 ---
 
 ### Form Components
@@ -673,6 +1361,130 @@ Search field with icon.
 ) %>
 ```
 
+#### Calendar
+
+Month, week, or day calendar that displays events grouped by date, with optional navigation header and custom day templates.
+
+```erb
+<%= render Bali::Calendar::Component.new(
+  start_date: Date.current,
+  period: :month,
+  events: @events,
+  template: 'events/calendar_event'
+) do |c| %>
+  <% c.with_header(route_path: events_path) %>
+  <% c.with_footer { 'Custom footer content' } %>
+<% end %>
+```
+
+**Options:**
+- `template` - Path to an HTML partial rendered for each day's events (default: nil)
+- `start_date` - Date or string to center the calendar on (default: `Date.current`)
+- `period` - Calendar view, one of `:month`, `:week`, or `:day` (default: `:month`)
+- `events` - Array of events; each must respond to `start_attribute` (default: `[]`)
+- `start_attribute` - Method called on each event for its start date (default: `:start_time`)
+- `end_attribute` - Method called on each event for its end date, enables multi-day events (default: `:end_time`)
+- `weekdays_only` - Show only Monday-Friday (default: false)
+- `all_week` - DEPRECATED: use `weekdays_only` instead
+- `show_date` - Display the day number in each cell (default: true)
+
+**Slots:** `header` (navigation with period switch, accepts `route_path:` and `period_switch:`), `footer`.
+
+#### ImageField
+
+Image preview with an optional file input overlay for uploading/replacing an image, plus a hover clear button.
+
+```erb
+<%= form_with(model: @user) do |f| %>
+  <%= render Bali::ImageField::Component.new(src: @user.avatar_url, size: :lg) do |c| %>
+    <% c.with_input(form: f, method: :avatar) %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `src` - URL of the current image; falls back to the placeholder when nil (default: nil)
+- `placeholder_url` - Image shown when there is no `src` or after clearing (default: `https://placehold.jp/128x128.png`)
+- `size` - One of `:xs`, `:sm`, `:md`, `:lg`, `:xl` (default: `:md`)
+- `**options` - Additional HTML attributes for the container (e.g. `class`)
+
+**Slots:** `input` (file input, takes `form:` and `method:`), `clear_button` (override the default clear button).
+
+#### RichTextEditor
+
+BlockNote-based rich text editor for editing or displaying HTML content, with a hidden input for form submission.
+
+```erb
+<%= render Bali::RichTextEditor::Component.new(
+  html_content: @post.body,
+  output_input_name: 'post[body]',
+  editable: true,
+  placeholder: 'Start typing...'
+) %>
+```
+
+**Options:**
+- `html_content` - Initial HTML content to load into the editor (default: nil)
+- `output_input_name` - Name of the hidden input that receives the edited HTML (default: nil)
+- `editable` - Enable editing; false renders read-only content (default: false)
+- `placeholder` - Placeholder text shown when empty (default: "Start typing...")
+- `images_url` - Endpoint for image uploads (default: nil)
+- `page_hyperlink_options` - Options for internal page hyperlinks (default: `[]`)
+
+Only renders when `Bali.rich_text_editor_enabled` is true.
+
+#### DirectUpload
+
+Uploads files from the browser directly to cloud storage (S3, GCS, Azure) via Active Storage's DirectUpload API, with drag & drop, progress, and client-side validation.
+
+```erb
+<%= form_with(model: @document) do |f| %>
+  <%= render Bali::DirectUpload::Component.new(
+    form: f,
+    method: :attachments,
+    multiple: true,
+    max_files: 5,
+    accept: 'application/pdf,image/*'
+  ) %>
+<% end %>
+```
+
+**Options:**
+- `form` - Rails form builder object (required)
+- `method` - Attachment attribute name, e.g. `:file`, `:images` (required)
+- `multiple` - Allow selecting multiple files (default: false)
+- `max_files` - Maximum number of files when `multiple: true` (default: 10)
+- `max_file_size` - Maximum file size in megabytes (default: 10)
+- `accept` - Accepted file types, MIME types or extensions (default: `"*"`)
+- `drop_zone` - Show the drag & drop area (default: true)
+- `auto_upload` - Upload files immediately on selection (default: true)
+
+Requires Active Storage and CORS configuration on the bucket — see the [DirectUpload setup guide](direct-upload-setup.md). Client-side validation is UX only; always validate on the server.
+
+#### RecurrentEventRuleForm
+
+Form control for building RFC 5545 RRULE strings (e.g. `FREQ=WEEKLY;BYDAY=MO,WE,FR`) with controls for frequency, interval, weekdays, and end conditions.
+
+```erb
+<%= form_with(model: @event, builder: Bali::FormBuilder) do |form| %>
+  <%= render Bali::RecurrentEventRuleForm::Component.new(
+    form: form,
+    method: :schedule,
+    value: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR;COUNT=10'
+  ) %>
+<% end %>
+```
+
+Also available through the form builder as `form.recurrent_event_rule_field :schedule` or `form.recurrent_event_rule_field_group :schedule`.
+
+**Options:**
+- `form` - The form builder instance (required)
+- `method` - The attribute name, e.g. `:schedule` (required)
+- `value` - Pre-populate with an existing RRULE string (default: nil)
+- `disabled` - Disable all form controls (default: false)
+- `skip_end_method` - Hide the "End" section for rules that never end (default: false)
+- `frequency_options` - Array of allowed frequencies from `yearly`, `monthly`, `weekly`, `daily`, `hourly` (default: all)
+
 ---
 
 ### Feedback Components
@@ -701,6 +1513,286 @@ Loading indicator.
 ```erb
 <%= render Bali::Loader::Component.new(size: :lg, color: :primary) %>
 ```
+
+#### FlashNotifications
+
+Renders Rails flash messages as auto-stacking notifications at the bottom-right of the screen.
+
+```erb
+<%= render Bali::FlashNotifications::Component.new(
+  notice: flash[:notice],
+  alert: flash[:alert]
+) %>
+```
+
+**Options:**
+- `notice` - Success message to display (default: `nil`)
+- `alert` - Error/warning message to display (default: `nil`)
+
+#### Message
+
+Inline alert box (DaisyUI `alert`) with an optional title or custom header slot.
+
+```erb
+<%= render Bali::Message::Component.new(title: 'Heads up', color: :warning, style: :soft) do %>
+  Your subscription expires in 3 days.
+<% end %>
+```
+
+**Options:**
+- `title` - Header text shortcut; use the `with_header` slot for custom markup (default: `nil`)
+- `size` - Text size: `:small`, `:regular`, `:medium`, `:large` (default: `:regular`)
+- `color` - Alert color: `:primary`, `:success`, `:danger`, `:warning`, `:info` (default: `:primary`)
+- `style` - Alert style: `:soft`, `:outline`, `:dash` (default: `nil`, solid)
+
+#### FeedbackWidget
+
+Floating feedback button that opens a drawer with an embedded Opina iframe and polls a badge endpoint for unread count.
+
+```erb
+<%= render Bali::FeedbackWidget::Component.new(
+  project_slug: 'my-project',
+  opina_url: 'https://opina.example.com',
+  secret: Rails.application.credentials.opina_secret,
+  user_id: current_user.id,
+  email: current_user.email
+) %>
+```
+
+**Options:**
+- `project_slug` - The project slug in Opina (required)
+- `opina_url` - Base URL of the Opina instance (required)
+- `token` - Pre-built JWT token for embed authentication (default: `nil`)
+- `secret` - Opina shared secret to generate the token automatically (default: `nil`; either `token` or `secret` is required)
+- `user_id` - User ID for token generation, required when using `secret` (default: `nil`)
+- `email` - User email for token generation, required when using `secret` (default: `nil`)
+- `user_name` - User display name for token generation (default: `nil`)
+- `title` - Drawer header title (default: `nil`, falls back to "Feedback")
+- `token_expires_in` - Token expiry in seconds (default: `3600`)
+- `badge_interval` - Polling interval in ms for the badge count (default: `300000`)
+
+---
+
+### Documents & Editors
+
+#### BlockEditor
+
+Notion-style block editor (BlockNote) with rich text, slash commands, mentions, entity references, comments, and PDF/DOCX export. See the [BlockEditor API](../api/block-editor.md) for the full reference.
+
+```erb
+<%= render Bali::BlockEditor::Component.new(
+  editable: true,
+  placeholder: 'Start writing...',
+  input_name: 'document[content]',
+  initial_content: @document.content,
+  mentions_url: '/users',
+  export: true
+) %>
+```
+
+**Options:**
+- `initial_content` - Initial document as BlockNote JSON (Hash/Array or JSON string) (default: nil)
+- `input_name` - Hidden input name for form submission (default: nil)
+- `format` - Serialization format for the hidden input, `:json` or `:html` (default: :json)
+- `editable` - Whether the editor accepts input (default: true)
+- `placeholder` - Placeholder text for the empty editor (default: nil)
+- `upload_url` - Image upload endpoint; `:auto` resolves the engine's upload route (default: :auto)
+- `export` - Enable export; `true` for PDF+DOCX or an array like `[:pdf]` (default: false)
+- `comments` - Inline comments config hash (`url:`, `user:`, `users:`) (default: false)
+
+See the component class for the full list (`ai_url`, `mentions`, `references_url`, `multi_column`, `table_of_contents`, `theme`, ...).
+
+#### DocumentEditor
+
+Full-screen document editing overlay wrapping BlockEditor with app bar, table of contents, comments sidebar, version history (preview and restore past versions), auto-save, and Cmd+S manual save.
+
+```erb
+<%= render Bali::DocumentEditor::Component.new(
+  title: @document.title,
+  initial_content: @document.content,
+  document_url: document_path(@document),
+  close_url: document_path(@document),
+  versions_url: document_versions_path(@document),
+  comments: { url: '/block_editor_comments', user: current_user_json, users: users_json },
+  export: true
+) do |editor| %>
+  <% editor.with_toolbar do %>
+    <span class="badge badge-ghost">Draft</span>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Document title shown in the app bar (required)
+- `initial_content` - Document content as BlockNote JSON (required)
+- `document_url` - URL where saves are PATCHed (required)
+- `close_url` - URL for the close button (default: document_url)
+- `versions_url` - Version history endpoint; enables the versions panel with preview/restore (default: nil)
+- `editable` - Read-only when false (default: true)
+- `auto_save` - Save automatically while editing (default: true)
+- `auto_save_delay` - Auto-save debounce in ms (default: 30000)
+
+See the component class for the full list (`comments`, `export`, `input_name`, `ai_url`, `mentions_url`, `references_url`, ...).
+
+#### DocumentPage
+
+Document-centric page with a three-panel layout: table of contents, read-only BlockEditor content, and a collapsible metadata panel.
+
+```erb
+<%= render Bali::DocumentPage::Component.new(
+  title: 'Q2 2026 Product Roadmap',
+  subtitle: 'Last edited 2 hours ago',
+  breadcrumbs: [{ name: 'Documents', href: documents_path }, { name: 'Roadmap' }],
+  initial_content: @document.content
+) do |page| %>
+  <% page.with_title_tag do %>
+    <%= render Bali::Tag::Component.new(text: 'Published', color: :success, size: :sm) %>
+  <% end %>
+  <% page.with_action do %>
+    <%= render Bali::Link::Component.new(name: 'Edit', href: edit_document_path(@document), variant: :ghost, icon_name: 'pencil') %>
+  <% end %>
+  <% page.with_metadata do %>
+    <p>Owner: Ana</p>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Page title (required)
+- `subtitle` - Text under the title (default: nil)
+- `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+- `back` - Back link, e.g. `{ href: path }` (default: nil)
+- `initial_content` - BlockNote JSON; renders the editor and TOC when present (default: nil)
+- `toc_open` / `metadata_open` - Initial panel visibility (default: true)
+
+---
+
+### Page Templates
+
+#### DashboardPage
+
+Dashboard layout with page header, stat cards grid, and a body area for charts and cards.
+
+```erb
+<%= render Bali::DashboardPage::Component.new(title: 'Dashboard', subtitle: 'Welcome back, Ana') do |page| %>
+  <% page.with_action do %>
+    <%= render Bali::Button::Component.new(name: 'Export', variant: :ghost, icon_name: 'download') %>
+  <% end %>
+  <% page.with_stat(label: 'Total Movies', value: '1,234', icon: 'film', color: :primary) %>
+  <% page.with_stat(label: 'Revenue', value: '$45.2K', icon: 'dollar-sign', color: :success, change: '+12.5%') %>
+  <% page.with_body do %>
+    <%= render Bali::Card::Component.new(style: :bordered) { 'Recent activity...' } %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Page title (required)
+- `subtitle` - Text under the title (default: nil)
+- `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+- `stats_columns` - Stat cards per row: 2, 3, or 4 (default: 4)
+- `max_width` - Content width: `:lg`, `:xl`, `:"2xl"`, or `:full` (default: :"2xl")
+
+#### IndexPage
+
+Standard listing page with breadcrumbs, title, action buttons, and a body area for tables.
+
+```erb
+<%= render Bali::IndexPage::Component.new(
+  title: 'Movies',
+  subtitle: '24 movies total',
+  breadcrumbs: [{ name: 'Dashboard', href: root_path, icon_name: 'home' }, { name: 'Movies' }]
+) do |page| %>
+  <% page.with_action do %>
+    <%= render Bali::Link::Component.new(name: 'New Movie', href: new_movie_path, variant: :primary, icon_name: 'plus') %>
+  <% end %>
+  <% page.with_body do %>
+    <%# DataTable goes here %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Page title (required)
+- `subtitle` - Text under the title (default: nil)
+- `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+
+#### ShowPage
+
+Record detail page with breadcrumbs, title with tags, actions, and an optional two-column layout with sidebar.
+
+```erb
+<%= render Bali::ShowPage::Component.new(
+  title: 'The Matrix',
+  subtitle: 'Added 2 days ago',
+  breadcrumbs: [{ name: 'Movies', href: movies_path }, { name: 'The Matrix' }],
+  back: { href: movies_path }
+) do |page| %>
+  <% page.with_title_tag do %>
+    <%= render Bali::Tag::Component.new(text: 'Released', color: :success, size: :sm) %>
+  <% end %>
+  <% page.with_action do %>
+    <%= render Bali::Link::Component.new(name: 'Edit', href: edit_movie_path(@movie), variant: :ghost, icon_name: 'pencil') %>
+  <% end %>
+  <% page.with_body do %>
+    <%= render Bali::Card::Component.new(style: :bordered) { 'Details...' } %>
+  <% end %>
+  <% page.with_sidebar do %>
+    <%= render Bali::Card::Component.new(style: :bordered) { 'Stats...' } %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Page title (required)
+- `subtitle` - Text under the title (default: nil)
+- `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+- `back` - Back link, e.g. `{ href: path }` (default: nil)
+
+#### FormPage
+
+New/edit page that wraps form content in a centered Card, with an optional sidebar column for help text.
+
+```erb
+<%= render Bali::FormPage::Component.new(
+  title: 'New Movie',
+  breadcrumbs: [{ name: 'Movies', href: movies_path }, { name: 'New' }],
+  back: { href: movies_path }
+) do |page| %>
+  <% page.with_body do %>
+    <%= form_with model: @movie do |f| %>
+      <%# form fields %>
+    <% end %>
+  <% end %>
+  <% page.with_sidebar do %>
+    <p class="text-base-content/60">Tips for filling out this form.</p>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `title` - Page title (required)
+- `subtitle` - Text under the title (default: nil)
+- `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+- `back` - Back link, e.g. `{ href: path }` (default: nil)
+- `max_width` - Form width: `:sm`, `:md`, `:lg`, `:xl`, or `:full` (default: :md)
+- `card` - Wrap the body in a Card (default: true)
+
+---
+
+### Utilities
+
+#### ThemeSampler
+
+Lookbook-only preview gallery that renders Bali components (buttons, tags, cards, alerts, form inputs) under a DaisyUI theme to compare color palettes at a glance.
+
+```erb
+<%# Not a renderable component — browse it in Lookbook instead: %>
+<%# http://localhost:3001/lookbook/preview/bali/theme_sampler/costa_norte %>
+```
+
+**Options:**
+- None — there is no `Bali::ThemeSampler::Component` class; it exists only as a Lookbook preview (`app/components/bali/theme_sampler/preview.rb`) using a theme-specific layout (e.g. Costa Norte).
 
 ---
 

--- a/docs/guides/form-builder.md
+++ b/docs/guides/form-builder.md
@@ -204,6 +204,16 @@ Native HTML select with DaisyUI styling.
 <%= f.select_group :country, Country.all.map { |c| [c.name, c.id] }, include_blank: "Select country" %>
 ```
 
+**Non-model forms** (`form_with url:` without a model): pass `input_name:` /
+`input_id:` in the options hash to namespace the rendered `<select>` under a
+param key. Also supported by `slim_select_group`. An explicit `name:`/`id:`
+in the html options hash still wins.
+
+```erb
+<%= f.select_group :approver_id, approvers, input_name: "thing[approver_id]" %>
+<%# => <select name="thing[approver_id]" ...> — works with params.require(:thing) %>
+```
+
 ### slim_select_group / slim_select_field
 
 Enhanced select with search, multi-select, and AJAX support.

--- a/docs/guides/javascript-integration.md
+++ b/docs/guides/javascript-integration.md
@@ -221,7 +221,7 @@ import { DatepickerController, TableController } from 'bali-view-components'
 
 // Avoid: Register all if you only need a few
 import { registerAll } from 'bali-view-components'
-registerAll(application)  // Includes all 40+ controllers
+registerAll(application)  // Includes all 50+ controllers (and installs the confirm dialog)
 ```
 
 ### Code Splitting


### PR DESCRIPTION
## Análisis

Auditoría de toda la documentación del repo contra el código real (75 componentes) tras el release v2.11.0.

| Documento | Estado encontrado | Fix |
|---|---|---|
| `README.md` | Decía "48+ componentes"; categorías y tabla de status omitían **29 componentes** (Kanban, ConfirmDialog, DocumentEditor, DirectUpload, Command, FeedbackWidget, page templates, Skeleton, StatCard…) | Conteo 75+, categorías completas (con secciones nuevas *Documents & Editors* y *Page Templates*), tabla de status con las 75 filas y flags reales de preview/docs/tests |
| `.claude/CLAUDE.md` (guía para agentes) | Decía "40+"; catálogo con los mismos huecos; sin las APIs de v2.11 | Catálogo completo + gotchas nuevos (`input_name:` en selects sin modelo, turbo_stream en Drawer/Modal) |
| `CLAUDE.md` raíz | "40+" | 75+ |
| `docs/guides/components.md` | 21/75 componentes con sección; sin los features de v2.11 | Secciones nuevas: Stepper (sublabel), ImageGrid (empty_state + i18n), Kanban (footer), ConfirmDialog, y patrón turbo_stream en Modal/Drawer con ejemplo de controller |
| `docs/guides/form-builder.md` | No documentaba `input_name:`/`input_id:` | Documentado con ejemplo de `params.require` |
| `docs/guides/javascript-integration.md` | "40+ controllers" | 50+ y nota del confirm dialog auto-instalado |
| `MIGRATION_STATUS.md` | Obsoleto: última entrada 2026-01-25, referencias a archivos borrados | Banner de migración completa (histórico), referencias muertas anotadas |
| `CHANGELOG.md`, Lookbook | Al día (75/75 componentes con preview) | — |

## ~~Fuera de alcance~~ (resuelto en el 2º commit)

- `components.md` cubre 25/75 componentes con sección propia; Lookbook es el catálogo canónico interactivo. Completar las 50 secciones restantes puede ir por partes si se desea.

## Verificación

- Minitest: 2614 runs, 0 failures (los docs no tocan código, sanity).
- Conteos verificados por script contra `app/components/bali/` (75 dirs de componente reales) y `test/bali/components/` para los flags de la tabla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)