### PR TITLE
feat(index_page): aceptar back: como ShowPage/FormPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **IndexPage** - accepts `back:` with the same contract as `ShowPage`/`FormPage` and forwards it to the `PageHeader` back button (#639). Nested listings under a resource (e.g. an initiative's approval requests) no longer need to render a `ShowPage` just to inherit the back link. Defaults to `nil` — existing index pages render unchanged.
+
 ## [v2.14.0] - 2026-07-21
 
 ### Added

--- a/app/components/bali/index_page/component.html.erb
+++ b/app/components/bali/index_page/component.html.erb
@@ -1,7 +1,7 @@
 <div class="index-page-component">
   <%= render_breadcrumbs %>
 
-  <%= render Bali::PageHeader::Component.new(title: title, subtitle: subtitle, class: breadcrumb_spacer_class) do |header| %>
+  <%= render Bali::PageHeader::Component.new(title: title, subtitle: subtitle, back: back, class: breadcrumb_spacer_class) do |header| %>
     <%= render_actions_bar %>
   <% end %>
 

--- a/app/components/bali/index_page/component.rb
+++ b/app/components/bali/index_page/component.rb
@@ -8,15 +8,16 @@ module Bali
       renders_many :actions
       renders_one :body
 
-      def initialize(title:, subtitle: nil, breadcrumbs: [])
+      def initialize(title:, subtitle: nil, breadcrumbs: [], back: nil)
         @title = title
         @subtitle = subtitle
         @breadcrumbs = breadcrumbs.map(&:symbolize_keys)
+        @back = back
       end
 
       private
 
-      attr_reader :title, :subtitle, :breadcrumbs
+      attr_reader :title, :subtitle, :breadcrumbs, :back
     end
   end
 end

--- a/app/components/bali/index_page/preview.rb
+++ b/app/components/bali/index_page/preview.rb
@@ -8,6 +8,13 @@ module Bali
       def default
         render_with_template(template: "bali/index_page/previews/default")
       end
+
+      # @label With Back Button
+      # Nested index page (e.g. a resource's sub-listing) with a back link to
+      # its parent, same contract as ShowPage/FormPage (#639).
+      def with_back
+        render_with_template(template: "bali/index_page/previews/with_back")
+      end
     end
   end
 end

--- a/app/components/bali/index_page/previews/with_back.html.erb
+++ b/app/components/bali/index_page/previews/with_back.html.erb
@@ -1,0 +1,19 @@
+<%= render Bali::IndexPage::Component.new(
+  title: 'Reviews',
+  subtitle: '12 reviews for The Matrix',
+  breadcrumbs: [
+    { name: 'Dashboard', href: '/lookbook', icon_name: 'home' },
+    { name: 'Movies', href: '/lookbook' },
+    { name: 'Reviews' }
+  ],
+  back: { href: '/lookbook' }
+) do |page| %>
+  <% page.with_action do %>
+    <%= render Bali::Link::Component.new(name: 'New Review', href: '#', variant: :primary, icon_name: 'plus') %>
+  <% end %>
+  <% page.with_body do %>
+    <%= render Bali::Card::Component.new(style: :bordered) do %>
+      <p class="text-base-content/60">DataTable would go here.</p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -1855,6 +1855,7 @@ Standard listing page with breadcrumbs, title, action buttons, and a body area f
 - `title` - Page title (required)
 - `subtitle` - Text under the title (default: nil)
 - `breadcrumbs` - Array of `{ name:, href: }` hashes (default: [])
+- `back` - Back link, e.g. `{ href: path }` (default: nil)
 
 #### ShowPage
 

--- a/test/bali/components/index_page_test.rb
+++ b/test/bali/components/index_page_test.rb
@@ -39,4 +39,21 @@ class BaliIndexPageComponentTest < ComponentTestCase
     end
     assert_text("24 total")
   end
+
+  def test_renders_back_button
+    render_inline(Bali::IndexPage::Component.new(
+      title: "Approval Requests",
+      back: { href: "/initiatives/1" }
+    )) do |page|
+      page.with_body { "Content" }
+    end
+    assert_selector("a.back-button[href='/initiatives/1']")
+  end
+
+  def test_renders_no_back_button_by_default
+    render_inline(Bali::IndexPage::Component.new(title: "Movies")) do |page|
+      page.with_body { "Content" }
+    end
+    assert_no_selector(".back-button")
+  end
 end


### PR DESCRIPTION
## Caso

Los listados **anidados** bajo un recurso (aprobaciones de una iniciativa, backlog de historias) necesitan el botón de regreso del `PageHeader` hacia su hub/padre. `ShowPage` y `FormPage` ya aceptan `back:`, pero `IndexPage` no — en afal-apps las vistas de índice anidadas terminaban renderizando un `ShowPage` solo para heredar `back:`, perdiendo la semántica del page component correcto (hallazgo emb-10 del informe de estandarización UX; regla R1 / propuesta B4).

Closes #639

## API

Misma forma que `ShowPage`/`FormPage`; se pasa tal cual al `PageHeader`:

```erb
<%= render Bali::IndexPage::Component.new(
      title: t('.title'),
      back: { href: td_flow_initiative_path(@initiative) }) do |page| %>
  <% page.with_body do %>
    ...
  <% end %>
<% end %>
```

`back:` es opcional y por default `nil` — los índices existentes renderizan idéntico (backwards compatible).

## Cambios

- `Bali::IndexPage::Component` acepta `back:` y lo reenvía al `Bali::PageHeader::Component` (mismo botón `back-button` que ShowPage/FormPage).
- Tests: presencia del botón con `back:` y ausencia por default.
- Preview Lookbook `with_back` (índice anidado con regreso al padre).
- Docs: opción `back` en la sección IndexPage de `docs/guides/components.md`.
- CHANGELOG bajo `[Unreleased]`.

## Verificación

- `bundle exec rails test` — 2771 runs, 0 failures, 0 errors.
- `bundle exec rubocop` — 442 files, no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)