### PR TITLE
feat(form_builder): placeholder hint and test coverage for allow_input date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **FormBuilder date fields** - `allow_input: true` (date_field_group/datetime_field_group/time_field_group) now auto-fills a `placeholder:` hinting at what the field will parse, unless the caller already passed one explicitly. Derived from the effective `alt_format:` (or an i18n string for the verbose default format). Addresses part of #620; the read-only-by-default behavior itself is unchanged — `allow_input:` remains opt-in.
+
 ## [v2.13.0] - 2026-07-19
 
 ### Added

--- a/app/components/bali/form/date/preview.rb
+++ b/app/components/bali/form/date/preview.rb
@@ -6,42 +6,42 @@ module Bali
       class Preview < ApplicationViewComponentPreview
         def default
           render_with_template(
-            template: "bali/form/date/previews/default",
+            template: 'bali/form/date/previews/default',
             locals: { model: form_record }
           )
         end
 
         def min_date
           render_with_template(
-            template: "bali/form/date/previews/min_date",
+            template: 'bali/form/date/previews/min_date',
             locals: { model: form_record }
           )
         end
 
         def date_range
           render_with_template(
-            template: "bali/form/date/previews/range",
+            template: 'bali/form/date/previews/range',
             locals: { model: form_record }
           )
         end
 
         def with_controls
           render_with_template(
-            template: "bali/form/date/previews/with_controls",
+            template: 'bali/form/date/previews/with_controls',
             locals: { model: form_record }
           )
         end
 
         def with_tooltip
           render_with_template(
-            template: "bali/form/date/previews/with_tooltip",
+            template: 'bali/form/date/previews/with_tooltip',
             locals: { model: form_record }
           )
         end
 
         def weekends_disabled
           render_with_template(
-            template: "bali/form/date/previews/weekends_disabled",
+            template: 'bali/form/date/previews/weekends_disabled',
             locals: { model: form_record }
           )
         end
@@ -51,7 +51,7 @@ module Bali
         # a hint at what the field will actually parse on blur.
         def allow_input
           render_with_template(
-            template: "bali/form/date/previews/allow_input",
+            template: 'bali/form/date/previews/allow_input',
             locals: { model: form_record }
           )
         end
@@ -61,7 +61,7 @@ module Bali
         # comes from an i18n string instead of a token-mapped hint.
         def allow_input_default_format
           render_with_template(
-            template: "bali/form/date/previews/allow_input_default_format",
+            template: 'bali/form/date/previews/allow_input_default_format',
             locals: { model: form_record }
           )
         end

--- a/app/components/bali/form/date/preview.rb
+++ b/app/components/bali/form/date/preview.rb
@@ -6,49 +6,62 @@ module Bali
       class Preview < ApplicationViewComponentPreview
         def default
           render_with_template(
-            template: 'bali/form/date/previews/default',
+            template: "bali/form/date/previews/default",
             locals: { model: form_record }
           )
         end
 
         def min_date
           render_with_template(
-            template: 'bali/form/date/previews/min_date',
+            template: "bali/form/date/previews/min_date",
             locals: { model: form_record }
           )
         end
 
         def date_range
           render_with_template(
-            template: 'bali/form/date/previews/range',
+            template: "bali/form/date/previews/range",
             locals: { model: form_record }
           )
         end
 
         def with_controls
           render_with_template(
-            template: 'bali/form/date/previews/with_controls',
+            template: "bali/form/date/previews/with_controls",
             locals: { model: form_record }
           )
         end
 
         def with_tooltip
           render_with_template(
-            template: 'bali/form/date/previews/with_tooltip',
+            template: "bali/form/date/previews/with_tooltip",
             locals: { model: form_record }
           )
         end
 
         def weekends_disabled
           render_with_template(
-            template: 'bali/form/date/previews/weekends_disabled',
+            template: "bali/form/date/previews/weekends_disabled",
             locals: { model: form_record }
           )
         end
 
+        # Typing is allowed (`allow_input: true`) and paired with an explicit
+        # `alt_format: 'd/m/Y'`, so Bali auto-fills `placeholder="dd/mm/yyyy"` —
+        # a hint at what the field will actually parse on blur.
         def allow_input
           render_with_template(
-            template: 'bali/form/date/previews/allow_input',
+            template: "bali/form/date/previews/allow_input",
+            locals: { model: form_record }
+          )
+        end
+
+        # Same as above, but with no explicit `alt_format:` — the field falls
+        # back to the verbose default format, so the auto-filled placeholder
+        # comes from an i18n string instead of a token-mapped hint.
+        def allow_input_default_format
+          render_with_template(
+            template: "bali/form/date/previews/allow_input_default_format",
             locals: { model: form_record }
           )
         end

--- a/app/components/bali/form/date/previews/allow_input_default_format.html.erb
+++ b/app/components/bali/form/date/previews/allow_input_default_format.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(model: model, url: '/', builder: Bali::FormBuilder) do |form| %>
+  <%= form.date_field_group :date, allow_input: true %>
+<% end %>

--- a/config/locales/bali.en.yml
+++ b/config/locales/bali.en.yml
@@ -161,6 +161,12 @@ en:
 
     # Form builder
     form_builder:
+      date_fields:
+        # Placeholder shown when `allow_input: true` and no explicit `alt_format:`
+        # is given. Mirrors flatpickr's non-localized "F j, Y" token order (month
+        # name, then day, then year) rather than a conventional Spanish date order,
+        # since that's the literal text the field will parse.
+        allow_input_placeholder: "e.g., December 31, 2026"
       file:
         choose_file: "Choose file"
         no_file_selected: "No file selected"

--- a/config/locales/bali.es.yml
+++ b/config/locales/bali.es.yml
@@ -161,6 +161,11 @@ es:
 
     # Form builder
     form_builder:
+      date_fields:
+        # Coincide con el orden de tokens no localizado de flatpickr ("F j, Y":
+        # nombre de mes, día, año) en vez del orden habitual en español, porque
+        # es el texto literal que el campo va a intentar interpretar.
+        allow_input_placeholder: "ej. diciembre 31, 2026"
       file:
         choose_file: "Seleccionar archivo"
         no_file_selected: "Ningún archivo seleccionado"

--- a/docs/guides/form-builder.md
+++ b/docs/guides/form-builder.md
@@ -295,6 +295,30 @@ Month/year picker.
 <%= f.month_field_group :billing_month %>
 ```
 
+### Typing into date/time fields (`allow_input:`)
+
+By default, date/datetime/time fields are read-only — users must pick a value
+from the calendar/time popup, with no way to type it directly. Pass
+`allow_input: true` to let users type into the field instead:
+
+```erb
+<%= f.date_field_group :birth_date, allow_input: true, alt_format: 'd/m/Y' %>
+```
+
+**Pair it with `alt_format:`.** Typed text is parsed against the visible
+input's format (flatpickr's `altFormat`) when the field loses focus; text that
+doesn't match is silently cleared. The default format is a verbose one (e.g.
+"December 31, 2026"), so an explicit numeric `alt_format:` like `'d/m/Y'`
+(or `'H:i'` for 24-hour time fields) gives users a format that's easier to
+type correctly.
+
+When `allow_input: true` is set and no explicit `placeholder:` is given, Bali
+automatically sets one derived from the effective format, so the field always
+hints at what to type. A caller-supplied `placeholder:` always takes
+precedence. This does not change the default behavior of `date_field_group` /
+`datetime_field_group` / `time_field_group` — fields remain read-only unless
+`allow_input: true` is passed explicitly.
+
 ---
 
 ## Boolean Fields

--- a/lib/bali/form_builder/shared_date_utils.rb
+++ b/lib/bali/form_builder/shared_date_utils.rb
@@ -15,7 +15,7 @@ module Bali
       # #allow_input_placeholder).
       ALT_FORMAT_PLACEHOLDER_TOKENS = {
         "d" => "dd", "j" => "d", "m" => "mm", "Y" => "yyyy",
-        "H" => "HH", "h" => "hh", "i" => "MM", "K" => "AM/PM"
+        "H" => "HH", "h" => "hh", "i" => "MM", "S" => "ss", "K" => "AM/PM"
       }.freeze
 
       def date_field(method, options = {})

--- a/lib/bali/form_builder/shared_date_utils.rb
+++ b/lib/bali/form_builder/shared_date_utils.rb
@@ -9,10 +9,20 @@ module Bali
       CLEAR_BUTTON_CLASS = "#{BUTTON_CLASS} #{JOIN_ITEM_CLASS}".freeze
       NAV_BUTTON_CLASS = "#{BUTTON_CLASS} #{JOIN_ITEM_CLASS}".freeze
 
+      # Maps flatpickr format tokens to a literal human hint for the auto-generated
+      # `allow_input` placeholder. `F` (localized month name) is intentionally absent —
+      # it has no universal literal hint, so it's handled via i18n instead (see
+      # #allow_input_placeholder).
+      ALT_FORMAT_PLACEHOLDER_TOKENS = {
+        "d" => "dd", "j" => "d", "m" => "mm", "Y" => "yyyy",
+        "H" => "HH", "h" => "hh", "i" => "MM", "K" => "AM/PM"
+      }.freeze
+
       def date_field(method, options = {})
         opts = options.dup
         clear_btn = build_clear_button if opts.delete(:clear)
         opts[:control_class] = [ "w-full", opts[:control_class] ].compact.join(" ")
+        opts[:placeholder] ||= allow_input_placeholder(opts) if opts[:allow_input]
 
         wrapper_options = build_wrapper_options(method, opts)
 
@@ -54,6 +64,45 @@ module Bali
       end
 
       private
+
+      # `allow_input: true` lets users type directly into the visible input, but
+      # flatpickr silently discards anything that doesn't match the effective
+      # altFormat on blur (see datepicker-controller.js#altFormat). Without a hint,
+      # users have no way to know what to type, so derive a placeholder from that
+      # same effective format — unless the caller already supplied one.
+      def allow_input_placeholder(options)
+        effective_format = options[:alt_format].presence || default_alt_format(options)
+
+        if effective_format.include?("F")
+          I18n.t("bali.form_builder.date_fields.allow_input_placeholder")
+        else
+          effective_format.gsub(/[A-Za-z]/) { |token| ALT_FORMAT_PLACEHOLDER_TOKENS[token] || token }
+        end
+      end
+
+      # Ruby port of DatepickerController#altFormat() in datepicker-controller.js,
+      # so the derived placeholder always matches what the visible input actually
+      # parses when no explicit `alt_format:` is given. Reads the same wrapper data
+      # attributes the JS controller receives (enable_time/no_calendar/time_24hr/
+      # seconds), before `build_wrapper_options` merges and removes `wrapper_options`.
+      def default_alt_format(options)
+        wrapper_data = (options[:wrapper_options] || {}).transform_keys(&:to_s)
+        enable_time = wrapper_data["data-datepicker-enable-time-value"]
+        no_calendar = wrapper_data["data-datepicker-no-calendar-value"]
+        time_24hr = wrapper_data["data-datepicker-time24hr-value"]
+        seconds = wrapper_data["data-datepicker-enable-seconds-value"]
+
+        time_portion =
+          if !no_calendar && !enable_time
+            ""
+          elsif seconds
+            time_24hr ? "H:i:S" : "h:i:S K"
+          else
+            time_24hr ? "H:i" : "h:i K"
+          end
+
+        no_calendar ? time_portion : "F j, Y #{time_portion}".strip
+      end
 
       def build_clear_button
         aria_label = I18n.t("bali.form_builder.date_fields.clear", default: "Clear date")

--- a/test/bali/form_builder/date_fields_test.rb
+++ b/test/bali/form_builder/date_fields_test.rb
@@ -110,6 +110,47 @@ class BaliFormBuilderDateFieldsTest < FormBuilderTestCase
     assert_html(result, 'div.custom-wrapper[data-controller="datepicker"]')
   end
 
+  # #date_field_group allow_input
+
+  def test_date_field_group_without_allow_input_option_does_not_render_allow_input_attribute
+    result = builder.date_field_group(:release_date)
+    refute_html(result, "[data-datepicker-allow-input-value]")
+  end
+
+  def test_date_field_group_without_allow_input_option_does_not_render_a_placeholder_attribute
+    result = builder.date_field_group(:release_date)
+    refute_html(result, "input[placeholder]")
+  end
+
+  def test_date_field_group_with_allow_input_option_renders_allow_input_attribute
+    result = builder.date_field_group(:release_date, allow_input: true)
+    assert_html(result, 'div[data-datepicker-allow-input-value="true"]')
+  end
+
+  def test_date_field_group_with_allow_input_and_explicit_alt_format_sets_a_token_mapped_placeholder
+    result = builder.date_field_group(:release_date, allow_input: true, alt_format: "d/m/Y")
+    assert_html(result, 'input[placeholder="dd/mm/yyyy"]')
+  end
+
+  def test_date_field_group_with_allow_input_and_no_alt_format_sets_an_i18n_placeholder
+    result = builder.date_field_group(:release_date, allow_input: true)
+    assert_html(result, 'input[placeholder="e.g., December 31, 2026"]')
+  end
+
+  def test_date_field_group_with_allow_input_and_no_alt_format_supports_spanish_locale
+    I18n.with_locale(:es) do
+      result = builder.date_field_group(:release_date, allow_input: true)
+      assert_html(result, 'input[placeholder="ej. diciembre 31, 2026"]')
+    end
+  end
+
+  def test_date_field_group_with_allow_input_and_explicit_placeholder_keeps_the_explicit_placeholder
+    result = builder.date_field_group(
+      :release_date, allow_input: true, alt_format: "d/m/Y", placeholder: "Type a date"
+    )
+    assert_html(result, 'input[placeholder="Type a date"]')
+  end
+
   # #month_field_group
 
   def test_month_field_group_renders_a_fieldset_wrapper

--- a/test/bali/form_builder/datetime_fields_test.rb
+++ b/test/bali/form_builder/datetime_fields_test.rb
@@ -88,4 +88,38 @@ class BaliFormBuilderDatetimeFieldsTest < FormBuilderTestCase
     assert_html(result, '.fieldset[data-custom="value"]')
     assert_html(result, '.fieldset[data-datepicker-enable-time-value="true"]')
   end
+
+  # #datetime_field_group allow_input
+
+  def test_datetime_field_group_without_allow_input_option_does_not_render_allow_input_attribute
+    result = builder.datetime_field_group(:release_date)
+    refute_html(result, "[data-datepicker-allow-input-value]")
+  end
+
+  def test_datetime_field_group_without_allow_input_option_does_not_render_a_placeholder_attribute
+    result = builder.datetime_field_group(:release_date)
+    refute_html(result, "input[placeholder]")
+  end
+
+  def test_datetime_field_group_with_allow_input_option_renders_allow_input_attribute
+    result = builder.datetime_field_group(:release_date, allow_input: true)
+    assert_html(result, '.fieldset[data-datepicker-allow-input-value="true"]')
+  end
+
+  def test_datetime_field_group_with_allow_input_and_explicit_alt_format_sets_a_token_mapped_placeholder
+    result = builder.datetime_field_group(:release_date, allow_input: true, alt_format: "d/m/Y H:i")
+    assert_html(result, 'input[placeholder="dd/mm/yyyy HH:MM"]')
+  end
+
+  def test_datetime_field_group_with_allow_input_and_no_alt_format_sets_an_i18n_placeholder
+    result = builder.datetime_field_group(:release_date, allow_input: true)
+    assert_html(result, 'input[placeholder="e.g., December 31, 2026"]')
+  end
+
+  def test_datetime_field_group_with_allow_input_and_explicit_placeholder_keeps_the_explicit_placeholder
+    result = builder.datetime_field_group(
+      :release_date, allow_input: true, alt_format: "d/m/Y H:i", placeholder: "Type a date and time"
+    )
+    assert_html(result, 'input[placeholder="Type a date and time"]')
+  end
 end

--- a/test/bali/form_builder/time_fields_test.rb
+++ b/test/bali/form_builder/time_fields_test.rb
@@ -109,4 +109,41 @@ class BaliFormBuilderTimeFieldsTest < FormBuilderTestCase
     builder.time_field(:duration, original_options)
     assert_equal(options_copy, original_options)
   end
+
+  # #time_field_group allow_input
+
+  def test_time_field_group_without_allow_input_option_does_not_render_allow_input_attribute
+    result = builder.time_field_group(:duration)
+    refute_html(result, "[data-datepicker-allow-input-value]")
+  end
+
+  def test_time_field_group_without_allow_input_option_does_not_render_a_placeholder_attribute
+    result = builder.time_field_group(:duration)
+    refute_html(result, "input[placeholder]")
+  end
+
+  def test_time_field_group_with_allow_input_option_renders_allow_input_attribute
+    result = builder.time_field_group(:duration, allow_input: true)
+    assert_html(result, '.fieldset[data-datepicker-allow-input-value="true"]')
+  end
+
+  def test_time_field_group_with_allow_input_and_explicit_alt_format_sets_a_token_mapped_placeholder
+    result = builder.time_field_group(:duration, allow_input: true, alt_format: "H:i")
+    assert_html(result, 'input[placeholder="HH:MM"]')
+  end
+
+  def test_time_field_group_with_allow_input_and_no_alt_format_sets_a_token_mapped_placeholder
+    result = builder.time_field_group(:duration, allow_input: true)
+    assert_html(result, 'input[placeholder="hh:MM AM/PM"]')
+  end
+
+  def test_time_field_group_with_allow_input_and_24_hour_format_maps_the_24_hour_placeholder
+    result = builder.time_field_group(:duration, allow_input: true, time_24hr: true)
+    assert_html(result, 'input[placeholder="HH:MM"]')
+  end
+
+  def test_time_field_group_with_allow_input_and_explicit_placeholder_keeps_the_explicit_placeholder
+    result = builder.time_field_group(:duration, allow_input: true, placeholder: "Type a time")
+    assert_html(result, 'input[placeholder="Type a time"]')
+  end
 end

--- a/test/bali/form_builder/time_fields_test.rb
+++ b/test/bali/form_builder/time_fields_test.rb
@@ -142,6 +142,16 @@ class BaliFormBuilderTimeFieldsTest < FormBuilderTestCase
     assert_html(result, 'input[placeholder="HH:MM"]')
   end
 
+  def test_time_field_group_with_allow_input_and_seconds_maps_the_seconds_token_in_the_placeholder
+    result = builder.time_field_group(:duration, allow_input: true, seconds: true)
+    assert_html(result, 'input[placeholder="hh:MM:ss AM/PM"]')
+  end
+
+  def test_time_field_group_with_allow_input_and_seconds_and_24_hour_format_maps_both_tokens
+    result = builder.time_field_group(:duration, allow_input: true, seconds: true, time_24hr: true)
+    assert_html(result, 'input[placeholder="HH:MM:ss"]')
+  end
+
   def test_time_field_group_with_allow_input_and_explicit_placeholder_keeps_the_explicit_placeholder
     result = builder.time_field_group(:duration, allow_input: true, placeholder: "Type a time")
     assert_html(result, 'input[placeholder="Type a time"]')


### PR DESCRIPTION
Addresses the risk-free portion of #620 (the readonly default itself is a separate pending decision — this PR does NOT change any datepicker default).

## Context

Since PR #358, `f.date_field_group :date, allow_input: true` already enables typing, but nothing hinted at the expected format: flatpickr silently clears typed text that doesn't parse against the effective `altFormat`, and the option had zero test coverage.

## Changes

- **Auto placeholder**: when `allow_input:` is on and no explicit `placeholder:` is given, the form builder derives a hint from the effective alt format — token-mapped for explicit formats (`d/m/Y` → `dd/mm/yyyy`) and an i18n sample date (`e.g., December 31, 2026`) for the verbose default format. Caller-provided placeholders always win; fields without `allow_input` are byte-identical to before.
- The Ruby-side format derivation mirrors `datepicker-controller.js#altFormat()` for every date/datetime/time shape (verified branch by branch in review).
- **Tests**: full `allow_input` coverage across date, datetime, and time field groups (attr present/absent, placeholder derivation incl. `seconds: true`, explicit placeholder wins) — 22 new tests.
- **i18n**: new `form_builder.date_fields` keys in en and es.
- **Docs + Lookbook**: `allow_input` documented with the recommended `alt_format: 'd/m/Y'` pairing; new `allow_input_default_format` preview variant.

## Testing

- Full Minitest suite: 2702 runs, 0 failures. RuboCop clean.
- Browser-verified in Lookbook: both placeholder variants render; typing `05/01/2026` + Enter parses and persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1N7BfwLwegVK1unPhFdKD