### PR TITLE
test(dummy): fuera la excepción de UNSWEPT que #802 dejó sin objeto

### DIFF
--- a/test/requests/dummy_pages_smoke_test.rb
+++ b/test/requests/dummy_pages_smoke_test.rb
@@ -24,12 +24,7 @@ class DummyPagesSmokeTest < ActionDispatch::IntegrationTest
   UNSWEPT = {
     "documents/comment_threads#index" => "Turbo Stream partial; a bare GET has no frame to " \
                                          "render into and the JSON shape belongs to a " \
-                                         "controller test",
-    # Found by this sweep on its first run and filed rather than fixed here: `resources
-    # :documents` declares the route but DocumentsController has no `edit` action and there
-    # is no `edit.html.erb`, so the URL 404s. Editing a document happens through the overlay
-    # on `documents#show`, so the route is dead rather than broken. See #791.
-    "documents#edit" => "route declared by `resources :documents` with no action behind it (#791)"
+                                         "controller test"
   }.freeze
 
   def setup


### PR DESCRIPTION
Un cabo suelto de la pareja #794 / #802, que ya están las dos dentro.

#794 metió `documents#edit` en la allowlist `UNSWEPT` del barrido de humo porque la ruta existía y respondía 404. **#802 la acotó con `except: :edit`**, así que la ruta ya no existe y la entrada pasó a describir algo que no está.

No rompía nada —`test_no_page_escapes_the_sweep` calcula `dummy_routes - covered`, así que una clave sobrante en `covered` no falla—, pero es documentación falsa dentro de un test cuyo valor entero es decir la verdad sobre qué páginas se piden y cuáles no.

El autor de #802 lo dejó anotado como pendiente para cuando las dos cosas estuvieran mergeadas. Lo estaban; esto es solo el cierre.

```
bundle exec rails test test/requests/dummy_pages_smoke_test.rb
  2 runs, 4 assertions, 0 failures, 0 errors, 0 skips
bundle exec rubocop  1 file inspected, no offenses detected
```

Queda una sola excepción en `UNSWEPT`, la de `documents/comment_threads#index`, que sí es real: es un partial de Turbo Stream y un GET pelado no tiene frame donde renderizar.
