### PR TITLE
fix(drawer,modal): confirm before discarding unsaved forms on close + flatpickr Escape guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Drawer / Modal** - a form inside a `Bali::Drawer` no longer silently discards typed input when the user presses Escape or clicks the overlay (#619). The drawer now tracks edits and, while the form is dirty, asks for confirmation (via the DaisyUI `confirmDialog`, not `window.confirm`) before closing; a successful submit still closes without prompting. A flatpickr calendar opened inside the drawer also gets its own Escape now — the first Escape closes the calendar, the second closes the drawer. Confirm-on-close is **on by default** for `Bali::Drawer::Component` (opt out per-drawer with `dismissable_without_confirm: true`, or customize the copy with `confirm_close_message:`). `Bali::Modal::Component` gains the same guard as **opt-in** via `confirm_on_close: true` (+ optional `confirm_close_message:`); modal default behavior is unchanged. The mechanism lives in the base `ModalController` (`DrawerController` inherits it).
+
 ## [v2.13.0] - 2026-07-19
 
 ### Added

--- a/app/components/bali/drawer/component.rb
+++ b/app/components/bali/drawer/component.rb
@@ -31,6 +31,8 @@ module Bali
         position: :right,
         drawer_id: nil,
         title: nil,
+        confirm_close_message: nil,
+        dismissable_without_confirm: false,
         **options
       )
         @active = active
@@ -38,6 +40,8 @@ module Bali
         @position = position&.to_sym
         @drawer_id = drawer_id || "drawer-#{SecureRandom.hex(4)}"
         @title = title
+        @confirm_close_message = confirm_close_message
+        @dismissable_without_confirm = dismissable_without_confirm
         @options = options
       end
 
@@ -80,6 +84,17 @@ module Bali
         t(".close_drawer")
       end
 
+      # Confirm-on-close is on by default: an unsaved form inside the drawer
+      # prompts before Escape/overlay/close-button discard the input. Opt out
+      # per-drawer with `dismissable_without_confirm: true`.
+      def confirm_close?
+        !@dismissable_without_confirm
+      end
+
+      def confirm_close_message
+        @confirm_close_message.presence || t(".confirm_close")
+      end
+
       private
 
       attr_reader :title, :options
@@ -104,7 +119,13 @@ module Bali
           controller: "drawer",
           drawer_target: "template",
           action: "keydown.esc->drawer#close"
-        }
+        }.merge(confirm_close_data_attributes)
+      end
+
+      def confirm_close_data_attributes
+        return {} unless confirm_close?
+
+        { drawer_confirm_close_message_value: confirm_close_message }
       end
     end
   end

--- a/app/components/bali/drawer/index.js
+++ b/app/components/bali/drawer/index.js
@@ -31,6 +31,9 @@ export class DrawerController extends ModalController {
 
   // Override to use drawer-open class instead of modal-open
   openModal (content) {
+    // A freshly opened drawer starts clean
+    this._dirty = false
+
     this.previouslyFocusedElement = document.activeElement
 
     if (this.wrapperClasses) {
@@ -102,12 +105,9 @@ export class DrawerController extends ModalController {
     }
   }
 
-  close = (event) => {
-    if (event && event.type === 'keydown' && event.key !== 'Escape') return
-
-    if (event) event.preventDefault()
-    this._closeModal()
-  }
+  // `close()`, `_onOverlayClick()` and the confirm/flatpickr guards are
+  // inherited from ModalController — the drawer only overrides the parts that
+  // differ (the `drawer-open` class and size map).
 
   // Override open to dispatch 'openDrawer' event with skeleton shown first
   open = async (event) => {

--- a/app/components/bali/drawer/preview.rb
+++ b/app/components/bali/drawer/preview.rb
@@ -11,10 +11,10 @@ module Bali
           active: active,
           size: size.to_sym,
           position: position.to_sym,
-          title: 'Drawer Title'
+          title: "Drawer Title"
         ) do
-          tag.p('This is the drawer content. It slides in from the side of the screen.',
-                class: 'text-base-content')
+          tag.p("This is the drawer content. It slides in from the side of the screen.",
+                class: "text-base-content")
         end
       end
 
@@ -38,7 +38,7 @@ module Bali
           title: "#{size.to_s.upcase} Drawer"
         ) do
           tag.p("This drawer uses the #{size} size (#{Bali::Drawer::Component::SIZES[size.to_sym]}).",
-                class: 'text-base-content')
+                class: "text-base-content")
         end
       end
 
@@ -52,6 +52,20 @@ module Bali
         render_with_template
       end
 
+      # Unsaved Changes (Confirm on Close)
+      # ---
+      # Drawers guard against silently discarding an unsaved form. Editing a
+      # field marks the drawer dirty; Escape, the overlay, or the close button
+      # then ask for confirmation before closing. Opt out per-drawer with
+      # `dismissable_without_confirm: true`.
+      #
+      # The date field uses flatpickr, whose calendar renders outside the drawer
+      # DOM. The first Escape closes the open calendar (flatpickr consumes it);
+      # only the next Escape closes the drawer. Used by the Cypress suite.
+      def dirty_form
+        render_with_template(locals: { model: form_record })
+      end
+
       # Left Position
       # ---
       # Drawer opens from the left side.
@@ -59,10 +73,10 @@ module Bali
         render Bali::Drawer::Component.new(
           active: active,
           position: :left,
-          title: 'Left Drawer'
+          title: "Left Drawer"
         ) do
-          tag.p('This drawer slides in from the left side of the screen.',
-                class: 'text-base-content')
+          tag.p("This drawer slides in from the left side of the screen.",
+                class: "text-base-content")
         end
       end
     end

--- a/app/components/bali/drawer/previews/dirty_form.html.erb
+++ b/app/components/bali/drawer/previews/dirty_form.html.erb
@@ -1,0 +1,9 @@
+<%= render Bali::Drawer::Component.new(active: true, title: 'Edit Item') do %>
+  <%= form_with(model: model, url: '/fake/submit', builder: Bali::FormBuilder) do |form| %>
+    <%= form.text_field_group :text %>
+    <%= form.date_field_group :date %>
+    <div class="mt-4">
+      <%= render Bali::Button::Component.new(name: 'Save', variant: :primary, type: :submit) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/bali/modal/component.html.erb
+++ b/app/components/bali/modal/component.html.erb
@@ -4,6 +4,7 @@
      aria-modal="true"
      aria-labelledby="<%= title_id %>"
      <% if description? %>aria-describedby="<%= description_id %>"<% end %>
+     <% if confirm_on_close? %>data-controller="modal" data-modal-confirm-close-message-value="<%= confirm_close_message %>"<% end %>
      data-modal-target="template"
      data-action="keydown.esc->modal#close">
   <div class="modal-backdrop fixed inset-0 bg-black/50" data-modal-target="background" aria-hidden="true"></div>

--- a/app/components/bali/modal/component.rb
+++ b/app/components/bali/modal/component.rb
@@ -34,11 +34,13 @@ module Bali
         Actions::Component.new(**options)
       end
 
-      def initialize(active: true, size: nil, id: nil, **options)
+      def initialize(active: true, size: nil, id: nil, confirm_on_close: false, confirm_close_message: nil, **options)
         @active = active
         @size = size&.to_sym
         @wrapper_class = options.delete(:wrapper_class)
         @id = id
+        @confirm_on_close = confirm_on_close
+        @confirm_close_message = confirm_close_message
         @options = options
       end
 
@@ -88,6 +90,18 @@ module Bali
       # Translated label for close button (accessibility)
       def close_label
         I18n.t("bali.modal.close", default: "Close modal")
+      end
+
+      # Opt-in confirm-on-close: when enabled, an unsaved form inside the modal
+      # prompts before Escape/overlay/close-button discard the input. Rendering
+      # its own `data-controller="modal"` scopes the confirm value to this modal
+      # (the shared body/main-level controller ignores the nested subtree).
+      def confirm_on_close?
+        @confirm_on_close
+      end
+
+      def confirm_close_message
+        @confirm_close_message.presence || I18n.t("bali.modal.confirm_close", default: "You have unsaved changes. Discard them?")
       end
     end
   end

--- a/app/components/bali/modal/index.js
+++ b/app/components/bali/modal/index.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { autoFocusInput } from '../../../assets/javascripts/bali/utils/form.js'
+import { confirmDialog } from '../../../assets/javascripts/bali/confirm/confirm_dialog.js'
 
 // Size classes matching Modal::Component::SIZES
 const SIZE_CLASSES = {
@@ -28,11 +29,25 @@ const SIZE_CLASSES = {
 export class ModalController extends Controller {
   static targets = ['template', 'background', 'wrapper', 'content', 'closeBtn']
 
+  // When set, closing while the form is dirty asks for confirmation first.
+  // Emitted by Drawer (default on) and Modal (opt-in). Subclasses inherit it.
+  static values = { confirmCloseMessage: String }
+
   async connect () {
     this.setupListeners('openModal')
   }
 
   setupListeners = eventName => {
+    this._dirty = false
+
+    // Track edits so we can warn before discarding an unsaved form. Only wired
+    // when confirm-on-close is configured, so the shared body/main-level
+    // controller (no value) stays inert.
+    if (this.hasConfirmCloseMessageValue) {
+      this.element.addEventListener('input', this._markDirty)
+      this.element.addEventListener('change', this._markDirty)
+    }
+
     if (this.hasWrapperTarget) {
       this.wrapperClasses = this.normalizeClass(
         this.wrapperTarget.getAttribute('data-wrapper-class')
@@ -50,6 +65,9 @@ export class ModalController extends Controller {
       // We detect clicks outside the wrapper to close the modal.
       this.templateTarget.addEventListener('mousedown', this._onOverlayMousedown)
       this.templateTarget.addEventListener('click', this._onOverlayClick)
+
+      // Capture-phase probe for the flatpickr popup guard (see _recordPopupState).
+      this.element.addEventListener('keydown', this._recordPopupState, true)
     }
 
     if (this.hasCloseBtnTarget) {
@@ -64,9 +82,15 @@ export class ModalController extends Controller {
   }
 
   removeListeners = eventName => {
+    if (this.hasConfirmCloseMessageValue) {
+      this.element.removeEventListener('input', this._markDirty)
+      this.element.removeEventListener('change', this._markDirty)
+    }
+
     if (this.hasTemplateTarget) {
       this.templateTarget.removeEventListener('mousedown', this._onOverlayMousedown)
       this.templateTarget.removeEventListener('click', this._onOverlayClick)
+      this.element.removeEventListener('keydown', this._recordPopupState, true)
     }
 
     if (this.hasCloseBtnTarget) {
@@ -97,6 +121,9 @@ export class ModalController extends Controller {
   }
 
   openModal (content) {
+    // A freshly opened modal starts clean
+    this._dirty = false
+
     // Store the element that triggered the modal for focus restoration
     this.previouslyFocusedElement = document.activeElement
 
@@ -189,9 +216,37 @@ export class ModalController extends Controller {
 
     // Close only if both mousedown AND click were outside the wrapper
     if (this._mousedownOnOverlay && !insideWrapper) {
-      this._closeModal()
+      this._closeWithConfirmation()
     }
     this._mousedownOnOverlay = false
+  }
+
+  _markDirty = () => {
+    this._dirty = true
+  }
+
+  // flatpickr binds its Escape handler on the input itself, so it closes the
+  // calendar at the target phase — before our bubble-phase `close()` could see
+  // `.flatpickr-calendar.open`. Sampling here in the capture phase (which runs
+  // before the target phase) records whether a popup was open so `close()` can
+  // defer to it. Kept generic to the `.flatpickr-calendar.open` marker.
+  _recordPopupState = event => {
+    if (event.key === 'Escape') {
+      this._escapeHadOpenPopup = Boolean(document.querySelector('.flatpickr-calendar.open'))
+    }
+  }
+
+  // Guards the close paths a user drives (Escape, overlay, close button) so an
+  // unsaved form is not silently discarded. Never call this from `submit()`: a
+  // successful submit must close without prompting.
+  _closeWithConfirmation = () => {
+    if (this._dirty && this.hasConfirmCloseMessageValue) {
+      confirmDialog(this.confirmCloseMessageValue).then(confirmed => {
+        if (confirmed) this._closeModal()
+      })
+    } else {
+      this._closeModal()
+    }
   }
 
   _closeModal = () => {
@@ -303,10 +358,20 @@ export class ModalController extends Controller {
     // Ignore synthetic keydown events from browser autocomplete selections.
     // When a user selects a browser autocomplete suggestion, some browsers fire
     // a keydown event with key: undefined, which Stimulus may not filter out.
-    if (event.type === 'keydown' && event.key !== 'Escape') return
+    if (event && event.type === 'keydown' && event.key !== 'Escape') return
 
-    event.preventDefault()
-    this._closeModal()
+    // Let an open flatpickr calendar (or similar popup) consume the Escape
+    // first. The popup state is sampled in the capture phase (_recordPopupState)
+    // because flatpickr closes its calendar at the target phase, before this
+    // bubble-phase handler runs. So the first Escape closes the calendar and
+    // only the next one closes the modal/drawer.
+    if (event && event.type === 'keydown' && this._escapeHadOpenPopup) {
+      this._escapeHadOpenPopup = false
+      return
+    }
+
+    if (event) event.preventDefault()
+    this._closeWithConfirmation()
   }
 
   /**
@@ -387,6 +452,9 @@ export class ModalController extends Controller {
         const event = new CustomEvent('modal:success', { detail: redirectData })
 
         if (redirected) {
+          // A successful submit is not a discard — clear dirty so the close
+          // below (and any that follows) does not prompt for confirmation.
+          this._dirty = false
           document.dispatchEvent(event)
 
           if (this.skipRender) {
@@ -401,7 +469,10 @@ export class ModalController extends Controller {
           // <turbo-stream> markup as inert HTML. Close only on success: an
           // error stream may re-render the form inside the modal/drawer.
           window.Turbo.renderStreamMessage(responseText)
-          if (responseOk) { this._closeModal() }
+          if (responseOk) {
+            this._dirty = false
+            this._closeModal()
+          }
         } else {
           if (responseOk) { document.dispatchEvent(event) }
 

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -116,6 +116,7 @@ en:
     # Modal
     modal:
       close: "Close modal"
+      confirm_close: "You have unsaved changes. Discard them?"
 
     # Image grid
     image_grid:

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -116,6 +116,7 @@ es:
     # Modal
     modal:
       close: "Cerrar modal"
+      confirm_close: "Hay cambios sin guardar. ¿Descartar los cambios?"
 
     # Image grid
     image_grid:

--- a/config/locales/view_components.en.yml
+++ b/config/locales/view_components.en.yml
@@ -29,6 +29,7 @@ en:
         copy_label: Copy to clipboard
       drawer:
         close_drawer: Close drawer
+        confirm_close: You have unsaved changes. Discard them?
       dropdown:
         menu_label: Dropdown menu
       delete_link:

--- a/config/locales/view_components.es.yml
+++ b/config/locales/view_components.es.yml
@@ -29,6 +29,7 @@ es:
         copy_label: Copiar al portapapeles
       drawer:
         close_drawer: Cerrar panel
+        confirm_close: Hay cambios sin guardar. ¿Descartar los cambios?
       dropdown:
         menu_label: Menú desplegable
       delete_link:

--- a/cypress/e2e/drawer-controller.cy.js
+++ b/cypress/e2e/drawer-controller.cy.js
@@ -41,4 +41,64 @@ describe('DrawerController', () => {
       cy.get('.drawer-open #form-error').should('have.text', 'Name is required')
     })
   })
+
+  context('confirm on close (unsaved changes)', () => {
+    beforeEach(() => {
+      cy.visit('/bali/drawer/dirty_form')
+      cy.get('.drawer-open').should('exist')
+    })
+
+    it('prompts before discarding an edited form on Escape; cancel keeps the values', () => {
+      cy.get('#form_record_text').type('Hello')
+
+      // Escape originates inside the drawer so it reaches the drawer#close action
+      cy.get('#form_record_text').type('{esc}')
+
+      // Confirmation dialog appears and the drawer stays open
+      cy.get('dialog[data-bali-confirm]').should('be.visible')
+      cy.get('.drawer-open').should('exist')
+
+      // Cancelling keeps the drawer open with the typed value intact
+      cy.get('#bali-confirm-cancel-btn').click()
+      cy.get('.drawer-open').should('exist')
+      cy.get('#form_record_text').should('have.value', 'Hello')
+
+      // Escape again + accept closes the drawer
+      cy.get('#form_record_text').type('{esc}')
+      cy.get('#bali-confirm-accept-btn').click()
+      cy.get('dialog[data-bali-confirm]').should('not.be.visible')
+      cy.get('.drawer-open').should('not.exist')
+    })
+
+    it('closes without prompting when the form is untouched', () => {
+      cy.get('#form_record_text').type('{esc}')
+
+      cy.get('dialog[data-bali-confirm]').should('not.exist')
+      cy.get('.drawer-open').should('not.exist')
+    })
+  })
+
+  context('flatpickr calendar inside the drawer', () => {
+    beforeEach(() => {
+      cy.visit('/bali/drawer/dirty_form')
+      cy.get('.drawer-open').should('exist')
+    })
+
+    it('first Escape closes the calendar, second Escape closes the (clean) drawer', () => {
+      // flatpickr renders its calendar on document.body, outside the drawer DOM.
+      // Its alt input is readonly, so Escape needs `force` to dispatch the keydown.
+      cy.get('.flatpickr input').filter(':visible').first().click()
+      cy.get('.flatpickr-calendar.open').should('exist')
+
+      // First Escape: flatpickr consumes it and closes the calendar; drawer stays
+      cy.get('.flatpickr input').filter(':visible').first().type('{esc}', { force: true })
+      cy.get('.flatpickr-calendar.open').should('not.exist')
+      cy.get('.drawer-open').should('exist')
+
+      // Second Escape: form is still clean, so the drawer closes without a prompt
+      cy.get('.flatpickr input').filter(':visible').first().type('{esc}', { force: true })
+      cy.get('dialog[data-bali-confirm]').should('not.exist')
+      cy.get('.drawer-open').should('not.exist')
+    })
+  })
 })

--- a/test/bali/components/drawer_test.rb
+++ b/test/bali/components/drawer_test.rb
@@ -185,4 +185,27 @@ class BaliDrawerComponentTest < ComponentTestCase
     assert_equal("drawer", dialog["data-controller"])
     assert_equal("value", dialog["data-custom"])
   end
+
+  def test_confirm_close_adds_confirm_close_message_value_by_default
+    render_inline(component)
+    assert_selector("[data-drawer-confirm-close-message-value]")
+  end
+
+  def test_confirm_close_uses_default_message
+    render_inline(component)
+    dialog = page.find('[role="dialog"]')
+    assert_equal("You have unsaved changes. Discard them?", dialog["data-drawer-confirm-close-message-value"])
+  end
+
+  def test_confirm_close_honors_custom_message
+    @options.merge!(confirm_close_message: "Descartar cambios?")
+    render_inline(component)
+    assert_selector('[data-drawer-confirm-close-message-value="Descartar cambios?"]')
+  end
+
+  def test_confirm_close_omitted_when_dismissable_without_confirm
+    @options.merge!(dismissable_without_confirm: true)
+    render_inline(component)
+    assert_no_selector("[data-drawer-confirm-close-message-value]")
+  end
 end

--- a/test/bali/components/modal_test.rb
+++ b/test/bali/components/modal_test.rb
@@ -199,4 +199,25 @@ class BaliModalComponentTest < ComponentTestCase
     assert_selector(".modal-body", text: "Modal body content")
     assert_selector(".modal-action button.btn", text: "Done")
   end
+
+  def test_confirm_on_close_is_opt_in_and_omitted_by_default
+    render_inline(Bali::Modal::Component.new)
+    assert_no_selector("[data-modal-confirm-close-message-value]")
+  end
+
+  def test_confirm_on_close_adds_confirm_close_message_value_and_self_scoped_controller
+    render_inline(Bali::Modal::Component.new(confirm_on_close: true))
+    assert_selector("div.modal[data-controller='modal'][data-modal-confirm-close-message-value]")
+  end
+
+  def test_confirm_on_close_uses_default_message
+    render_inline(Bali::Modal::Component.new(confirm_on_close: true))
+    modal = page.find("div.modal")
+    assert_equal("You have unsaved changes. Discard them?", modal["data-modal-confirm-close-message-value"])
+  end
+
+  def test_confirm_on_close_honors_custom_message
+    render_inline(Bali::Modal::Component.new(confirm_on_close: true, confirm_close_message: "Discard?"))
+    assert_selector('[data-modal-confirm-close-message-value="Discard?"]')
+  end
 end


### PR DESCRIPTION
Closes #619.

## Problem

Pressing Escape (or clicking the overlay/close button) on a `Bali::Drawer` containing a form silently discarded everything typed. Worse, with a flatpickr calendar open inside the drawer, the Escape meant to close the calendar closed the whole drawer.

## Solution

`DrawerController` inherits from `ModalController`, so the mechanism lives in the shared base and both components expose it:

- **Popup guard**: while a `.flatpickr-calendar.open` exists, Escape is ignored by the drawer/modal — the first Escape closes the calendar, the next one closes the drawer. flatpickr removes the `open` class before a bubble-phase handler can see it, so the guard samples state with a capture-phase probe.
- **Dirty tracking + confirm**: `input`/`change` inside the drawer set a dirty flag; closing while dirty shows the existing Promise-based `confirmDialog` (not `window.confirm`). Guards live in `close()`/`_onOverlayClick()` only — the successful-submit path (`submit()` → `_closeModal()`) still closes without prompting.
- **API**: Drawer is protected by default, with `confirm_close_message:` (i18n default, en/es) and `dismissable_without_confirm: true` opt-out. Modal is opt-in via `confirm_on_close: true`.
- New Lookbook preview `bali/drawer/dirty_form` (form + datepicker) serves as repro and Cypress fixture.

## Testing

- Minitest full suite: 2688 runs, 0 failures. RuboCop + StandardJS clean.
- Cypress 55/55 (`--browser electron`), including: dirty + Escape → confirm (cancel keeps values, accept closes); flatpickr open + Escape → only the calendar closes; pre-existing turbo_stream submit spec unchanged and green.
- Browser-verified manually in Lookbook (all three flows).

Non-blocking follow-ups noted during review: a Cypress case for the modal opt-in path, and a dormant `closeBtn` target listener in the base controller that bypasses confirm (no markup uses it today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1N7BfwLwegVK1unPhFdKD