### PR TITLE
feat(data_table): filter persistence for SimpleFilters (storage_id/persist_enabled) (#612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **DataTable / SimpleFilters** - `SimpleFilters::Component` now accepts `storage_id:` and `persist_enabled:`, rendering the same bookmark persistence toggle as `Bali::Filters` (wired to the `filter-persistence` Stimulus controller, which stores the user's on/off preference in `localStorage` + a `bali_persist_<storage_id>` cookie for server-side access). `DataTable#with_simple_filters` auto-populates both from the `FilterForm` (mirroring `with_filters_panel`), so screens using SimpleFilters no longer lose their filters on redirects. The toggle only renders when a `storage_id` is present; restoring filter *values* remains the consuming app's server-side responsibility. Backwards compatible.
+
 ## [v2.12.0] - 2026-07-16
 
 ### Added

--- a/app/components/bali/data_table/component.rb
+++ b/app/components/bali/data_table/component.rb
@@ -104,17 +104,27 @@ module Bali
       #   data_table.with_simple_filters(filters: [
       #     { attribute: :status, collection: [["Active", "active"]], blank: "All" }
       #   ])
-      renders_one :simple_filters, ->(filters: nil, search: nil) do
+      renders_one :simple_filters, ->(filters: nil, search: nil, storage_id: nil, persist_enabled: nil) do
         resolved_filters = filters || @filter_form&.simple_filters_config || []
         resolved_search = search || @filter_form&.simple_search_config
         filters_active = @filter_form&.simple_filters_active? || false
         search_active = resolved_search&.dig(:value).present?
 
+        # Auto-populate storage_id from filter_form unless explicitly provided
+        storage_id ||= @filter_form&.storage_id if @filter_form.respond_to?(:storage_id)
+
+        # Auto-populate persist_enabled from filter_form unless explicitly provided
+        if persist_enabled.nil? && @filter_form.respond_to?(:persist_enabled?)
+          persist_enabled = @filter_form.persist_enabled?
+        end
+
         SimpleFilters::Component.new(
           url: @url,
           filters: resolved_filters,
           show_clear: filters_active || search_active,
-          search: resolved_search
+          search: resolved_search,
+          storage_id: storage_id,
+          persist_enabled: persist_enabled || false
         )
       end
 

--- a/app/components/bali/data_table/simple_filters/component.html.erb
+++ b/app/components/bali/data_table/simple_filters/component.html.erb
@@ -155,6 +155,30 @@
           responsive: true
         ) %>
       <% end %>
+
+      <%# Persistence toggle (bookmark icon) %>
+      <% if persistence_available? %>
+        <div class="max-sm:overflow-hidden" data-controller="filter-persistence"
+             data-filter-persistence-storage-id-value="<%= @storage_id %>"
+             data-filter-persistence-enabled-value="<%= persist_enabled? %>">
+          <button type="button"
+                  class="tooltip tooltip-bottom btn btn-ghost btn-sm btn-square"
+                  data-action="filter-persistence#toggle"
+                  data-filter-persistence-target="button"
+                  data-filter-persistence-enabled-tooltip="<%= t('bali.filters.persistence_enabled', default: 'Filters are being saved. Click to disable.') %>"
+                  data-filter-persistence-disabled-tooltip="<%= t('bali.filters.persistence_disabled', default: 'Filters are not saved. Click to enable.') %>"
+                  data-tip="<%= persist_enabled? ? t('bali.filters.persistence_enabled', default: 'Filters are being saved. Click to disable.') : t('bali.filters.persistence_disabled', default: 'Filters are not saved. Click to enable.') %>">
+            <%# Filled bookmark when enabled %>
+            <span data-filter-persistence-target="iconEnabled" class="<%= 'hidden' unless persist_enabled? %>">
+              <%= render Bali::Icon::Component.new('bookmark-check', class: 'w-5 h-5 text-primary') %>
+            </span>
+            <%# Outline bookmark when disabled %>
+            <span data-filter-persistence-target="iconDisabled" class="<%= 'hidden' if persist_enabled? %>">
+              <%= render Bali::Icon::Component.new('bookmark', class: 'w-5 h-5 text-base-content/40') %>
+            </span>
+          </button>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/components/bali/data_table/simple_filters/component.rb
+++ b/app/components/bali/data_table/simple_filters/component.rb
@@ -31,11 +31,15 @@ module Bali
         #   - :placeholder [String, nil] Placeholder text
         #   - :label [String, nil] Custom label (defaults to I18n)
         #   - :width [String, nil] Tailwind width classes (default: "w-48 sm:w-96")
-        def initialize(url:, filters: [], show_clear: false, search: nil)
+        # @param storage_id [String, nil] Optional storage ID indicating filters can be persisted
+        # @param persist_enabled [Boolean] Whether user has opted into filter persistence
+        def initialize(url:, filters: [], show_clear: false, search: nil, storage_id: nil, persist_enabled: false)
           @url = url
           @filters = filters
           @show_clear = show_clear
           @search = search
+          @storage_id = storage_id
+          @persist_enabled = persist_enabled
         end
 
         def render?
@@ -44,6 +48,16 @@ module Bali
 
         def show_clear?
           @show_clear
+        end
+
+        # Returns true if persistence is available (storage_id is configured)
+        def persistence_available?
+          @storage_id.present?
+        end
+
+        # Returns true if user has enabled persistence
+        def persist_enabled?
+          @persist_enabled
         end
 
         def search_enabled?

--- a/app/components/bali/data_table/simple_filters/preview.rb
+++ b/app/components/bali/data_table/simple_filters/preview.rb
@@ -320,6 +320,34 @@ module Bali
             show_clear: status.present? || country.present?
           )
         end
+
+        # @label With Persistence
+        # A bookmark toggle appears next to the actions when `storage_id` is set,
+        # letting users opt into persisting their filters across visits. The
+        # preference is stored in localStorage + a cookie by the
+        # `filter-persistence` controller (mirrors Bali::Filters).
+        #
+        # @param status select { choices: ["", active, inactive] }
+        # @param persist_enabled toggle
+        def with_persistence(status: '', persist_enabled: false)
+          filters = [
+            {
+              attribute: :status,
+              collection: [%w[Active active], %w[Inactive inactive]],
+              blank: 'All Statuses',
+              label: 'Status',
+              value: status.presence
+            }
+          ]
+
+          render Bali::DataTable::SimpleFilters::Component.new(
+            url: '/lookbook',
+            filters: filters,
+            show_clear: status.present?,
+            storage_id: 'lookbook_simple_filters',
+            persist_enabled: persist_enabled
+          )
+        end
       end
     end
   end

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -484,4 +484,56 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
 
     assert_selector("input[type='number'][step='1']", count: 2)
   end
+
+  # Persistence toggle tests
+
+  def test_persistence_available_returns_false_when_no_storage_id
+    component = Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters)
+    refute(component.persistence_available?)
+  end
+
+  def test_persistence_available_returns_true_when_storage_id_is_present
+    component = Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters")
+    assert(component.persistence_available?)
+  end
+
+  def test_persist_enabled_returns_false_by_default
+    component = Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters")
+    refute(component.persist_enabled?)
+  end
+
+  def test_persist_enabled_returns_true_when_explicitly_enabled
+    component = Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters", persist_enabled: true)
+    assert(component.persist_enabled?)
+  end
+
+  def test_does_not_render_persistence_toggle_when_storage_id_is_absent
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters))
+    assert_no_selector('[data-controller="filter-persistence"]')
+  end
+
+  def test_renders_persistence_toggle_when_storage_id_is_present
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters"))
+    assert_selector('[data-controller="filter-persistence"]')
+    assert_selector('[data-filter-persistence-storage-id-value="records_filters"]')
+  end
+
+  def test_persistence_toggle_shows_disabled_icon_by_default
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters"))
+    assert_selector('[data-filter-persistence-target="iconDisabled"]:not(.hidden)')
+    assert_selector('[data-filter-persistence-target="iconEnabled"].hidden')
+    assert_selector('[data-filter-persistence-enabled-value="false"]')
+  end
+
+  def test_persistence_toggle_shows_enabled_icon_when_persist_enabled_is_true
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, storage_id: "records_filters", persist_enabled: true))
+    assert_selector('[data-filter-persistence-target="iconEnabled"]:not(.hidden)')
+    assert_selector('[data-filter-persistence-target="iconDisabled"].hidden')
+    assert_selector('[data-filter-persistence-enabled-value="true"]')
+  end
+
+  def test_persistence_toggle_renders_with_search_only_and_no_filters
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: [], search: @search, storage_id: "records_filters"))
+    assert_selector('[data-controller="filter-persistence"]')
+  end
 end


### PR DESCRIPTION
Closes #612.

## What

Brings the filter-persistence sticky (opt-in save/restore) that `Bali::Filters` already has to `Bali::DataTable::SimpleFilters`, so screens whose collection isn't expressible via Ransack (and therefore use `SimpleFilters` instead of `FilterForm`) can persist their filters across redirects without hand threading `params[:q]`.

## Changes

- **`SimpleFilters::Component`** — new `storage_id:` / `persist_enabled:` kwargs plus `persistence_available?` / `persist_enabled?` helpers, mirroring `Bali::Filters::Component` exactly.
- **`simple_filters/component.html.erb`** — renders the persistence toggle (bookmark button) when `persistence_available?`, reusing the identical `data-controller="filter-persistence"` markup, icons (`bookmark-check`/`bookmark`), targets and `bali.filters.persistence_enabled/disabled` i18n keys already used by `Bali::Filters`. Placed inline in the actions row next to Filter/Clear; renders for both the filters+search and search-only layouts.
- **`DataTable#simple_filters` slot** — accepts optional `storage_id:`/`persist_enabled:` and auto-populates them from the `filter_form` (same `respond_to?` guard style as `filters_panel`).
- **Preview** — new "With Persistence" variant.
- **Tests** — +9 (helpers, toggle present/absent by `storage_id`, icon-visibility + enabled-value state, search-only case).

## Scope

Reuses the existing `filter-persistence-controller.js` — it persists only the user's on/off **preference** (localStorage + `bali_persist_<storage_id>` cookie for server-side access). Server-side restoration of filter **values** stays the consuming app's responsibility, exactly as with `Bali::Filters`. Backwards compatible — no behavior change unless `storage_id` is passed.

## Verification

- Targeted tests + full suite via pre-push hook: **2658 runs, 0 failures**.
- Rubocop clean.
- Browser-verified in Lookbook (`simple_filters/with_persistence`): toggle renders; clicking flips `localStorage`→`true`, cookie→`1`, and the filled-bookmark/enabled state persists across the Turbo reload. Screenshot of both states captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
