### PR TITLE
feat(tooltip): expose append_to to portal the balloon out of overflow ancestors (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Tooltip** - new `append_to:` option (default `:parent`) controls where the balloon is portaled in the DOM. Pass `:body` or a CSS-selector String to portal the balloon out of ancestors with `overflow` (wide tables in `overflow-x-auto`, cards with `overflow-hidden`) that would otherwise clip it. Balloon styling now applies via a global `bali` tippy theme (`.tippy-box[data-theme~='bali']`) so it renders correctly wherever the box is appended. Backwards compatible — the default `:parent` behavior and appearance are unchanged.
+
 ## [v2.12.0] - 2026-07-16
 
 ### Added

--- a/app/components/bali/tooltip/component.rb
+++ b/app/components/bali/tooltip/component.rb
@@ -15,9 +15,14 @@ module Bali
       CONTROLLER = "tooltip"
 
       # NOTE: The `trigger_event` parameter is named to avoid collision with the `trigger` slot
-      def initialize(placement: :top, trigger_event: "mouseenter focus", **options)
+      #
+      # `append_to` controls where the balloon is portaled in the DOM. Defaults to
+      # `:parent` (rendered inside the trigger). Pass `:body` or a CSS-selector String
+      # to portal the balloon out of ancestors with `overflow` that would clip it.
+      def initialize(placement: :top, trigger_event: "mouseenter focus", append_to: :parent, **options)
         @placement = placement&.to_sym
         @trigger_event = trigger_event
+        @append_to = append_to
         @options = options
       end
 
@@ -41,18 +46,23 @@ module Bali
 
       private
 
-      attr_reader :placement, :trigger_event, :options
+      attr_reader :placement, :trigger_event, :append_to, :options
 
       def stimulus_data
         {
           controller: CONTROLLER,
           "#{CONTROLLER}-placement-value": placement_value,
-          "#{CONTROLLER}-trigger-value": trigger_event
+          "#{CONTROLLER}-trigger-value": trigger_event,
+          "#{CONTROLLER}-append-to-value": append_to_value
         }
       end
 
       def placement_value
         POSITIONS.fetch(placement, "top")
+      end
+
+      def append_to_value
+        append_to.to_s
       end
     end
   end

--- a/app/components/bali/tooltip/index.css
+++ b/app/components/bali/tooltip/index.css
@@ -1,4 +1,7 @@
 /* Tooltip component - Tippy.js styling */
+
+/* Trigger styling stays scoped to the component wrapper — the trigger
+   always lives inside `.tooltip-component`. */
 .tooltip-component {
 
   &.help-tip {
@@ -17,66 +20,68 @@
       @apply inline-flex justify-center items-center text-base;
     }
   }
+}
 
-  .tippy-box {
-    @apply relative bg-neutral text-neutral-content rounded;
-    @apply text-sm tracking-normal normal-case leading-relaxed;
-    @apply whitespace-normal outline-none;
-    transition-property: transform, visibility, opacity;
+/* Balloon styling is keyed to the `bali` tippy theme and left global so it
+   applies wherever the box is appended (parent, body, or a custom selector). */
+.tippy-box[data-theme~='bali'] {
+  @apply relative bg-neutral text-neutral-content rounded;
+  @apply text-sm tracking-normal normal-case leading-relaxed;
+  @apply whitespace-normal outline-none;
+  transition-property: transform, visibility, opacity;
 
-    &[data-animation='fade'][data-state='hidden'] {
-      @apply opacity-0;
-    }
+  &[data-animation='fade'][data-state='hidden'] {
+    @apply opacity-0;
+  }
 
-    &[data-placement^='top'] > .tippy-arrow {
-      @apply bottom-0;
-    }
+  &[data-placement^='top'] > .tippy-arrow {
+    @apply bottom-0;
+  }
 
-    &[data-placement^='top'] > .tippy-arrow:before {
-      bottom: -7px;
-      @apply left-0;
-      border-width: 8px 8px 0;
-      border-top-color: initial;
-      transform-origin: center top;
-    }
+  &[data-placement^='top'] > .tippy-arrow:before {
+    bottom: -7px;
+    @apply left-0;
+    border-width: 8px 8px 0;
+    border-top-color: initial;
+    transform-origin: center top;
+  }
 
-    &[data-placement^='bottom'] > .tippy-arrow {
-      @apply top-0;
-    }
+  &[data-placement^='bottom'] > .tippy-arrow {
+    @apply top-0;
+  }
 
-    &[data-placement^='bottom'] > .tippy-arrow:before {
-      top: -7px;
-      @apply left-0;
-      border-width: 0 8px 8px;
-      border-bottom-color: initial;
-      transform-origin: center bottom;
-    }
+  &[data-placement^='bottom'] > .tippy-arrow:before {
+    top: -7px;
+    @apply left-0;
+    border-width: 0 8px 8px;
+    border-bottom-color: initial;
+    transform-origin: center bottom;
+  }
 
-    &[data-placement^='left'] > .tippy-arrow {
-      @apply right-0;
-    }
+  &[data-placement^='left'] > .tippy-arrow {
+    @apply right-0;
+  }
 
-    &[data-placement^='left'] > .tippy-arrow:before {
-      border-width: 8px 0 8px 8px;
-      border-left-color: initial;
-      right: -7px;
-      transform-origin: center left;
-    }
+  &[data-placement^='left'] > .tippy-arrow:before {
+    border-width: 8px 0 8px 8px;
+    border-left-color: initial;
+    right: -7px;
+    transform-origin: center left;
+  }
 
-    &[data-placement^='right'] > .tippy-arrow {
-      @apply left-0;
-    }
+  &[data-placement^='right'] > .tippy-arrow {
+    @apply left-0;
+  }
 
-    &[data-placement^='right'] > .tippy-arrow:before {
-      left: -7px;
-      border-width: 8px 8px 8px 0;
-      border-right-color: initial;
-      transform-origin: center right;
-    }
+  &[data-placement^='right'] > .tippy-arrow:before {
+    left: -7px;
+    border-width: 8px 8px 8px 0;
+    border-right-color: initial;
+    transform-origin: center right;
+  }
 
-    &[data-inertia][data-state='visible'] {
-      transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
-    }
+  &[data-inertia][data-state='visible'] {
+    transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
   }
 
   .tippy-arrow {

--- a/app/components/bali/tooltip/index.js
+++ b/app/components/bali/tooltip/index.js
@@ -4,7 +4,8 @@ export class TooltipController extends Controller {
   static targets = ['content', 'trigger']
   static values = {
     placement: { type: String, default: 'top' },
-    trigger: { type: String, default: 'mouseenter focus' }
+    trigger: { type: String, default: 'mouseenter focus' },
+    appendTo: { type: String, default: 'parent' }
   }
 
   async connect () {
@@ -14,13 +15,26 @@ export class TooltipController extends Controller {
 
     this.tippy = tippy(this.triggerTarget, {
       allowHTML: true,
-      appendTo: 'parent',
+      appendTo: this.appendToOption,
       content: this.contentTarget.content,
       placement: this.placementValue,
       trigger: this.triggerValue,
+      theme: 'bali',
       arrow: true,
       offset: [0, 24]
     })
+  }
+
+  // Resolves the `appendTo` value into a tippy.js `appendTo` option.
+  // 'parent' keeps the balloon inside the trigger (default). 'body' or a
+  // CSS selector portals it out of clipping ancestors.
+  get appendToOption () {
+    const value = this.appendToValue
+
+    if (value === 'parent') return 'parent'
+    if (value === 'body') return () => document.body
+
+    return () => document.querySelector(value) || document.body
   }
 
   disconnect () {

--- a/app/components/bali/tooltip/preview.rb
+++ b/app/components/bali/tooltip/preview.rb
@@ -5,32 +5,39 @@ module Bali
     class Preview < ApplicationViewComponentPreview
       # @param placement select { choices: [top, bottom, left, right] }
       # @param trigger_event select { choices: [mouseenter focus, click, manual] }
-      def default(placement: :top, trigger_event: 'mouseenter focus')
+      def default(placement: :top, trigger_event: "mouseenter focus")
         render Tooltip::Component.new(placement: placement, trigger_event: trigger_event) do |c|
-          c.with_trigger { tag.span 'Hover me', class: 'link link-primary' }
-          tag.p 'Hi, this is the tooltip content'
+          c.with_trigger { tag.span "Hover me", class: "link link-primary" }
+          tag.p "Hi, this is the tooltip content"
         end
       end
 
       # Shows tooltip behavior when content is empty (no tooltip appears)
       def empty_tooltip
         render Tooltip::Component.new do |c|
-          c.with_trigger { tag.span 'Link without tooltip', class: 'link' }
+          c.with_trigger { tag.span "Link without tooltip", class: "link" }
         end
       end
 
       # Common pattern: help icon with tooltip explanation
       def help_tip
-        render Tooltip::Component.new(class: 'help-tip') do |c|
+        render Tooltip::Component.new(class: "help-tip") do |c|
           c.with_trigger do
-            tag.span '?',
-                     class: 'w-6 h-6 rounded-full border border-neutral flex items-center justify-center text-sm'
+            tag.span "?",
+                     class: "w-6 h-6 rounded-full border border-neutral flex items-center justify-center text-sm"
           end
-          tag.p 'Hi, this is the help tip content'
+          tag.p "Hi, this is the help tip content"
         end
       end
 
       def all_placements
+        render_with_template
+      end
+
+      # Portals the balloon to <body> with `append_to: :body` so it escapes a
+      # clipping ancestor. Both triggers sit inside an `overflow-hidden` box:
+      # the default (`:parent`) balloon is clipped, the `:body` one escapes.
+      def escapes_overflow
         render_with_template
       end
     end

--- a/app/components/bali/tooltip/previews/escapes_overflow.html.erb
+++ b/app/components/bali/tooltip/previews/escapes_overflow.html.erb
@@ -1,0 +1,19 @@
+<div class="flex justify-center items-center gap-16 p-16">
+  <div class="relative w-40 h-20 overflow-hidden border border-base-300 rounded flex items-center justify-center">
+    <%= render Bali::Tooltip::Component.new(placement: :top) do |c| %>
+      <% c.with_trigger do %>
+        <span class="btn btn-sm">Clipped (parent)</span>
+      <% end %>
+      <p>The default balloon is clipped by the overflow-hidden container.</p>
+    <% end %>
+  </div>
+
+  <div class="relative w-40 h-20 overflow-hidden border border-base-300 rounded flex items-center justify-center">
+    <%= render Bali::Tooltip::Component.new(placement: :top, append_to: :body) do |c| %>
+      <% c.with_trigger do %>
+        <span class="btn btn-sm btn-primary">Escapes (body)</span>
+      <% end %>
+      <p>This balloon is portaled to &lt;body&gt; and escapes the container.</p>
+    <% end %>
+  </div>
+</div>

--- a/test/bali/components/tooltip_test.rb
+++ b/test/bali/components/tooltip_test.rb
@@ -104,6 +104,27 @@ class BaliTooltipComponentTest < ComponentTestCase
     assert_selector('#tooltip-1[role="tooltip"]')
   end
 
+  def test_append_to_defaults_to_parent
+    render_inline(Bali::Tooltip::Component.new) do |c|
+      c.with_trigger { c.tag.span "Hover" }
+    end
+    assert_selector('[data-tooltip-append-to-value="parent"]')
+  end
+
+  def test_append_to_body_sets_body_value
+    render_inline(Bali::Tooltip::Component.new(append_to: :body)) do |c|
+      c.with_trigger { c.tag.span "Hover" }
+    end
+    assert_selector('[data-tooltip-append-to-value="body"]')
+  end
+
+  def test_append_to_accepts_css_selector_string
+    render_inline(Bali::Tooltip::Component.new(append_to: "#portal")) do |c|
+      c.with_trigger { c.tag.span "Hover" }
+    end
+    assert_selector('[data-tooltip-append-to-value="#portal"]')
+  end
+
   def test_trigger_slot_renders_custom_trigger_content
     render_inline(Bali::Tooltip::Component.new) do |c|
       c.with_trigger { c.tag.button "Click me", class: "btn btn-primary" }


### PR DESCRIPTION
Closes #611.

## What

Adds an `append_to:` option to `Bali::Tooltip::Component` so the tooltip balloon can be portaled out of ancestors with `overflow-hidden` / `overflow-x-auto` (wide tables, rounded cards) that otherwise clip it. Defaults to today's behavior.

## Changes

- **`Component#initialize`** — new `append_to:` param (default `:parent`). Accepts `:parent`, `:body`, or a CSS-selector string; exposed as the `tooltip-append-to-value` Stimulus value.
- **`index.js`** — resolves the value to tippy's `appendTo` (`'parent'` → parent, `'body'` → `() => document.body`, selector → `document.querySelector(...) || document.body`) and always passes `theme: 'bali'`.
- **`index.css`** — the balloon styles (`.tippy-box` / `.tippy-arrow` / `.tippy-content` + placement arrows) move out of the `.tooltip-component` scope into a global, theme-keyed `.tippy-box[data-theme~='bali']` block, so they apply wherever the box is appended. Trigger styling (`.help-tip` / `.trigger`) stays scoped. Recompiled `tailwind.css`.
- **Preview** — new `escapes_overflow` variant: two identical `relative overflow-hidden` boxes; the default balloon clips, the `append_to: :body` balloon escapes.
- **Tests** — assert the Stimulus value renders `parent` by default and `body` when set.

## Verification

- Full suite via pre-push hook: **2652 runs, 0 failures**. Rubocop clean.
- Browser-verified in Lookbook:
  - `tooltip/escapes_overflow`: default (`parent`) balloon is clipped by the container (only the arrow peeks out); `append_to: :body` balloon renders fully and styled, with its tippy root confirmed (via DOM) as a direct child of `<body>`.
  - `tooltip/help_tip`: no regression — the circular badge and the themed balloon both render correctly after the CSS scope migration.

## Compatibility

Backwards compatible — `append_to` defaults to `:parent` and the balloon renders identically to before (now via the `bali` theme). No API changes for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
