### PR TITLE
fix(dummy): keep bin/dev alive (tailwind @source paths + watch=always)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rolled up all open Dependabot version bumps into one update. npm: `daisyui` 5.6.17 → 5.6.18. Gems (dev): `yard` 0.9.44 → 0.9.45, `simplecov` 0.22.0 → 1.0.2 (1.0 vendors its former runtime deps `docile`/`simplecov-html`/`simplecov_json_formatter`, which drop out of the lockfile). CI: `actions/setup-node` v6 → v7 across all workflows. Supersedes Dependabot PRs #615–#618.
 
+### Fixed
+
+- **Dev server (dummy app)** - `bin/dev` no longer dies on startup. Two bugs in `spec/dummy` broke it: (1) four `@source` directives in `app/assets/tailwind/application.css` had one extra `../` and pointed at non-existent directories, which is harmless for `tailwindcss build` but makes `--watch` fail with `ENOENT`; corrected to the real `app/{views,helpers,javascript}` and `public` paths (the dummy app's own sources are now scanned for classes too). (2) Tailwind v4's `--watch` exits when stdin closes under foreman, tearing down the whole process group — `Procfile.dev` now uses `tailwindcss:watch[always]` (`--watch=always`) so the watcher stays alive. Dev-only; no consumer-facing change.
+
 ## [v2.12.1] - 2026-07-17
 
 ### Added

--- a/spec/dummy/Procfile.dev
+++ b/spec/dummy/Procfile.dev
@@ -1,3 +1,3 @@
 web: bin/rails server -p 3001
-tailwind: bin/rails tailwindcss:watch
+tailwind: bin/rails "tailwindcss:watch[always]"
 js: yarn build:watch

--- a/spec/dummy/app/assets/tailwind/application.css
+++ b/spec/dummy/app/assets/tailwind/application.css
@@ -7,11 +7,11 @@
    Source Paths - Tailwind class scanning
    ============================================== */
 
-/* Dummy app sources */
-@source "../../../views/**/*.erb";
-@source "../../../helpers/**/*.rb";
-@source "../../../javascript/**/*.js";
-@source "../../../../public/*.html";
+/* Dummy app sources (relative to this file at app/assets/tailwind/) */
+@source "../../views/**/*.erb";
+@source "../../helpers/**/*.rb";
+@source "../../javascript/**/*.js";
+@source "../../../public/*.html";
 
 /* Bali ViewComponents sources (via node_modules symlink) */
 @source "../../../node_modules/bali-view-components/app/components/**/*.{erb,rb}";


### PR DESCRIPTION
## Problem

`bin/dev` in the dummy app dies on startup: the `tailwind` foreman process exits and takes the whole stack down with it (`system | sending SIGTERM to all processes`), so the server never stays up.

```
tailwind.1 | error: No such file or directory
tailwind.1 | exited with code 0
system     | sending SIGTERM to all processes
```

## Root causes (two, both fixed here)

1. **Wrong `@source` paths.** Four directives in `spec/dummy/app/assets/tailwind/application.css` had one extra `../`, resolving to `spec/dummy/{views,helpers,javascript}` and `spec/dummy/../public` — none of which exist (the real dirs are under `app/`). `tailwindcss build` silently tolerates missing globs, but `--watch` registers a filesystem watcher per `@source` dir and dies with **ENOENT** on the missing ones. Corrected to `../../{views,helpers,javascript}` and `../../../public`. Side benefit: the dummy app's own sources are now actually scanned for Tailwind classes (they weren't before).
2. **Tailwind v4 `--watch` exits when stdin closes**, which foreman does. So even after fix #1, the watcher exited (code 0) and foreman tore everything down. Switched the Procfile to `tailwindcss:watch[always]`, which the tailwindcss-rails gem turns into `--watch=always` so the watcher survives under foreman.

## Verification

Ran the full `bin/dev` stack: `web` + `tailwind` + `js` all stay up, Lookbook previews serve `200`, and the tailwind watcher survives past the first build (`Done in 2s`, then keeps watching) instead of exiting. Full test suite green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)