### PR TITLE
feat(form_builder)!: el Cancel de `submit_group` pasa a ghost (#820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **`submit_group`'s Cancel renders `btn-ghost` instead of `btn-secondary`.** Every form using `submit_group` with a `cancel_path:`, `cancel_options:`, `modal:` or `drawer:` repaints its Cancel — no call site changes, but the button changes weight, so it is listed here rather than under Fixed.
+
+  The library was teaching two things at the same time. Every `FormPage` preview builds its actions row by hand and writes `variant: :ghost` on Cancel; `submit_group` — the helper those previews exist to promote — defaulted to `:secondary`. A form has one primary action, and a filled secondary sitting next to Submit reads as a second thing to do rather than as the way out of the form. Whichever of the two was right, shipping both meant the reference implementation and the helper disagreed on the page.
+
+  An explicit class still wins: `cancel_options: { class: 'btn btn-secondary' }`. A test now pins that, next to the one that pins the new default.
+
 - **`Modal` and `Drawer` are native `<dialog>` elements now, opened with `showModal()` — and everything the stacking scale ranked above them had to follow them into the top layer.** This is the last cut of #679; #784 modernised the interior and #796 made portaled popups survive a top-layer overlay, which was this change's precondition. The loading mechanism is untouched: `?layout=false`, the manual fetch, `_replaceBodyAndURL` and the contract of all 194 `drawer: true` / `modal: true` call sites are exactly as they were, per the 31/07 decision that DX parity is the acceptance criterion.
 
   **What the element buys.** `showModal()` paints the panel in the top layer, so no `z-index` in the document can cover it; it makes every node outside the panel inert, so the page behind stops taking clicks and stops being reachable by Tab without any focus trap of ours; and it restores focus to the trigger on close. What is kept hand-written is everything `<dialog>` knows nothing about — the remote load, the instant skeleton, the sequence number that discards an abandoned open, the unsaved-form prompt, and the popups that portal out of the panel.

--- a/docs/guides/form-builder.md
+++ b/docs/guides/form-builder.md
@@ -566,7 +566,9 @@ The actions row: submit with the cancel control beside it. Spelled
 
 **Options:**
 - `cancel_path` - Path for cancel link
-- `cancel_options` - HTML options for cancel link (including `:label`)
+- `cancel_options` - HTML options for cancel link (including `:label`). Cancel renders
+  `btn-ghost`: a form has one primary action, and Cancel is the way out of it rather than a
+  second thing to do. Pass `class:` here to override.
 - `modal` - Integrate with modal controller
 - `drawer` - Integrate with drawer controller
 - `field_class` - Wrapper class (default: flexbox with gap)

--- a/docs/guides/migration-v2-to-v3.md
+++ b/docs/guides/migration-v2-to-v3.md
@@ -1551,6 +1551,24 @@ from the shared table instead of `"btn-#{size}"`. That interpolation was invisib
 Tailwind's scanner, so those classes only ever shipped because some other component happened
 to spell them out. Nothing to change at your call sites.
 
+### `submit_group`'s Cancel is `btn-ghost`, not `btn-secondary`
+
+Nothing to change at the call site, but every form using `submit_group` with a `cancel_path:`,
+`cancel_options:`, `modal:` or `drawer:` repaints its Cancel — from filled secondary to ghost.
+
+The library was teaching two things at once. Every `FormPage` preview builds its actions row by
+hand and writes `variant: :ghost` on Cancel; `submit_group`, the helper those previews exist to
+promote, defaulted to `:secondary`. A form has one primary action, and a filled secondary next
+to Submit reads as a second thing to do rather than as the way out of the form.
+
+If a form wants the old weight, it is one keyword, and an explicit class still wins over the
+default:
+
+```erb
+<%= f.submit_group 'Save', cancel_path: movies_path,
+      cancel_options: { class: 'btn btn-secondary' } %>
+```
+
 ## Timeline renders each entry once, and its slots lose the `tag_` prefix
 
 A timeline item used to emit its heading and its content twice — once in `.timeline-start`,

--- a/lib/bali/form_builder/submit_fields.rb
+++ b/lib/bali/form_builder/submit_fields.rb
@@ -135,11 +135,16 @@ module Bali
           config[:modal] || config[:drawer]
       end
 
+      # Ghost, not secondary: there is one primary action in an actions row and
+      # Cancel is not it. A filled secondary reads as a second thing to do and
+      # competes with Submit for the eye — which is why every `FormPage` preview
+      # in the library already hand-wrote `variant: :ghost` instead of taking
+      # this default. `class:` in `cancel_options` still wins.
       def build_cancel_link_options(config)
         link_options = dup_options(config[:options] || {}).except(:label)
         link_options = prepend_action(link_options, "modal#close") if config[:modal]
         link_options = prepend_action(link_options, "drawer#close") if config[:drawer]
-        link_options.with_defaults(class: button_classes(variant: :secondary))
+        link_options.with_defaults(class: button_classes(variant: :ghost))
       end
 
       def show_cancel_button?(options)

--- a/test/bali/form_builder/submit_buttons_test.rb
+++ b/test/bali/form_builder/submit_buttons_test.rb
@@ -157,7 +157,13 @@ class BaliFormBuilderSubmitButtonsTest < FormBuilderTestCase
 
   def test_submit_group_with_cancel_path_and_cancel_options_renders_a_cancel_button
     result = builder.submit_group("Save", cancel_path: "/", cancel_options: { label: "Back" })
-    assert_html(result, 'a.btn.btn-secondary[href="/"]', text: "Back")
+    assert_html(result, 'a.btn.btn-ghost[href="/"]', text: "Back")
+  end
+
+  def test_submit_group_cancel_takes_an_explicit_class_over_the_ghost_default
+    result = builder.submit_group("Save", cancel_path: "/", cancel_options: { class: "btn btn-secondary" })
+    assert_html(result, 'a.btn.btn-secondary[href="/"]')
+    refute_html(result, "a.btn-ghost")
   end
 
   def test_submit_group_with_cancel_path_and_cancel_options_renders_a_submit_button


### PR DESCRIPTION
Cierra #820.

## El problema

La librería enseñaba dos cosas a la vez:

- todos los previews de `FormPage` arman su fila de acciones a mano y escriben `variant: :ghost` en el Cancel;
- `submit_group` — el helper que esos previews existen para promover — traía `:secondary` de default.

Un formulario tiene **una** acción primaria, y un secundario relleno al lado del Submit se lee como una segunda cosa que hacer en vez de como la salida del formulario. Cualquiera de las dos convenciones podía ser la buena; enviar las dos significaba que la implementación de referencia y el helper se contradecían en la misma página.

## El cambio

`lib/bali/form_builder/submit_fields.rb` → `button_classes(variant: :ghost)`.

No cambia ningún call site, pero **el botón cambia de peso** en todo form que use `submit_group` con `cancel_path:`, `cancel_options:`, `modal:` o `drawer:`. Por eso va en `### Changed (breaking)` y en la guía de migración, no en Fixed.

Una clase explícita sigue ganando:

```erb
<%= f.submit_group 'Save', cancel_path: movies_path,
      cancel_options: { class: 'btn btn-secondary' } %>
```

Hay un test nuevo que fija ese escape, al lado del que fija el default nuevo.

## Verificación

- Navegador: `/studios/new` (el `submit_group` real del dummy, con `drawer:`) y el preview `bali/form/submit/submit_group`. El Cancel ya no compite con el primario.
- Minitest **3688/0** (el que rompía a propósito, `submit_buttons_test.rb:158`, actualizado; el de `:54` no rompe porque pasa `variant: :secondary` explícito, que es otra cosa).
- Cypress **187/187**.

Documentado en `docs/guides/migration-v2-to-v3.md` (sección de la taxonomía de botones) y en `docs/guides/form-builder.md`.