### PR TITLE
feat(navbar): opción `shadow:`, y la sombra baja a la capa donde `is-transparent` la alcanza (#870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Added
+
+- **`Bali::Navbar::Component.new(shadow: false)`.** Turns off the drop shadow under the bar, for a layout that already separates it some other way — an app shell whose navbar carries a bottom border continuing the sidebar's draws two dividers otherwise. On by default, so nothing changes for anyone who does not ask. The `default` preview takes it as a toggle.
+
+### Fixed
+
+- **A transparent navbar is finally transparent, and shadowless.** `.navbar.is-transparent { @apply bg-transparent shadow-none }` had never had any effect. It lives in `@layer components`, and the `shadow-sm` the component put on the element itself is a utility, from a layer that outranks it — so with `is-transparent` on the element, box-shadow measured `0 1px 3px rgba(0,0,0,.1)` and the background measured `oklch(1 0 0)`, on `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`. The shadow half is fixed here, by moving the default into the sheet next to the state that overrides it, which is the rule the rest of the package follows. The background half is a separate defect and is not addressed by this change.
+
+  The `@apply shadow-md` that had been sitting in `navbar/index.css` went with it. It lost the same way and had never rendered at all: the effective shadow was always the element's `shadow-sm`.
+
+- **Classes passed to `Navbar` land on the `<nav>` once.** `navbar_classes` named `@options[:class]` and then handed its result to `prepend_class_name`, which appends the caller's classes a second time — measured on the AppLayout preview, the four it passes came out twice over.
+
 ## [v3.0.0.beta.2] - 2026-08-03
 
 ### Fixed

--- a/app/components/bali/navbar/component.rb
+++ b/app/components/bali/navbar/component.rb
@@ -3,8 +3,18 @@
 module Bali
   module Navbar
     class Component < ApplicationViewComponent
-      BASE_CLASSES = "navbar shadow-sm"
+      BASE_CLASSES = "navbar"
       STICKY_CLASSES = "sticky top-0 z-50"
+
+      # `shadow: false` emits a class instead of skipping one, because the
+      # default it turns off is not a class: it is `.navbar { @apply shadow-sm }`
+      # in navbar/index.css. The default had to move there so that
+      # `.navbar.is-transparent { @apply shadow-none }` — same layer, one
+      # compound more specific — finally beats it; as a utility on the element it
+      # never did. Nothing declared in @layer components can be undone from the
+      # `class:` option, so the off switch has to come from @layer utilities,
+      # which outranks it.
+      NO_SHADOW_CLASSES = "shadow-none"
 
       COLORS = {
         base: "bg-base-100",
@@ -25,11 +35,17 @@ module Bali
       # @param fullscreen [Boolean] Full-width navbar without max-width constraint
       # @param color [Symbol, nil] Background color preset (:base, :primary, :secondary, :accent,
       #   :neutral). Pass nil to skip color classes and use your own via the class: option.
-      def initialize(sticky: true, transparency: false, fullscreen: false, color: :base, **options)
+      # @param shadow [Boolean] Draw the drop shadow under the bar (default: true).
+      #   Pass false where the bar already separates itself some other way — an app
+      #   shell whose navbar carries a bottom border that continues the sidebar's
+      #   gets two dividers otherwise.
+      def initialize(sticky: true, transparency: false, fullscreen: false, color: :base,
+                     shadow: true, **options)
         @sticky = sticky
         @transparency = transparency.present?
         @fullscreen = fullscreen.present?
         @color = color&.to_sym
+        @shadow = shadow
         @container_class = options.delete(:container_class)
 
         @options = prepend_controller(options, "navbar")
@@ -58,12 +74,17 @@ module Bali
         COLORS.fetch(@color, nil)
       end
 
+      # `@options[:class]` is deliberately absent: `prepend_class_name` appends
+      # whatever the caller passed after this string, so naming it here printed
+      # every host class twice — measured on the AppLayout preview, the
+      # `min-h-0 bali-chrome-height border-b border-base-300` it passes came out
+      # in the attribute two times over.
       def navbar_classes
         class_names(
           BASE_CLASSES,
           color_classes,
           @sticky && STICKY_CLASSES,
-          @options[:class]
+          !@shadow && NO_SHADOW_CLASSES
         )
       end
     end

--- a/app/components/bali/navbar/index.css
+++ b/app/components/bali/navbar/index.css
@@ -3,8 +3,17 @@
   --bali-navbar-height: 3.75rem;
 }
 
+/* The shadow lives here and not on the element, so that the `.is-transparent`
+ * rule below can reach it. It used to be `shadow-sm` in the component's
+ * BASE_CLASSES — a utility, so from @layer components the state rule's
+ * `shadow-none` never won, and a transparent navbar kept its shadow: measured
+ * on /lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true,
+ * box-shadow stayed `0 1px 3px rgba(0,0,0,.1)` with `is-transparent` on the
+ * element. (The `@apply shadow-md` that stood here lost the same way and had
+ * never rendered at all.) `shadow-none` from `shadow: false` still wins, on
+ * purpose: that one comes from @layer utilities. */
 .navbar {
-  @apply shadow-md;
+  @apply shadow-sm;
   transition: background-color 1s;
 
   &>.container {

--- a/app/components/bali/navbar/preview.rb
+++ b/app/components/bali/navbar/preview.rb
@@ -5,13 +5,23 @@ module Bali
     class Preview < ApplicationViewComponentPreview
       # @param fullscreen toggle "Edge-to-edge layout vs centered (1152px max)"
       # @param transparency toggle
+      # @param shadow toggle "Drop shadow under the bar"
       # @param color [Symbol] select [base, primary, secondary, accent, neutral]
       # **Fullscreen**: removes the max-width constraint so content spans edge-to-edge.
       # **Non-fullscreen** (default): content centered with 1152px max-width.
-      def default(fullscreen: false, transparency: false, color: :base)
+      #
+      # **Shadow**: on by default. Turn it off in a layout where the bar already
+      # separates itself — an app shell whose navbar carries a bottom border that
+      # continues the sidebar's draws two dividers otherwise.
+      def default(fullscreen: false, transparency: false, shadow: true, color: :base)
         render_with_template(
           template: 'bali/navbar/previews/default',
-          locals: { fullscreen: fullscreen, transparency: transparency, color: color }
+          locals: {
+            fullscreen: fullscreen,
+            transparency: transparency,
+            shadow: shadow,
+            color: color
+          }
         )
       end
 

--- a/app/components/bali/navbar/previews/default.html.erb
+++ b/app/components/bali/navbar/previews/default.html.erb
@@ -1,6 +1,7 @@
 <%= render Bali::Navbar::Component.new(
     fullscreen: fullscreen,
     transparency: transparency,
+    shadow: local_assigns.fetch(:shadow, true),
     color: local_assigns[:color] || :base,
     class: 'sticky top-0 z-50'
 ) do |nav| %>

--- a/cypress/e2e/navbar-shadow.cy.js
+++ b/cypress/e2e/navbar-shadow.cy.js
@@ -1,0 +1,50 @@
+// `box-shadow` no vuelve "none" cuando Tailwind lo apaga: vuelve la lista de capas que
+// arma con sus custom properties, todas en cero. Compararla contra 'none' da un falso
+// negativo, asi que se lee capa por capa: una capa pinta si su color no tiene alpha 0 y
+// alguna de sus longitudes no es 0.
+const capas = valor => (valor === 'none' ? [] : valor.split(/,\s*(?=rgba?\()/))
+
+const pinta = valor =>
+  capas(valor).some(
+    capa => !/^rgba\(\s*\d+,\s*\d+,\s*\d+,\s*0\s*\)/.test(capa) && /[1-9]\d*px/.test(capa)
+  )
+
+const sombra = $n => window.getComputedStyle($n[0]).boxShadow
+
+describe('Navbar: la sombra', () => {
+  it('viene puesta, y desde la hoja en vez de una utilidad sobre el elemento', () => {
+    cy.visit('/bali/navbar/default')
+
+    cy.get('.navbar').should($n => {
+      // El default es `.navbar { @apply shadow-sm }` en navbar/index.css. Tiene que vivir
+      // ahi, dentro de @layer components, porque es el unico lugar donde la regla de
+      // `.is-transparent` puede ganarle.
+      expect($n[0].className, 'sin utilidad de sombra en el atributo').to.not.match(
+        /\bshadow-(sm|md|none)\b/
+      )
+      expect(pinta(sombra($n)), 'la sombra se ve').to.equal(true)
+    })
+  })
+
+  it('`shadow: false` la apaga desde @layer utilities', () => {
+    cy.visit('/bali/navbar/default?shadow=false')
+
+    cy.get('.navbar').should($n => {
+      expect($n[0].className, 'lleva shadow-none').to.match(/\bshadow-none\b/)
+      expect(pinta(sombra($n)), 'y no queda sombra').to.equal(false)
+    })
+  })
+
+  // Lo que estaba roto sin que se notara: `.navbar.is-transparent { @apply shadow-none }`
+  // vive en @layer components y perdia contra el `shadow-sm` que el propio componente se
+  // ponia como utilidad. Medido antes del arreglo sobre este mismo preview, con
+  // `is-transparent` en el elemento, box-shadow seguia en `0 1px 3px rgba(0,0,0,.1)`.
+  it('un navbar transparente ya no la conserva', () => {
+    cy.visit('/bali/navbar/with_sidebar_burger?transparency=true')
+
+    cy.get('.navbar').should('have.class', 'is-transparent')
+    cy.get('.navbar').should($n => {
+      expect(pinta(sombra($n)), 'transparente y sin sombra').to.equal(false)
+    })
+  })
+})

--- a/test/bali/components/navbar_test.rb
+++ b/test/bali/components/navbar_test.rb
@@ -262,6 +262,35 @@ class BaliNavbarBurgerComponentTest < ComponentTestCase
     assert_no_selector("[data-action]")
   end
 
+  # --- shadow: ---
+
+  # The default is `.navbar { @apply shadow-sm }` in navbar/index.css, and it has
+  # to stay there: from @layer components is the only place the `.is-transparent`
+  # rule can beat it. As a utility on the element (which is where it used to be)
+  # it outranked every state rule the sheet declares for that property.
+  def test_shadow_is_on_by_default_and_puts_no_class_on_the_element
+    render_inline(Bali::Navbar::Component.new)
+
+    classes = page.find("nav")[:class].split
+    assert_not_includes classes, "shadow-sm"
+    assert_not_includes classes, "shadow-none"
+  end
+
+  def test_shadow_false_turns_it_off_from_the_utilities_layer
+    render_inline(Bali::Navbar::Component.new(shadow: false))
+    assert_selector("nav.navbar.shadow-none")
+  end
+
+  # `navbar_classes` used to name `@options[:class]` and then hand its result to
+  # `prepend_class_name`, which appends the caller's classes a second time.
+  def test_caller_classes_land_on_the_nav_exactly_once
+    render_inline(Bali::Navbar::Component.new(class: "border-b border-base-300"))
+
+    classes = page.find("nav")[:class].split
+    assert_equal 1, classes.count("border-b")
+    assert_equal 1, classes.count("border-base-300")
+  end
+
   # --- type: :sidebar delegates to the one shared trigger ---
 
   def test_sidebar_burger_renders_the_shared_trigger


### PR DESCRIPTION
Cierra #870.

## Lo pedido

Quitar la sombra del navbar en la config de app shell, donde el borde inferior ya es el separador. Elegido en la consulta: opción `shadow:` con default `true`, para que nadie cambie salvo quien lo pida.

## Lo que apareció al medirlo

`BASE_CLASSES = "navbar shadow-sm"` es una utilidad puesta por el componente sobre el elemento, así que el host no la puede apagar: un `class: 'shadow-none'` cae en la misma capa con la misma especificidad y decide el orden de la hoja compilada. El comentario del preview de AppLayout ya dejaba constancia de eso.

Pero además, y esto no estaba en el issue: **`.navbar.is-transparent` nunca hizo nada**. Vive en `@layer components` y pierde contra la utilidad del elemento. Medido sobre `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`, con `is-transparent` puesto:

```
box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px, rgba(0,0,0,0.1) 0px 1px 2px -1px
background: oklch(1 0 0)
```

O sea: ni transparente ni sin sombra.

## Lo que hace este PR

- El default baja a `.navbar { @apply shadow-sm }` en la hoja, **al lado del estado que lo pisa** — la regla que CLAUDE.md ya enuncia y que el resto del paquete sigue. Con eso `is-transparent` le gana por especificidad dentro de la misma capa.
- `shadow: false` emite `shadow-none`, que viene de `@layer utilities` y le gana a la capa de componentes. Es por eso que la opción emite una clase en vez de omitir una.
- Se va el `@apply shadow-md` que estaba en la hoja: perdía igual y **nunca se renderizó**. La sombra efectiva siempre fue el `shadow-sm` del elemento.
- De paso: `navbar_classes` nombraba `@options[:class]` y después pasaba su resultado a `prepend_class_name`, que vuelve a agregar las clases del llamador. Salían dos veces en el atributo.

**Sin cambio visual para nadie**, salvo el navbar transparente, que ahora sí pierde la sombra — que es lo que la regla decía desde siempre.

## Lo que NO arregla

La otra mitad de `is-transparent`: el `bg-transparent` sigue perdiendo contra el `bg-base-100` que emite el preset de `color:`. Es el mismo mecanismo pero el arreglo es otro — los colores son dinámicos y no se pueden bajar a la hoja sin una tabla de clases propias. Queda para un issue aparte; no lo abrí para no adelantarme a cómo lo querés resolver.

## Verificación

- Minitest: 3 casos nuevos en `navbar_test.rb` (default sin utilidad de sombra, `shadow: false` con `shadow-none`, clases del llamador una sola vez). 47 runs, 0 failures.
- Cypress: `cypress/e2e/navbar-shadow.cy.js`, 3 casos, incluido el del navbar transparente que hoy fallaría. Lee `box-shadow` capa por capa, porque Tailwind no devuelve `none` al apagarla sino la lista de capas en cero — compararla contra `'none'` da un falso negativo.
- Rubocop limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)