### PR TITLE
feat(filter_form): unify simple and advanced filter DSLs into filter_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **FilterForm** - unified filter DSL (#644). `filter_attribute` is now the single declaration from which BOTH filter UIs derive: the advanced `Filters` popover (as always, via `available_attributes`) and, with `simple: true`, the inline `SimpleFilters` row (via `simple_filters_config`). New kwargs: `simple:` / `advanced:` (which UIs offer the attribute), `input:` (simple widget override, e.g. `type: :select, input: :slim_select`; validated against the widget list, invalid values raise at class-definition time), `predicate:`, `blank:`, `default:`, `icon:`, `collection:` (alias of `options:`), and `step:`/`placeholder_min:`/`placeholder_max:` for `:number_range` (previously reachable only through instance-level hashes). `options:`/`collection:`, `label:` and `blank:` also accept **zero-arity procs resolved per-instance with `instance_exec`** — inside them you can use `scope` (the relation the controller passed in, typically already narrowed to the policy scope) and per-request `I18n`, removing the two reasons apps had to bypass the class DSL (overriding `available_attributes` wholesale, or building `simple_filters:` hashes in the controller). Both escape hatches remain supported.
+
+### Deprecated
+
+- **FilterForm** - `simple_filter` is now a thin alias of `filter_attribute(..., simple: true, advanced: false)` and is soft-deprecated (no runtime warning; existing forms keep working unchanged and stay out of the advanced popover, exactly as before). New code should declare one `filter_attribute` per attribute. Note for exotic procs: collection procs now run under `instance_exec` (receiver = the form instance instead of the class where the lambda was defined); lambdas referencing constants/models — every known usage — are unaffected.
+
+### Fixed
+
+- **FilterForm** - `simple_filter type: :date` no longer silently discards the declared `predicate:` (#644). `simple_filter :created_at, type: :date, predicate: :gteq` — the DSL docstring's own example — used to filter by `created_at_eq`; it now honors `:gteq`. `:date_range` still has no single predicate (handled as a range). Also, unknown widget `type:` values now raise `ArgumentError` at class-definition time instead of silently rendering a plain select.
+
 ## [v2.14.0] - 2026-07-21
 
 ### Added

--- a/lib/bali/filter_form.rb
+++ b/lib/bali/filter_form.rb
@@ -54,31 +54,84 @@ module Bali
     attribute :s
 
     class << self
+      # Widgets available in the SimpleFilters UI (valid `input:` values)
+      SIMPLE_INPUTS = %i[select slim_select toggle_group radio_group boolean date
+                         date_range number_range].freeze
+
+      # Default SimpleFilters widget derived from the declared data type.
+      # :text has no entry on purpose — quick text search belongs to search_fields.
+      DEFAULT_SIMPLE_INPUT_FOR_TYPE = {
+        select: :select, boolean: :boolean, date: :date, datetime: :date, number: :number_range
+      }.freeze
+
       # Storage for filter attribute definitions used by Filters UI
       def filter_attributes
         @filter_attributes ||= []
       end
 
-      # Define a filterable attribute for the Filters component.
-      # This is used to generate the filter UI and provide labels/options.
+      # Define a filterable attribute. One declaration can feed BOTH filter UIs:
+      # the advanced Filters popover (via #available_attributes) and, when
+      # `simple: true`, the inline SimpleFilters row (via #simple_filters_config).
       #
       # @param key [Symbol] Attribute key (column name or Ransack association path)
-      # @param type [Symbol] Attribute type: :text, :number, :date, :datetime,
-      #   :select, :boolean
-      # @param label [String] Human-readable label (defaults to humanized key)
-      # @param options [Array] For select types, array of [label, value] pairs
+      # @param type [Symbol] Data type: :text, :number, :date, :datetime,
+      #   :select, :boolean. Drives the advanced UI operators and the default
+      #   simple widget.
+      # @param label [String, Proc] Human-readable label (defaults to humanized key).
+      #   Zero-arity procs are resolved per-instance with instance_exec (useful
+      #   for I18n lookups that must not be frozen at class-load time).
+      # @param options [Array, Proc] For select types, array of [label, value]
+      #   pairs or a zero-arity proc resolved per-instance with instance_exec —
+      #   inside it you can use `scope` (the relation the controller passed in,
+      #   typically already narrowed to the policy scope).
+      # @param collection [Array, Proc] Alias of options (legacy simple_filter name)
+      # @param simple [Boolean] Also render this attribute in the SimpleFilters UI
+      # @param advanced [Boolean] Offer this attribute in the Filters popover
+      #   (default true; the legacy simple_filter DSL declares with false)
+      # @param input [Symbol] SimpleFilters widget when it differs from the one
+      #   derived from type (e.g. type: :select, input: :slim_select)
+      # @param predicate [Symbol] Fixed Ransack predicate for the simple UI
+      #   (default :eq; the advanced UI lets the user pick the operator)
+      # @param blank [String, Proc] Blank option text for the simple UI
+      # @param default [String] Default value for the simple UI
+      # @param icon [String] Icon name for the simple UI
+      # @param step [Numeric] Step for the :number_range simple widget
+      # @param placeholder_min [String] Min placeholder for :number_range
+      # @param placeholder_max [String] Max placeholder for :number_range
       #
-      # @example
+      # @example Advanced popover only (same as always)
       #   filter_attribute :name, type: :text
-      #   filter_attribute :status, type: :select,
-      #     options: [['Active', 'active'], ['Inactive', 'inactive']]
-      #   filter_attribute :created_at, type: :date, label: 'Created Date'
-      def filter_attribute(key, type: :text, label: nil, options: [])
+      #
+      # @example Both UIs, collection narrowed to the policy scope
+      #   filter_attribute :pm_id, type: :select, simple: true,
+      #     options: -> { User.where(id: scope.select(:pm_id)).pluck(:name, :id) }
+      #
+      # @example Simple UI only, custom widget
+      #   filter_attribute :priority, type: :select, simple: true, advanced: false,
+      #     options: [['High', 'high'], ['Low', 'low']], input: :toggle_group
+      # rubocop:disable Metrics/ParameterLists
+      def filter_attribute(key, type: :text, label: nil, options: [], collection: nil,
+                           simple: false, advanced: true, input: nil, predicate: :eq,
+                           blank: nil, default: nil, icon: nil, step: nil,
+                           placeholder_min: nil, placeholder_max: nil)
+        # rubocop:enable Metrics/ParameterLists
+        type = type.to_sym
         filter_attributes << {
-          key: key,
+          key: key.to_sym,
           type: type,
           label: label || key.to_s.humanize,
-          options: options
+          explicit_label: label,
+          options: options.presence || collection || [],
+          simple: simple,
+          advanced: advanced,
+          input: simple ? resolve_simple_input(key, type, input) : input&.to_sym,
+          predicate: predicate&.to_sym,
+          blank: blank,
+          default: default,
+          icon: icon,
+          step: step,
+          placeholder_min: placeholder_min,
+          placeholder_max: placeholder_max
         }
       end
 
@@ -87,6 +140,27 @@ module Bali
       def inherited(subclass)
         super
         subclass.instance_variable_set(:@filter_attributes, filter_attributes.dup)
+      end
+
+      private
+
+      # Validate an explicit simple `input:` or derive it from the data type.
+      # Fails fast at class-definition time so a typo'd widget never renders
+      # silently as a plain select.
+      def resolve_simple_input(key, type, input)
+        if input
+          input = input.to_sym
+          return input if SIMPLE_INPUTS.include?(input)
+
+          raise ArgumentError, "filter_attribute #{key}: unknown input: :#{input} " \
+                               "(valid: #{SIMPLE_INPUTS.join(', ')})"
+        end
+
+        DEFAULT_SIMPLE_INPUT_FOR_TYPE.fetch(type) do
+          raise ArgumentError, "filter_attribute #{key}: type :#{type} has no simple filter " \
+                               "widget; pass input: (one of #{SIMPLE_INPUTS.join(', ')}) or " \
+                               "declare quick text search with search_fields"
+        end
       end
     end
 
@@ -219,9 +293,26 @@ module Bali
     # Get the available filter attributes defined via filter_attribute DSL.
     # Used by Filters component for rendering the filter UI.
     #
+    # Entries declared with `advanced: false` (including everything declared
+    # through the legacy simple_filter DSL) are excluded. `label:`/`options:`
+    # given as zero-arity procs are resolved here with instance_exec, so they
+    # can use instance context — most importantly `scope`, the (typically
+    # policy-scoped) relation the controller passed in.
+    #
+    # Override this method for full control; the Filters component consumes
+    # whatever it returns.
+    #
     # @return [Array<Hash>] Array of attribute definitions with :key, :type, :label, :options
     def available_attributes
-      self.class.filter_attributes
+      @available_attributes ||=
+        self.class.filter_attributes.reject { |attr| attr[:advanced] == false }.map do |attr|
+          {
+            key: attr[:key],
+            type: attr[:type],
+            label: resolve_definition_value(attr[:label]) || attr[:key].to_s.humanize,
+            options: resolve_definition_value(attr[:options]) || []
+          }
+        end
     end
 
     def query_params
@@ -280,6 +371,15 @@ module Bali
     end
 
     private
+
+    # Resolve a DSL value that may be callable. Zero-arity procs run under
+    # instance_exec so they can reference the form instance (e.g. `scope`);
+    # other callables are invoked as-is.
+    def resolve_definition_value(value)
+      return value unless value.respond_to?(:call)
+
+      value.is_a?(Proc) && value.arity.zero? ? instance_exec(&value) : value.call
+    end
 
     def non_date_range_attribute_names
       attribute_names - date_range_attributes

--- a/lib/bali/filter_form/simple_filters_configuration.rb
+++ b/lib/bali/filter_form/simple_filters_configuration.rb
@@ -6,12 +6,13 @@ module Bali
     # Unlike the complex Filters component, simple filters render as inline select dropdowns
     # without AND/OR groupings, operators, or popovers.
     #
-    # @example Class-level DSL
+    # @example Class-level DSL (canonical: unified filter_attribute)
     #   class DepartmentsFilterForm < Bali::FilterForm
-    #     simple_filter :legal_entity_id,
-    #       collection: -> { LegalEntity.active.pluck(:name, :id) },
+    #     filter_attribute :legal_entity_id, type: :select, simple: true,
+    #       options: -> { LegalEntity.where(id: scope.select(:legal_entity_id)).pluck(:name, :id) },
     #       blank: "All Entities"
     #
+    #     # Legacy alias (still supported): simple-UI-only declaration
     #     simple_filter :status,
     #       collection: [["Active", "active"], ["Inactive", "inactive"]],
     #       blank: "All",
@@ -27,16 +28,47 @@ module Bali
       extend ActiveSupport::Concern
 
       class_methods do
-        # Storage for simple filter definitions
+        # Data type (advanced Filters UI vocabulary) implied by each legacy
+        # simple_filter widget type.
+        LEGACY_TYPE_FOR_INPUT = {
+          select: :select, slim_select: :select, toggle_group: :select, radio_group: :select,
+          boolean: :boolean, date: :date, date_range: :date, number_range: :number
+        }.freeze
+
+        # Simple filter definitions, derived from the unified filter_attribute
+        # storage (entries declared with `simple: true`) and mapped to the
+        # legacy shape the SimpleFilters pipeline consumes.
         def defined_simple_filters
-          @defined_simple_filters ||= []
+          filter_attributes.select { |attr| attr[:simple] }.map do |attr|
+            {
+              attribute: attr[:key],
+              collection: attr[:options],
+              blank: attr[:blank],
+              label: attr[:explicit_label],
+              default: attr[:default],
+              type: attr[:input],
+              # date_range filters have no single predicate (range handled via where clause)
+              predicate: attr[:input] == :date_range ? nil : attr[:predicate],
+              icon: attr[:icon],
+              step: attr[:step],
+              placeholder_min: attr[:placeholder_min],
+              placeholder_max: attr[:placeholder_max]
+            }
+          end
         end
 
         # Define a simple dropdown filter for the SimpleFilters component.
         #
+        # @deprecated Legacy alias for {Bali::FilterForm.filter_attribute} with
+        #   `simple: true, advanced: false`. Kept for backwards compatibility;
+        #   new code should declare a single filter_attribute per attribute so
+        #   both filter UIs share one definition.
+        #
         # @param attribute [Symbol] Attribute key (column name)
         # @param collection [Array, Proc] Options for select - array of [label, value] pairs
-        #   or a Proc that returns such an array (not needed for :date type)
+        #   or a Proc that returns such an array (not needed for :date type).
+        #   Zero-arity procs run with instance_exec, so they can use `scope`
+        #   (the relation the controller passed in, typically policy-scoped).
         # @param blank [String, nil] Blank option text (e.g., "All Statuses")
         # @param label [String, nil] Human-readable label (defaults to humanized attribute)
         # @param default [String, nil] Default value when no filter is active
@@ -49,12 +81,6 @@ module Bali
         #     collection: [["Active", "active"], ["Inactive", "inactive"]],
         #     blank: "All"
         #
-        # @example Searchable dropdown
-        #   simple_filter :country,
-        #     collection: Country.pluck(:name, :code),
-        #     blank: "All Countries",
-        #     type: :slim_select
-        #
         # @example Date filter
         #   simple_filter :created_at,
         #     type: :date,
@@ -62,23 +88,20 @@ module Bali
         #     label: "Created after"
         def simple_filter(attribute, collection: nil, blank: nil, label: nil, default: nil,
                           type: :select, predicate: :eq, icon: nil)
-          resolved_predicate = type.to_sym.in?(%i[date date_range]) ? nil : predicate
-          defined_simple_filters << {
-            attribute: attribute.to_sym,
-            collection: collection,
-            blank: blank,
+          input = type.to_sym
+          filter_attribute(
+            attribute,
+            type: LEGACY_TYPE_FOR_INPUT.fetch(input, :select),
             label: label,
+            options: collection,
+            simple: true,
+            advanced: false,
+            input: input,
+            predicate: predicate,
+            blank: blank,
             default: default,
-            type: type.to_sym,
-            predicate: resolved_predicate&.to_sym,
             icon: icon
-          }
-        end
-
-        # Inherit simple_filters from parent class
-        def inherited(subclass)
-          super
-          subclass.instance_variable_set(:@defined_simple_filters, defined_simple_filters.dup)
+          )
         end
       end
 
@@ -110,8 +133,8 @@ module Bali
           config = {
             attribute: filter[:attribute],
             collection: resolve_collection(filter[:collection]),
-            blank: filter[:blank],
-            label: filter[:label] || infer_simple_filter_label(filter[:attribute]),
+            blank: resolve_definition_value(filter[:blank]),
+            label: resolve_definition_value(filter[:label]) || infer_simple_filter_label(filter[:attribute]),
             default: filter[:default],
             type: type,
             predicate: predicate,
@@ -228,9 +251,11 @@ module Bali
         }
       end
 
-      # Resolve collection - call if Proc, return as-is otherwise
+      # Resolve collection — arrays pass through; zero-arity procs run with
+      # instance_exec (see FilterForm#resolve_definition_value), so class-level
+      # lambdas can build collections narrowed to the policy scope via `scope`.
       def resolve_collection(collection)
-        collection.respond_to?(:call) ? collection.call : collection
+        resolve_definition_value(collection)
       end
 
       # Infer label from attribute name using I18n or humanization

--- a/test/bali/filter_form_test.rb
+++ b/test/bali/filter_form_test.rb
@@ -57,6 +57,23 @@ class ExtendedSimpleFilterForm < SimpleFilterableMovieFilterForm
                 label: "Indie Film"
 end
 
+# Unified DSL: one filter_attribute declaration feeding BOTH filter UIs (#644)
+class UnifiedMovieFilterForm < Bali::FilterForm
+  filter_attribute :genre, type: :select, simple: true,
+                   options: -> { scope.order(:genre).distinct.pluck(:genre).compact.map { |g| [ g, g ] } },
+                   blank: "All Genres"
+  filter_attribute :name, type: :text
+  filter_attribute :status, type: :select, simple: true, advanced: false,
+                   options: [ %w[Done done], %w[Draft draft] ],
+                   label: -> { "Estado" }, default: "draft", input: :slim_select
+end
+
+# Legacy alias declaring a :date filter with an explicit predicate (bug fix:
+# the declared predicate used to be silently discarded and replaced with :eq)
+class DatePredicateFilterForm < Bali::FilterForm
+  simple_filter :created_at, type: :date, predicate: :gteq, label: "Created after"
+end
+
 # Test form with group_by_attribute DSL. No custom scope order so the
 # group-first ordering is the sole ORDER BY (sort-within-groups assertions).
 class GroupableMovieFilterForm < Bali::FilterForm
@@ -170,7 +187,10 @@ class BaliFilterFormTest < ActiveSupport::TestCase
 
   def test_available_attributes_returns_the_filter_attributes_from_the_class
     @form = AdvancedMovieFilterForm.new(Movie.all, params({}))
-    assert_equal(AdvancedMovieFilterForm.filter_attributes, @form.available_attributes)
+    expected = AdvancedMovieFilterForm.filter_attributes.map do |attr|
+      attr.slice(:key, :type, :label, :options)
+    end
+    assert_equal(expected, @form.available_attributes)
   end
 
   def test_available_attributes_returns_empty_array_for_forms_without_filter_attribute_definitions
@@ -800,5 +820,93 @@ class BaliFilterFormGroupByTest < ActiveSupport::TestCase
     form = Bali::FilterForm.new(@tenant.movies, group_params("genre"), group_by_attributes: %i[genre status])
     assert_equal(:genre, form.group_by)
     assert_equal(%i[genre status], form.group_by_attributes)
+  end
+end
+
+class BaliFilterFormTestUnifiedDsl < ActiveSupport::TestCase
+  def setup
+    @tenant = Tenant.create(name: "Test")
+    @tenant.movies.create(name: "Snatch", genre: "crime", status: 0)
+    @tenant.movies.create(name: "Heat", genre: "thriller", status: 0)
+  end
+
+  def params(filter_attributes)
+    ActionController::Parameters.new(q: filter_attributes)
+  end
+
+  def test_unified_attribute_appears_in_both_uis
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    assert_includes(form.available_attributes.pluck(:key), :genre)
+    assert_includes(form.simple_filters_config.pluck(:attribute), :genre)
+  end
+
+  def test_options_proc_resolves_with_instance_context_for_the_advanced_ui
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    genre = form.available_attributes.find { |a| a[:key] == :genre }
+    assert_equal([ %w[crime crime], %w[thriller thriller] ], genre[:options])
+  end
+
+  def test_options_proc_sees_only_the_scoped_relation
+    other_tenant = Tenant.create(name: "Other")
+    other_tenant.movies.create(name: "Z", genre: "zombie", status: 0)
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    genre = form.available_attributes.find { |a| a[:key] == :genre }
+    refute_includes(genre[:options].map(&:last), "zombie")
+  end
+
+  def test_options_proc_resolves_for_the_simple_ui_too
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    genre = form.simple_filters_config.find { |c| c[:attribute] == :genre }
+    assert_equal([ %w[crime crime], %w[thriller thriller] ], genre[:collection])
+    assert_equal("All Genres", genre[:blank])
+  end
+
+  def test_advanced_false_keeps_the_attribute_out_of_the_popover
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    refute_includes(form.available_attributes.pluck(:key), :status)
+  end
+
+  def test_input_overrides_the_simple_widget
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    status = form.simple_filters_config.find { |c| c[:attribute] == :status }
+    assert_equal(:slim_select, status[:type])
+    assert_equal("draft", status[:default])
+  end
+
+  def test_label_proc_resolves_at_instance_time
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({}))
+    status = form.simple_filters_config.find { |c| c[:attribute] == :status }
+    assert_equal("Estado", status[:label])
+  end
+
+  def test_legacy_simple_filter_stays_out_of_the_advanced_popover
+    form = SimpleFilterableMovieFilterForm.new(@tenant.movies, params({}))
+    assert_equal([], form.available_attributes)
+  end
+
+  def test_simple_text_attribute_without_input_raises
+    error = assert_raises(ArgumentError) do
+      Class.new(Bali::FilterForm) { filter_attribute :notes, type: :text, simple: true }
+    end
+    assert_match(/no simple filter widget/, error.message)
+  end
+
+  def test_unknown_simple_input_raises
+    error = assert_raises(ArgumentError) do
+      Class.new(Bali::FilterForm) { filter_attribute :notes, type: :select, simple: true, input: :bogus }
+    end
+    assert_match(/unknown input/, error.message)
+  end
+
+  def test_date_simple_filter_honors_declared_predicate
+    form = DatePredicateFilterForm.new(Movie.all, params({ created_at_gteq: "2024-01-01" }))
+    assert_includes(form.simple_filters_permitted_keys, "created_at_gteq")
+    assert_equal("2024-01-01", form.ransack_params["created_at_gteq"])
+  end
+
+  def test_unified_simple_value_reaches_ransack_params_and_result
+    form = UnifiedMovieFilterForm.new(@tenant.movies, params({ genre_eq: "crime" }))
+    assert_equal("crime", form.ransack_params["genre_eq"])
+    assert_equal([ "Snatch" ], form.result.pluck(:name))
   end
 end


### PR DESCRIPTION
Closes #644

## Qué hace

Homologa los dos DSLs paralelos de `Bali::FilterForm` en **una sola declaración `filter_attribute`** de la que se derivan AMBAS UIs de filtros, manteniendo `simple_filter` como alias deprecado con comportamiento idéntico.

```ruby
class ProjectsFilterForm < Bali::FilterForm
  # Ambas UIs; colección acotada al policy scope (la lambda VE `scope` vía instance_exec)
  filter_attribute :pm_id, type: :select, simple: true,
                   label: -> { I18n.t("td_flow.filters.pm") },
                   options: -> { User.where(id: scope.select(:pm_id)).order(:name).pluck(:name, :id) }

  # Solo UI simple, widget custom
  filter_attribute :priority, type: :select, simple: true, advanced: false,
                   options: [...], input: :toggle_group
end
```

- `simple:` / `advanced:` controlan en qué UI aparece cada atributo; `input:` elige el widget simple cuando difiere del derivado por `type:` (validado, ArgumentError con typo).
- `options:`/`collection:`, `label:` y `blank:` aceptan **Procs de aridad 0 resueltos por instancia con `instance_exec`** → dentro se puede usar `scope` (la relación que pasó el controller, ya acotada al policy scope) e `I18n` por request. Esto elimina las dos razones por las que las apps rodeaban el DSL de clase (override completo de `available_attributes`; hashes `simple_filters:` armados en el controller). Ambas vías de escape siguen soportadas.
- `step:`/`placeholder_min:`/`placeholder_max:` de `:number_range` por fin declarables en el DSL.

## Retrocompatibilidad

- Forms existentes (solo `simple_filter` o solo `filter_attribute`): comportamiento idéntico; los `simple_filter` siguen SIN aparecer en el popover avanzado. La maquinaria aguas abajo (`simple_filters_config`, permitted keys, ransack params, componentes) consume el mismo shape legacy de siempre.
- `defined_simple_filters` ahora se **deriva** del store unificado (mismo shape de salida; los tests existentes de shape pasan sin tocarse).
- Un solo test existente ajustado: el que asertaba identidad de objetos entre `filter_attributes` (clase) y `available_attributes` (instancia) — contrato interno que esta PR cambia a propósito (ahora la instancia filtra `advanced: false` y resuelve Procs); se compara por `slice(:key, :type, :label, :options)`.

## Bug fix incluido

`simple_filter type: :date` descartaba en silencio el `predicate:` declarado y filtraba por `_eq` — el propio ejemplo del docstring del DSL (`predicate: :gteq`) estaba roto. Ahora se honra. `:date_range` sigue sin predicado único (rango vía where).

## Riesgo documentado

Los Procs de `collection:` ahora corren bajo `instance_exec` (receptor = la instancia del form, no la clase donde se definió la lambda). Toda lambda que referencia constantes/modelos —el 100% de los usos conocidos en afal-apps y gobierno-corporativo— es idéntica; solo cambiaría un Proc que llamara métodos de clase a pelo (no existe ninguno).

## Tests

- `bundle exec rails test test/bali/filter_form_test.rb` → **111 runs, 191 assertions, 0 failures, 0 errors** (12 tests nuevos: ambas UIs desde una declaración, Proc con `scope` acotado por tenant, `advanced: false`, `input:` override, label Proc, alias legacy fuera del popover, ArgumentError fail-fast x2, predicate de `:date` honrado, valor simple → ransack_params/result).
- Suite completa → **2781 runs, 4102 assertions, 0 failures** (los 8 errores de `kitchen_sink_test` en worktree limpio son ambientales —asset tailwind.css sin compilar— y existen igual en origin/main prístino; verificado con stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
