### PR TITLE
chore(tooling): los CLAUDE.md cobran contexto por lo que el repo ya contesta, y el statusline apunta a una ruta inexistente

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,29 +20,10 @@ Two project skills load on demand: `lookbook-previews` (writing/editing preview 
 
 ## Development Commands
 
-```bash
-# Run Minitest tests
-bundle exec rails test
+The Lookbook preview server is not a plain `rails s` — start it with `cd spec/dummy && bin/dev`
+and open http://localhost:3001/lookbook. Cypress needs that server already running.
 
-# Run specific component test
-bundle exec rails test test/bali/components/button_test.rb
-
-# Start Lookbook preview server
-cd spec/dummy && bin/dev
-# Open http://localhost:3001/lookbook
-
-# Run Cypress tests (requires server running)
-yarn run cy:run   # Headless
-yarn run cy:open  # Interactive
-```
-
-### Batch Processing (Shell Script)
-```bash
-./scripts/batch-review.sh                          # Review all components (code-only, parallel)
-./scripts/batch-review.sh Button Modal Card        # Review specific components
-./scripts/batch-review.sh --with-visual --parallel 4  # With visual verification (needs port coordination)
-./scripts/batch-review.sh --dry-run
-```
+Bulk component review: `./scripts/batch-review.sh` (read the script for its flags).
 
 ## Engine Gotchas
 
@@ -67,41 +48,14 @@ Cypress tests render Stimulus controllers by visiting `http://localhost:3001/loo
 
 ## Dependency Version Alignment
 
-Bali must stay on the latest Tailwind CSS and daisyUI to keep all AFAL apps aligned. Check versions at the start of substantial work and update before doing other changes if either is behind:
-
-| Dependency | Source | Spec location |
-|------------|--------|---------------|
-| **Tailwind CSS** | `tailwindcss-rails` gem | `Gemfile` |
-| **daisyUI** | `daisyui` npm package | `package.json` |
-
-```bash
-# Update Tailwind CSS (gem)
-bundle update tailwindcss-rails
-
-# Update daisyUI (npm)
-yarn upgrade daisyui
-```
-
-After updating, run the full test suite to confirm nothing breaks.
+Bali must stay on the latest Tailwind CSS (`tailwindcss-rails` gem) and daisyUI (npm) to keep all
+AFAL apps aligned. Check both at the start of substantial work and update them *before* other
+changes if either is behind, then run the full test suite.
 
 ## Pre-Commit Checklist
 
-Before committing changes:
-
-```bash
-# 1. Run tests
-bundle exec rails test
-
-# 2. Run Rubocop
-bundle exec rubocop -a
-
-# 3. Check Lookbook preview works
-cd spec/dummy && bin/dev
-# Verify component renders correctly
-
-# 4. Run Cypress tests (if JS changes)
-yarn run cy:run
-```
+Rubocop and Minitest run automatically via `.githooks` (pre-commit and pre-push). Cypress does
+not — run `yarn run cy:run` yourself when you touch JS, and confirm the Lookbook preview renders.
 
 ## Tailwind v4 CSS Layer Gotcha
 
@@ -211,54 +165,14 @@ Use the correct component based on **what the element does**, not how it looks:
 
 ## Icons
 
-The Bali icon system uses **Lucide icons** as the primary source, with backwards compatibility for existing icon names.
+Icons resolve through a pipeline that falls back across several sources, so a name that "should"
+be Lucide may not be. Never assume a mapping — read the source:
 
-### Icon Resolution Pipeline
-
-When you use `Bali::Icon::Component.new('icon-name')`, the system resolves icons in this order:
-
-1. **Lucide mapping** - Old Bali names mapped to Lucide equivalents (e.g., `edit` → `pencil`)
-2. **Direct Lucide** - Use any [Lucide icon](https://lucide.dev/icons) name directly
-3. **Kept icons** - Brand logos, regional icons, custom domain icons
-4. **Legacy fallback** - Original Bali SVGs for full backwards compatibility
-
-### Icon Categories
-
-| Category | Source | Examples |
-|----------|--------|----------|
-| **UI Icons** | Lucide (via mapping) | `edit`, `trash`, `search`, `check`, `times` |
-| **Direct Lucide** | Lucide | Any icon from [lucide.dev/icons](https://lucide.dev/icons) |
-| **Payment Brands** | Kept SVGs | `visa`, `mastercard`, `american-express`, `paypal`, `oxxo` |
-| **Social Brands** | Kept SVGs | `whatsapp`, `facebook`, `youtube`, `twitter`, `linkedin` |
-| **Regional** | Kept SVGs | `mexico-flag`, `us-flag` |
-| **Custom Domain** | Kept SVGs | `recipe-book`, `diagnose`, `day`, `month`, `week` |
-
-### Key Files
-
-| File | Purpose |
-|------|---------|
-| `app/components/bali/icon/lucide_mapping.rb` | Maps old Bali names → Lucide names (authoritative — check it before assuming a mapping) |
-| `app/components/bali/icon/kept_icons.rb` | Brand, regional, and custom icons |
-| `app/components/bali/icon/component.rb` | Resolution pipeline |
+- `app/components/bali/icon/component.rb` — the resolution pipeline
+- `app/components/bali/icon/lucide_mapping.rb` — old Bali names → Lucide (authoritative)
+- `app/components/bali/icon/kept_icons.rb` — brand, regional, and custom-domain SVGs
 
 ## BlockNote / ProseMirror Gotchas
 
-### Turbo + React + ProseMirror cleanup
-ProseMirror plugins (e.g. Placeholder) remove DOM nodes during destroy. If Turbo detaches the tree first, `removeChild` throws. Fix: destroy `_tiptapEditor` before calling `root.unmount()` in Stimulus `disconnect()`.
-
-### Content serialization with comment marks
-`useContentSync` debounces content writes to the hidden input by 500ms. If `save()` reads the input immediately, it may get stale content without comment marks. Fix: flush content synchronously from the editor before reading the hidden input in `save()`.
-
-### BlockNote comment mark cleanup
-`ThreadStore.deleteThread()` removes the thread from the store but does NOT remove `comment` marks from the ProseMirror document. Must explicitly call `tr.removeMark()` for the deleted threadId.
-
-### Multiple Stimulus controllers on same page
-Document show pages may render multiple overlays (editor + viewer), each with their own `document-editor` controller. Global keyboard listeners (e.g. Cmd+S on `document`) fire on ALL controllers. Guard actions against read-only/empty state.
-
-## Resources
-
-- [ViewComponent Docs](https://viewcomponent.org/)
-- [DaisyUI Components](https://daisyui.com/components/)
-- [Tailwind CSS](https://tailwindcss.com/docs)
-- [Lookbook](https://lookbook.build/)
-- [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introduction)
+See `app/components/bali/block_editor/CLAUDE.md` — loads automatically when working in the
+editor components.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,10 +59,6 @@
       "Bash(> /dev/*)"
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "bash /Users/fede/code/shared/bali-view-components/.claude/statusline-command.sh"
-  },
   "enabledPlugins": {
     "rails-tools@afal-plugins": true,
     "oh-my-claudecode@omc": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tooling** - `.claude/settings.json` no longer overrides the statusline with a dead path. The `statusLine` command pointed at `/Users/fede/code/shared/bali-view-components/.claude/statusline-command.sh`, an absolute path into a directory that exists on no machine — and since project settings win over user settings, it silently replaced whatever statusline each contributor had configured with nothing at all. Removed, so the user-scope statusline applies again. No effect on the published gem.
+
 ## [v2.18.0] - 2026-07-31
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Tooling** - adelgazados los CLAUDE.md que se cargan en cada sesión (`CLAUDE.md` 47 → 29 líneas, `.claude/CLAUDE.md` 264 → 178). Se eliminó lo que una sesión puede reconstruir leyendo el repo: overview del proyecto, comandos estándar de Rails/Cypress ya presentes en `package.json`, la tabla de dependencias y sus comandos de update, el checklist pre-commit que `.githooks` ya impone (rubocop y minitest), el catálogo de iconos derivable de `lucide_mapping.rb`/`kept_icons.rb`, la lista de enlaces a documentación pública, y la sección "Session Memory" que describía hooks SessionStart/Stop que no están registrados en ninguna configuración. Se conservan íntegros los gotchas (Zeitwerk, Tailwind v4 layers, tooltip móvil), Prohibited Patterns y Component Composition. Los gotchas de BlockNote/ProseMirror se movieron a `app/components/bali/block_editor/CLAUDE.md`, que carga solo al trabajar en los componentes de editor. No effect on the published gem.
+
 ### Fixed
 
 - **Tooling** - `.claude/settings.json` no longer overrides the statusline with a dead path. The `statusLine` command pointed at `/Users/fede/code/shared/bali-view-components/.claude/statusline-command.sh`, an absolute path into a directory that exists on no machine — and since project settings win over user settings, it silently replaced whatever statusline each contributor had configured with nothing at all. Removed, so the user-scope statusline applies again. No effect on the published gem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,24 +2,6 @@
 
 This file provides guidance to Claude Code when working in this repository.
 
-## Project Overview
-
-**Bali** is AFAL's open-source ViewComponent library providing 75+ reusable UI components for Rails applications, styled with Tailwind CSS and DaisyUI.
-
-## Session Memory
-
-This project uses `.ai-sessions/` for session continuity between Docker sandbox runs.
-
-**How it works:**
-- **SessionStart hook** (`bin/hooks/session-memory-load.sh`): Automatically injects `.ai-sessions/latest.md` into every new session
-- **Stop hook** (`bin/hooks/session-memory-save.sh`): Reminds you to write a session summary before exiting
-
-**When ending a session**, write a summary to `.ai-sessions/<timestamp>.md` and copy it to `.ai-sessions/latest.md`. Include:
-- What was accomplished
-- What remains to be done
-- Key decisions made
-- Any blockers or issues
-
 ## Codebase Search (SocratiCode)
 
 This repo is indexed by SocratiCode (hybrid semantic + BM25 search, file watcher active). For exploratory questions ("where is X?", "how does Y work?", "find code that does Z"), reach for `codebase_search` **before** `Grep` or speculative `Read` calls — it returns ranked snippets across the whole repo in one tool call.

--- a/app/components/bali/block_editor/CLAUDE.md
+++ b/app/components/bali/block_editor/CLAUDE.md
@@ -1,0 +1,15 @@
+# BlockNote / ProseMirror Gotchas
+
+Applies to `block_editor`, `document_editor`, and `document_page`.
+
+### Turbo + React + ProseMirror cleanup
+ProseMirror plugins (e.g. Placeholder) remove DOM nodes during destroy. If Turbo detaches the tree first, `removeChild` throws. Fix: destroy `_tiptapEditor` before calling `root.unmount()` in Stimulus `disconnect()`.
+
+### Content serialization with comment marks
+`useContentSync` debounces content writes to the hidden input by 500ms. If `save()` reads the input immediately, it may get stale content without comment marks. Fix: flush content synchronously from the editor before reading the hidden input in `save()`.
+
+### BlockNote comment mark cleanup
+`ThreadStore.deleteThread()` removes the thread from the store but does NOT remove `comment` marks from the ProseMirror document. Must explicitly call `tr.removeMark()` for the deleted threadId.
+
+### Multiple Stimulus controllers on same page
+Document show pages may render multiple overlays (editor + viewer), each with their own `document-editor` controller. Global keyboard listeners (e.g. Cmd+S on `document`) fire on ALL controllers. Guard actions against read-only/empty state.


### PR DESCRIPTION
Dos arreglos de tooling de agentes IA, ninguno toca la gema publicada.

## 1. El statusline del repo estaba muerto (`1fd71ab`)

`.claude/settings.json` fijaba:

```json
"statusLine": {
  "type": "command",
  "command": "bash /Users/fede/code/shared/bali-view-components/.claude/statusline-command.sh"
}
```

Esa ruta no existe — ni el script ni el directorio padre `~/code/shared/bali-view-components`. Y como el scope de proyecto le gana al de usuario en la cascada de settings, la entrada muerta reemplazaba silenciosamente el statusline de **cada contribuidor** por nada. Al ser una ruta absoluta `/Users/fede/...`, tampoco podía resolver en ninguna otra máquina.

Se elimina la clave para que vuelva a aplicar el statusline de usuario.

## 2. Los CLAUDE.md pagaban cada sesión por contexto derivable (`2561f53`)

`CLAUDE.md` 47 → 29 líneas, `.claude/CLAUDE.md` 264 → 178. Sale lo que una sesión reconstruye con un `ls`, un `cat` del manifest o leyendo la fuente:

| Recortado | Por qué |
|---|---|
| Project overview | derivable del gemspec y `app/components/bali/` |
| Comandos de Rails y Cypress | `cy:run`/`cy:open` ya están en `package.json` |
| Tabla de dependencias + comandos de update | derivable de `Gemfile` y `package.json` (se conserva la **política** de mantenerse en la última versión) |
| Checklist pre-commit | `.githooks/pre-commit` ya corre rubocop y `pre-push` ya corre minitest |
| Catálogo de iconos | derivable de `lucide_mapping.rb` y `kept_icons.rb`, que el propio archivo declara autoritativos |
| Lista de enlaces a docs públicas | ViewComponent, DaisyUI, Tailwind, Lookbook, Stimulus |
| Sección "Session Memory" | describía un hook `SessionStart` y uno `Stop` que **no están registrados** en ninguna settings del repo ni del usuario — documentaba maquinaria que no corre |

Se conservan íntegros los gotchas (Zeitwerk `do_not_eager_load`, Tailwind v4 layers, tooltip móvil de DaisyUI), la tabla completa de Prohibited Patterns y todo Component Composition incluido Button vs Link.

Los gotchas de BlockNote/ProseMirror se mueven a `app/components/bali/block_editor/CLAUDE.md`, que carga solo al trabajar bajo ese directorio en lugar de en cada sesión.

**Neto:** ~990 tokens estimados menos de contexto siempre cargado, por sesión.

## Notas

- `bin/hooks/session-memory-load.sh` y `session-memory-save.sh` siguen en el repo pero sin cablear. Si se quieren de vuelta, hay que registrarlos en `.claude/settings.json` antes de volver a documentarlos.
- La sección de SocratiCode se conserva pese a que su MCP no conectaba en mi sesión; eso se decide arreglando `/mcp`, no aquí.

## Verificación

Suite completa vía el hook `pre-push`: **2911 runs, 4355 assertions, 0 failures, 0 errors, 0 skips**. No cambió nada ejecutable — solo `.md` y `.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)