### PR TITLE
fix(slim-select): survive Turbo cache restore + include_blank placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.16.0] - 2026-07-26
+
+### Fixed
+
+- **SlimSelect** - the widget no longer dies (search stops filtering, clicks stop selecting, only the arrow toggles it) after a Turbo restoration visit. Turbo caches a page snapshot while controllers are still connected, so the snapshot already contained the `.ss-main` widget SlimSelect injects; on back/forward — or any navigation to an already-cached page — the controller reconnected and stacked a second, event-less widget over the dead cached one. The controller now tears SlimSelect down on `turbo:before-cache` (so the stored snapshot stays clean) and defensively removes any stale `.ss-main` before re-initializing. Only reproducible through Turbo navigation, not a hard reload — which is why it surfaced in normal app use but not in isolated page loads.
+- **SlimSelect** - `include_blank` / `prompt` now render a proper SlimSelect placeholder instead of a selectable, checkmarked option. Rails emits a plain empty `<option>`; SlimSelect only treats an option as a placeholder — muted and excluded from the selectable list — when it carries `data-placeholder="true"`, so the "choose one" blank previously showed up inside the dropdown as a pickable row with a selected checkmark. `slim_select_field` now promotes the blank of a flat option list to a `data-placeholder="true"` option.
+
 ## [v2.15.0] - 2026-07-22
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    bali_view_components (2.15.0)
+    bali_view_components (2.16.0)
       caxlsx
       lucide-rails (>= 0.3.0)
       rails (>= 7.0, < 9.0)
@@ -421,7 +421,7 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bali_view_components (2.15.0)
+  bali_view_components (2.16.0)
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be

--- a/app/assets/javascripts/bali/controllers/slim-select-controller.js
+++ b/app/assets/javascripts/bali/controllers/slim-select-controller.js
@@ -34,6 +34,19 @@ export class SlimSelectController extends Controller {
   static targets = ['select', 'selectAllButton', 'deselectAllButton']
 
   async connect () {
+    // A Turbo restoration visit (back/forward, or navigating to an already
+    // cached page) replays a snapshot that was captured while this controller
+    // was still connected, so it already contains the `.ss-main` widget
+    // SlimSelect injected. Re-initializing on top of it would stack a second,
+    // event-less widget over the dead cached one — the visible select then
+    // neither filters on search nor selects on click. Drop any stale widget
+    // before (re)initializing, and tear SlimSelect down again right before
+    // Turbo caches the page so the stored snapshot stays clean.
+    this.removeStaleWidget()
+
+    this.beforeCacheHandler = () => this.teardown()
+    document.addEventListener('turbo:before-cache', this.beforeCacheHandler)
+
     try {
       const { default: SlimSelect } = await import('slim-select')
 
@@ -108,7 +121,25 @@ export class SlimSelectController extends Controller {
   }
 
   disconnect () {
+    if (this.beforeCacheHandler) {
+      document.removeEventListener('turbo:before-cache', this.beforeCacheHandler)
+      this.beforeCacheHandler = null
+    }
+    this.teardown()
+  }
+
+  teardown () {
     this.select?.destroy()
+    this.select = null
+  }
+
+  // Remove a SlimSelect widget left behind in a restored Turbo snapshot. The
+  // original <select> (SlimSelect's target) is intentionally preserved so a
+  // fresh instance can attach to it on connect.
+  removeStaleWidget () {
+    this.element
+      .querySelectorAll('.ss-main')
+      .forEach(widget => widget.remove())
   }
 
   dataWithHTML () {

--- a/lib/bali/form_builder/slim_select_fields.rb
+++ b/lib/bali/form_builder/slim_select_fields.rb
@@ -82,12 +82,34 @@ module Bali
       end
 
       def build_select_content(method, values, options, html_options)
-        select_element = select(method, values, options, html_options)
+        select_element = build_select(method, values, options, html_options)
 
         if options[:select_all]
           select_all_buttons(options) + select_element
         else
           select_element
+        end
+      end
+
+      # Rails' include_blank / prompt emit a plain empty <option>. SlimSelect only
+      # treats an <option> as a placeholder — rendered muted and excluded from the
+      # selectable list — when it carries data-placeholder="true"; otherwise it shows
+      # the blank as a real, checkmarked, selectable row. When a blank is requested
+      # for a flat option list, promote it to a proper SlimSelect placeholder so the
+      # "choose one" hint behaves like a placeholder instead of a pickable value.
+      def build_select(method, values, options, html_options)
+        text = placeholder_option_text(options)
+        return select(method, values, options, html_options) if text.nil? || !values.is_a?(Array)
+
+        values = [ [ text, "", { data: { placeholder: true } } ], *values ]
+        select(method, values, options.except(:include_blank, :prompt), html_options)
+      end
+
+      def placeholder_option_text(options)
+        if options[:include_blank]
+          options[:include_blank] == true ? "" : options[:include_blank].to_s
+        elsif options[:prompt].is_a?(String)
+          options[:prompt]
         end
       end
 

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bali
-  VERSION = "2.15.0"
+  VERSION = "2.16.0"
 end

--- a/test/bali/form_builder/slim_select_fields_test.rb
+++ b/test/bali/form_builder/slim_select_fields_test.rb
@@ -60,6 +60,30 @@ class BaliFormBuilderSlimSelectFieldsTest < FormBuilderTestCase
     end
   end
 
+  # include_blank / prompt -> SlimSelect placeholder (issue gobierno-corporativo#570)
+
+  def test_slim_select_field_include_blank_renders_a_slim_select_placeholder_option
+    result = builder.slim_select_field(:status, Movie.statuses.to_a, include_blank: "Choose a status")
+    assert_html(result, 'option[data-placeholder="true"][value=""]', text: "Choose a status")
+  end
+
+  def test_slim_select_field_prompt_renders_a_slim_select_placeholder_option
+    result = builder.slim_select_field(:status, Movie.statuses.to_a, prompt: "Pick one")
+    assert_html(result, 'option[data-placeholder="true"][value=""]', text: "Pick one")
+  end
+
+  def test_slim_select_field_without_blank_renders_no_placeholder_option
+    result = builder.slim_select_field(:status, Movie.statuses.to_a)
+    assert_html(result, "option[data-placeholder]", count: 0)
+  end
+
+  def test_slim_select_field_include_blank_keeps_the_real_options_selectable
+    result = builder.slim_select_field(:status, Movie.statuses.to_a, include_blank: "Choose a status")
+    Movie.statuses.each do |name, value|
+      assert_html(result, "option[value=\"#{value}\"]:not([data-placeholder])", text: name)
+    end
+  end
+
   def test_slim_select_field_applies_daisyui_select_classes
     result = builder.slim_select_field(:status, Movie.statuses.to_a)
     assert_html(result, "select.select.select-bordered")


### PR DESCRIPTION
## Contexto

Dos gaps del componente **SlimSelect** que afloran usando la app AFAL `gobierno-corporativo` — bloquean la unificación de registros maestros MDM (issue [Grupo-AFAL/gobierno-corporativo#570](https://github.com/Grupo-AFAL/gobierno-corporativo/issues/570)). Ninguno estaba arreglado en `main` (v2.15.0); el controlador y el `slim_select_fields.rb` eran idénticos byte a byte desde v2.12.1.

## Qué arregla

### 1. Doble-init tras restauración de Turbo (el BLOCKER)
Turbo cachea el snapshot de la página **mientras los controllers siguen conectados**, así que el DOM cacheado ya contiene el `.ss-main` que SlimSelect inyecta. En una visita de restauración (back/forward, o navegar a una página ya cacheada) el controller reconectaba y **apilaba un segundo widget sin listeners encima del cacheado muerto**: el select visible dejaba de filtrar al buscar, dejaba de seleccionar al hacer clic, y solo la flechita lo abría.

**Fix:** el controller ahora destruye SlimSelect en `turbo:before-cache` (para que el snapshot guardado quede limpio) y, defensivamente, elimina cualquier `.ss-main` stale antes de re-inicializar. Solo reproducible vía navegación Turbo, no en un hard reload — por eso aparecía en el uso normal de la app pero no en cargas aisladas de página.

### 2. `include_blank` / `prompt` como opción seleccionable
SlimSelect solo trata un `<option>` como placeholder (atenuado, excluido de la lista) cuando lleva `data-placeholder="true"`. El blank plano de Rails salía como una fila seleccionable **con palomita** dentro del dropdown. `slim_select_field` ahora promueve el blank de una lista plana de opciones a un placeholder real (`data-placeholder="true"`).

## Verificación

- **RuboCop** (rubocop-rails-omakase): sin ofensas.
- **StandardJS**: limpio sobre el controller.
- **Suite Ruby**: `slim_select_fields_test.rb` 46/46. Suite completa 2826 runs, 0 failures (los 8 errores de `KitchenSinkDemoPagesTest` son pre-existentes: `tailwind.css` no precompilado en el entorno local; fallan idéntico en `main` sin este cambio — CI los cubre al precompilar assets).
- **Navegador** (app consumidora, ambos escenarios): carga fresca y **restauración Turbo** — buscar filtra, clic selecciona, abre en cualquier área, el placeholder ya no es opción, y un solo `.ss-main` tras la restauración (antes: widget muerto / renderer colgado).

## Notas

- El controller slim-select sigue sin harness de tests JS (#157); el fix de Turbo se verifica en el navegador de la app consumidora.
- **No cubierto:** listas de opciones agrupadas (optgroups) conservan el `include_blank` de Rails (los usos actuales son listas planas).

Bump de versión a **v2.16.0**.