### PR TITLE
fix(document_page): stack three-panel body below lg breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **DocumentPage** - the three-panel body (TOC + content + metadata) now stacks vertically below the `lg` breakpoint instead of crushing the content column to ~1 word per line on mobile (#631). Both side panels go full-width and static (drop `sticky`) with adjusted borders; the TOC panel gets a bounded, scrollable height (`max-h-72`) so a long table of contents doesn't push content off-screen, while metadata flows full height. Content padding narrows (`px-4`) and the header toolbar wraps instead of overflowing. Pure Tailwind utility additions (`max-lg:*` + toolbar `flex-wrap`) — no JS changes, desktop (`≥lg`) layout is unchanged.
+
 ## [v2.13.0] - 2026-07-19
 
 ### Added

--- a/app/components/bali/document_page/component.html.erb
+++ b/app/components/bali/document_page/component.html.erb
@@ -80,7 +80,7 @@
       <%# Right: Metadata Panel %>
       <% if metadata? %>
         <div class="w-72 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-l border-base-300 p-4
-                    max-lg:w-full max-lg:static max-lg:max-h-none max-lg:overflow-y-visible max-lg:border-l-0 max-lg:border-t"
+                    max-lg:w-full max-lg:static max-lg:max-h-none max-lg:border-l-0 max-lg:border-t"
              data-document-page-target="metadataPanel">
           <%= metadata %>
         </div>

--- a/app/components/bali/document_page/component.html.erb
+++ b/app/components/bali/document_page/component.html.erb
@@ -13,7 +13,7 @@
       <% header.with_subtitle(subtitle) %>
     <% end %>
 
-    <div class="flex items-center gap-2 flex-wrap gap-y-2">
+    <div class="flex items-center gap-2 flex-wrap">
       <% if toc? %>
         <%= render Bali::Button::Component.new(variant: :ghost, size: :sm, class: "btn-square",
               data: { action: "document-page#toggleToc", document_page_target: "tocToggle" },
@@ -80,7 +80,7 @@
       <%# Right: Metadata Panel %>
       <% if metadata? %>
         <div class="w-72 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-l border-base-300 p-4
-                    max-lg:w-full max-lg:static max-lg:max-h-none max-lg:overflow-visible max-lg:border-l-0 max-lg:border-t"
+                    max-lg:w-full max-lg:static max-lg:max-h-none max-lg:overflow-y-visible max-lg:border-l-0 max-lg:border-t"
              data-document-page-target="metadataPanel">
           <%= metadata %>
         </div>

--- a/app/components/bali/document_page/component.html.erb
+++ b/app/components/bali/document_page/component.html.erb
@@ -13,7 +13,7 @@
       <% header.with_subtitle(subtitle) %>
     <% end %>
 
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2 flex-wrap gap-y-2">
       <% if toc? %>
         <%= render Bali::Button::Component.new(variant: :ghost, size: :sm, class: "btn-square",
               data: { action: "document-page#toggleToc", document_page_target: "tocToggle" },
@@ -46,10 +46,11 @@
 
   <% if three_panel? %>
     <%# Three-panel layout %>
-    <div class="flex items-start border-t border-base-300 mt-4">
+    <div class="flex items-start max-lg:flex-col border-t border-base-300 mt-4">
       <%# Left: TOC Panel %>
       <% if toc? %>
-        <div class="w-56 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-r border-base-300 p-4"
+        <div class="w-56 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-r border-base-300 p-4
+                    max-lg:w-full max-lg:static max-lg:max-h-72 max-lg:border-r-0 max-lg:border-b"
              data-document-page-target="tocPanel">
           <h3 class="text-xs font-semibold text-base-content/50 uppercase tracking-wider mb-3">Contents</h3>
           <div id="document-page-toc-container"></div>
@@ -57,7 +58,7 @@
       <% end %>
 
       <%# Center: Content %>
-      <div class="flex-1 min-w-0 px-8 py-6">
+      <div class="flex-1 min-w-0 px-8 py-6 max-lg:px-4">
         <% if block_editor? %>
           <%= render Bali::BlockEditor::Component.new(
             initial_content: initial_content,
@@ -78,7 +79,8 @@
 
       <%# Right: Metadata Panel %>
       <% if metadata? %>
-        <div class="w-72 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-l border-base-300 p-4"
+        <div class="w-72 shrink-0 sticky top-4 overflow-y-auto max-h-[calc(100vh-12rem)] border-l border-base-300 p-4
+                    max-lg:w-full max-lg:static max-lg:max-h-none max-lg:overflow-visible max-lg:border-l-0 max-lg:border-t"
              data-document-page-target="metadataPanel">
           <%= metadata %>
         </div>

--- a/test/bali/components/document_page_test.rb
+++ b/test/bali/components/document_page_test.rb
@@ -217,7 +217,7 @@ class BaliDocumentPageComponentTest < ComponentTestCase
     end
     assert_selector(
       "[data-document-page-target='metadataPanel'].max-lg\\:w-full.max-lg\\:static" \
-        ".max-lg\\:max-h-none.max-lg\\:overflow-y-visible.max-lg\\:border-l-0.max-lg\\:border-t"
+        ".max-lg\\:max-h-none.max-lg\\:border-l-0.max-lg\\:border-t"
     )
   end
 

--- a/test/bali/components/document_page_test.rb
+++ b/test/bali/components/document_page_test.rb
@@ -217,7 +217,7 @@ class BaliDocumentPageComponentTest < ComponentTestCase
     end
     assert_selector(
       "[data-document-page-target='metadataPanel'].max-lg\\:w-full.max-lg\\:static" \
-        ".max-lg\\:max-h-none.max-lg\\:overflow-visible.max-lg\\:border-l-0.max-lg\\:border-t"
+        ".max-lg\\:max-h-none.max-lg\\:overflow-y-visible.max-lg\\:border-l-0.max-lg\\:border-t"
     )
   end
 
@@ -226,6 +226,6 @@ class BaliDocumentPageComponentTest < ComponentTestCase
       page.with_action { "Edit Button" }
       page.with_preview { "Content" }
     end
-    assert_selector(".flex.items-center.gap-2.flex-wrap.gap-y-2")
+    assert_selector(".flex.items-center.gap-2.flex-wrap")
   end
 end

--- a/test/bali/components/document_page_test.rb
+++ b/test/bali/components/document_page_test.rb
@@ -188,4 +188,44 @@ class BaliDocumentPageComponentTest < ComponentTestCase
     render_inline(Bali::DocumentPage::Component.new(title: "My Document")) { "Fallback content" }
     assert_text("Fallback content")
   end
+
+  def test_three_panel_container_stacks_on_mobile
+    render_inline(Bali::DocumentPage::Component.new(title: "My Document")) do |page|
+      page.with_metadata { "Meta" }
+      page.with_preview { "Content" }
+    end
+    assert_selector(".flex.items-start.max-lg\\:flex-col")
+  end
+
+  def test_toc_panel_has_mobile_stacking_classes
+    render_inline(Bali::DocumentPage::Component.new(
+      title: "My Document",
+      initial_content: [ { type: "paragraph", content: [ { type: "text", text: "Hello" } ] } ].to_json
+    )) do |page|
+      page.with_metadata { "Meta" }
+    end
+    assert_selector(
+      "[data-document-page-target='tocPanel'].max-lg\\:w-full.max-lg\\:static.max-lg\\:max-h-72" \
+        ".max-lg\\:border-r-0.max-lg\\:border-b"
+    )
+  end
+
+  def test_metadata_panel_has_mobile_stacking_classes
+    render_inline(Bali::DocumentPage::Component.new(title: "My Document")) do |page|
+      page.with_metadata { "Meta" }
+      page.with_preview { "Content" }
+    end
+    assert_selector(
+      "[data-document-page-target='metadataPanel'].max-lg\\:w-full.max-lg\\:static" \
+        ".max-lg\\:max-h-none.max-lg\\:overflow-visible.max-lg\\:border-l-0.max-lg\\:border-t"
+    )
+  end
+
+  def test_toolbar_wraps_on_mobile
+    render_inline(Bali::DocumentPage::Component.new(title: "My Document")) do |page|
+      page.with_action { "Edit Button" }
+      page.with_preview { "Content" }
+    end
+    assert_selector(".flex.items-center.gap-2.flex-wrap.gap-y-2")
+  end
 end


### PR DESCRIPTION
Closes #631.

## Problem

DocumentPage's three-panel body (TOC + content + metadata) kept its side-by-side flex row at every viewport: two fixed-width `shrink-0` panels (224px + 288px) crushed the content column to ~1 word per line at 390px, with headings rendering vertically.

## Solution

Pure-utility responsive stack — no JS, no new CSS files:

- The three-panel container stacks below `lg` (`max-lg:flex-col`), natural DOM order TOC → content → metadata.
- Panels go full-width and non-sticky on mobile; the TOC stays bounded and scrollable (`max-lg:max-h-72`) so a long TOC doesn't bury the content; metadata flows full height via `max-lg:max-h-none` alone (deliberately no overflow override — an explicit `overflow-y: visible` would un-pair `overflow-x` from `auto` and reintroduce horizontal leaking; browser-verified during review).
- Side borders become top/bottom borders when stacked; content padding tightens on mobile.
- Header toolbar row gets `flex-wrap` so toggles + actions wrap instead of overflowing.
- The Stimulus panel toggles keep working unchanged at all breakpoints (`hidden` never contested).

A Filters-style mobile overlay (collapsed-by-default panels + backdrop) was evaluated and deferred as a possible v2 — it requires viewport-aware toggle state in JS.

## Testing

- Full Minitest suite: 2684 runs, 0 failures; 4 new assertions for the stacking classes. RuboCop clean.
- Browser-verified: 390px and 768px stack correctly with readable content and working TOC toggle; desktop (1495px) three-column layout byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1N7BfwLwegVK1unPhFdKD