### PR TITLE
fix(block_editor): los comentarios se escribían en vertical y la burbuja no tenía ancho (#869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **A `BlockEditor` comment is written across the card instead of one letter per line, and the bubble it is written in has a width.** Two defects in the same feature, both visible the moment you type a comment on `/lookbook/preview/bali/block_editor/with_comments`.
+
+  Every comment body is its own nested BlockNote instance, and it emits a **second** `.bn-container` — `.bn-container.bn-comment-editor` — inside `.bn-thread`. The two rules that lay the editor out beside its threads sidebar, `.bn-with-comments .bn-container` and `.bn-with-comments .bn-container > .bn-editor`, reached those nested containers as well: each became a flex row whose editor child took `flex: 1; min-width: 0`, which is a `flex-basis: 0%` item inside a shrink-to-fit box and resolves to zero. Measured with a comment open: the comment editor 163px wide, its `.bn-editor` **0px**. So the text — and the "Add comment" placeholder with it — wrapped at every character, in the floating popover and in the sidebar alike. Both rules, and the `@media` rule that flips them to a column, now use the child combinator, so they describe the top-level container and nothing else. The rules are from the original comments work (#482); this is not a regression of #832.
+
+  With the text laid out again, the popover had no width of its own: **165px** for a three-letter draft and **966px** for one long line, breathing with every keystroke. The rule meant to bound it keyed off `.bn-floating-composer` and `.bn-floating-thread`, and neither is in the DOM any more — measured 0 elements with a composer open — so its `max-width: 20rem` had never applied. BlockNote floats the card with Floating UI, and the portal it renders into is a hook that does exist; the card is `20rem` wide there now, `max-width: calc(100vw - 2rem)`, and carries its own card edges, since `.document-editor-panel .bn-thread` deliberately strips them for the side panel's list rows.
+
 ## [v3.0.0.beta.2] - 2026-08-03
 
 ### Fixed

--- a/app/components/bali/block_editor/index.css
+++ b/app/components/bali/block_editor/index.css
@@ -403,15 +403,25 @@
 
 /* When comments are enabled, the ThreadsSidebar lives inside BlockNoteView
  * (required for React context). We apply flex layout to .bn-container so
- * the editor and sidebar sit side-by-side. */
-.bn-with-comments .bn-container {
+ * the editor and sidebar sit side-by-side.
+ *
+ * The child combinator is load-bearing. Every comment body is its own nested
+ * BlockNote instance, and it emits a SECOND `.bn-container`
+ * (`.bn-container.bn-comment-editor`) inside `.bn-thread`. As a descendant
+ * selector this pair turned each of those into a flex row and handed its
+ * `.bn-editor` `flex: 1; min-width: 0` — a `flex-basis: 0%` item in a
+ * shrink-to-fit container, which resolves to width 0. Measured on
+ * /lookbook/preview/bali/block_editor/with_comments: comment editor 163px wide,
+ * its `.bn-editor` 0px, so every comment and the "Add comment" placeholder
+ * wrapped one character per line, in the popover and in the sidebar alike. */
+.bn-with-comments > .bn-container {
   display: flex;
   gap: 1.5rem;
   align-items: flex-start;
 }
 
 /* Editor takes remaining space */
-.bn-with-comments .bn-container > .bn-editor {
+.bn-with-comments > .bn-container > .bn-editor {
   flex: 1;
   min-width: 0;
 }
@@ -494,14 +504,31 @@
   background-color: color-mix(in oklch, var(--color-warning) 35%, transparent);
 }
 
-/* Floating composer and thread popovers */
-.block-editor-component .bn-floating-composer,
-.block-editor-component .bn-floating-thread {
-  background-color: var(--color-base-100) !important;
-  border: 1px solid color-mix(in oklch, var(--color-base-content) 15%, transparent) !important;
-  box-shadow: 0 4px 16px color-mix(in oklch, var(--color-base-content) 15%, transparent) !important;
+/* Floating composer and thread popovers.
+ *
+ * The two selectors this rule used to carry, `.bn-floating-composer` and
+ * `.bn-floating-thread`, match nothing — measured 0 elements on
+ * /lookbook/preview/bali/block_editor/with_comments while a composer was open —
+ * so its `max-width: 20rem` never applied. BlockNote floats the card with
+ * Floating UI, and the portal that renders it is the hook that does exist.
+ *
+ * `width` and not `max-width`, because the positioned box Floating UI emits
+ * carries no width of its own: the card was shrink-to-fit and breathed with the
+ * text, measured 165px for a three-letter draft and 966px for one long line.
+ * 20rem is the threads sidebar's 18rem plus the gutters the popover has and the
+ * sidebar does not.
+ *
+ * The card look is repeated here rather than inherited because
+ * `.document-editor-panel .bn-thread` further down deliberately strips it — a
+ * thread in that side panel is a row in a list, not a card — and a popover
+ * floating over the page needs its own edges either way. */
+:is(.block-editor-component, .document-editor-panel) [data-floating-ui-portal] .bn-thread {
+  width: 20rem;
+  max-width: calc(100vw - 2rem);
+  background-color: var(--color-base-100);
+  border: 1px solid color-mix(in oklch, var(--color-base-content) 15%, transparent);
   border-radius: var(--radius-box, 0.5rem);
-  max-width: 20rem;
+  box-shadow: 0 4px 16px color-mix(in oklch, var(--color-base-content) 15%, transparent);
 }
 
 /* --- Tooltip styling (Mantine Tooltip used by reaction badges, action buttons) ---
@@ -900,9 +927,10 @@
   border-radius: 0.25rem;
 }
 
-/* Collapse comments sidebar on narrow viewports */
+/* Collapse comments sidebar on narrow viewports.
+ * `>` for the same reason as the rule this overrides — see the note there. */
 @media (max-width: 768px) {
-  .bn-with-comments .bn-container {
+  .bn-with-comments > .bn-container {
     flex-direction: column;
   }
 

--- a/cypress/e2e/block-editor-comments.cy.js
+++ b/cypress/e2e/block-editor-comments.cy.js
@@ -1,0 +1,78 @@
+// Los comentarios del BlockEditor se rompian por el alcance de dos selectores, no por una
+// interaccion, asi que esto maneja la cascada en vez de la interaccion: monta el markup que
+// BlockNote emite dentro del contenedor real y lee lo que pintan las hojas que se embarcan.
+// Es el mismo enfoque que document-editor.cy.js usa para el tooltip, y por la misma razon —
+// el composer flotante solo lo monta un click real sobre una seleccion real, y nada de lo
+// que se prueba aca depende de como aparecio la tarjeta.
+//
+// Lo que reproduce, medido sobre /lookbook/preview/bali/block_editor/with_comments antes
+// del arreglo:
+//   - el `.bn-container` anidado de cada comentario media 163px y su `.bn-editor` 0px,
+//     porque `.bn-with-comments .bn-container > .bn-editor` lo alcanzaba con
+//     `flex: 1; min-width: 0`. Una letra por renglon.
+//   - la tarjeta flotante no tenia ancho propio: 165px con tres letras, 966px con una
+//     linea larga. `.bn-floating-composer` / `.bn-floating-thread`, los selectores que la
+//     hoja usaba para acotarla, no existen en el DOM (0 elementos).
+
+const LARGO =
+  'este es otro comentario con un texto que se expande conforme voy escribiendo y ' +
+  'quiero ver hasta donde me limita asdfkjasldkfj alksdjflajsdlkfjasldkfj alksdjflkajsdf'
+
+const comentario = texto => `
+  <div data-floating-ui-portal>
+    <div tabindex="-1" data-floating-ui-focusable style="position:absolute;top:0;left:0">
+      <div class="bn-thread mantine-Card-root mantine-Paper-root">
+        <div class="bn-root bn-container bn-mantine bn-comment-editor">
+          <div class="tiptap ProseMirror bn-editor bn-default-styles">
+            <p class="bn-inline-content">${texto}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>`
+
+describe('BlockEditor: comentarios', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 900)
+    cy.visit('/bali/block_editor/with_comments')
+    cy.get('.bn-with-comments > .bn-container > .bn-editor').should('contain.text', 'Block Editor')
+
+    cy.get('.bn-with-comments > .bn-container').then($container => {
+      const doc = $container[0].ownerDocument
+      const host = doc.createElement('div')
+      host.dataset.test = 'sondas'
+      host.innerHTML = comentario('est') + comentario(LARGO)
+      $container[0].appendChild(host)
+    })
+  })
+
+  const tarjetas = () => cy.get('[data-test="sondas"] .bn-thread')
+
+  it('deja al editor anidado con el ancho de su tarjeta, no en cero', () => {
+    cy.get('[data-test="sondas"] .bn-comment-editor').each($anidado => {
+      const estilo = window.getComputedStyle($anidado[0])
+      const editor = $anidado[0].querySelector('.bn-editor')
+
+      // La regla de dos columnas es del contenedor de primer nivel y de nadie mas.
+      expect(estilo.display, 'el contenedor anidado no es una fila flex').to.not.equal('flex')
+      expect(editor.getBoundingClientRect().width, 'el editor mide algo').to.be.greaterThan(100)
+    })
+  })
+
+  // No hay un tercer caso que mida los renglones del parrafo. Se escribio y pasaba igual
+  // con la hoja vieja: en esta sonda el contenedor flotante es `position: absolute` sin
+  // ancho, o sea shrink-to-fit sobre max-content, y ahi el texto entra en una linea aunque
+  // el `.bn-editor` mida cero. La letra por renglon necesita el ancho que Floating UI le
+  // escribe a la caja real. Los dos casos de arriba SI fallan sin el arreglo — verificado
+  // revirtiendo index.css y reconstruyendo — y son los que describen la causa.
+
+  it('la burbuja flotante mide lo mismo con tres letras que con un parrafo', () => {
+    tarjetas().should('have.length', 2)
+    tarjetas().then($t => {
+      const anchos = [...$t].map(el => Math.round(el.getBoundingClientRect().width))
+
+      expect(anchos[0], 'corta y larga miden igual').to.equal(anchos[1])
+      expect(anchos[0], 'y ese ancho es el declarado').to.equal(320)
+    })
+  })
+})


### PR DESCRIPTION
Cierra #869.

## Lo que se veía

Al escribir un comentario en `/lookbook/preview/bali/block_editor/with_comments`, el texto salía **una letra por renglón** — en el popover flotante y en la barra lateral, y el placeholder "Add comment" también.

## Causa, medida

Cada cuerpo de comentario es una instancia anidada de BlockNote, y emite un **segundo** `.bn-container` (con `.bn-comment-editor`) dentro de `.bn-thread`. Las dos reglas del layout de dos columnas lo alcanzaban con selectores de descendiente:

```
.bn-container.bn-comment-editor   display: flex   width: 163px
  └ .bn-editor                    flex-basis: 0%  width: 0px   ← acá se rompe
```

Un ítem con `flex-basis: 0%` dentro de una caja que se dimensiona por su contenido resuelve a cero. Combinador hijo en las dos reglas (y en la del `@media` que las voltea a columna) y el contenedor anidado vuelve a `display: block`: **0px → 139px**.

Las reglas son de #482 (feb/2026), no una regresión de #832.

## Y el segundo problema, que apareció al arreglar el primero

Con el texto acomodado, la burbuja no tenía ancho propio: **165px** con tres letras, **966px** con una línea larga. Crecía con cada tecla.

La regla que debía acotarla apunta a `.bn-floating-composer` y `.bn-floating-thread`, y **ninguna de las dos existe ya en el DOM** — medido, 0 elementos con el composer abierto — así que su `max-width: 20rem` nunca aplicó. BlockNote flota la tarjeta con Floating UI; el portal que renderiza es el hook que sí existe. Queda en `20rem`, con `max-width: calc(100vw - 2rem)` y sus propios bordes de tarjeta, porque `.document-editor-panel .bn-thread` se los quita a propósito para las filas del panel lateral.

## Verificación

- Medido en el navegador sobre la hoja compilada, no con CSS inyectado: `0px → 139px` el editor anidado, `165/966 → 320` la burbuja.
- `cypress/e2e/block-editor-comments.cy.js`, 2 casos. Maneja la cascada en vez de la interacción, como hace `document-editor.cy.js` con el tooltip. **Verificado que los dos fallan** revirtiendo `index.css` y reconstruyendo.
- Se escribió un tercer caso que medía los renglones del párrafo y **pasaba igual sin el arreglo** — en esa sonda el contenedor flotante es `position: absolute` sin ancho, o sea shrink-to-fit sobre max-content. Está documentado en el archivo en vez de dejarlo como un test que no puede fallar.
- Minitest completo y el resto de Cypress: en verde. Falta el `yarn build` del consumidor — este CSS lo empaqueta esbuild, no `app:tailwindcss:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)