### PR TITLE
fix(data_table): el popover del ⋯ crecía al abrir uno de sus hijos (#879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **Opening Views, Columns or Group by inside the `DataTable` overflow menu no longer resizes the menu.** Measured on `/admin/studios` at 1900px, the `⋯` panel went from 320x176 to 320x338 — a popover growing under the pointer, with the child laid out in flow inside it.
+
+  The container forced `position: static` on every `.dropdown-content` beneath it, and that was deliberate: a nested absolute dropdown positions against the container and leaves the viewport on a phone (measured, `left: -115px` at 375px), so stacking them as sections in flow is the sensible thing there. What changed is that the `⋯` used to *be* the mobile mode; since the valve started measuring the row it fires at any width, and the same rule was reaching the desktop. It is scoped to `max-sm` now — below the breakpoint nothing changes, above it the child floats over the panel as a popover inside a popover should.
+
 ## [v3.0.0.beta.2] - 2026-08-03
 
 ### Fixed

--- a/app/components/bali/data_table/component.html.erb
+++ b/app/components/bali/data_table/component.html.erb
@@ -130,11 +130,19 @@
                 viewport (medido: left -115px en un teléfono de 375px, cuando además eran
                 `.dropdown-end`). En flujo quedan como secciones apiladas, que es lo
                 razonable en un teléfono. Cerrados siguen siendo `display:none`, así que no
-                dejan huecos. %>
+                dejan huecos.
+
+                `max-sm:` es lo que acota esa decisión al teléfono para el que se tomó.
+                Cuando se escribió, el ⋯ ERA el modo de móvil; desde #842 la válvula se
+                dispara a cualquier ancho — medido, se lleva cuatro controles a 1900px. En
+                un escritorio apilar en flujo hace que el popover contenedor CREZCA al abrir
+                un hijo: medido en /admin/studios, el panel del ⋯ pasaba de 320x176 a
+                320x338 al abrir Views. Arriba del breakpoint el anidado vuelve a flotar,
+                que es lo que un popover dentro de otro tiene que hacer. %>
             <div class="toolbar-overflow-menu
                         flex flex-col items-stretch gap-2 w-full p-1
                         max-w-[calc(100vw-3rem)] max-h-[70vh] overflow-y-auto
-                        [&_.dropdown-content]:!static [&_.dropdown-content]:!w-full"
+                        max-sm:[&_.dropdown-content]:!static max-sm:[&_.dropdown-content]:!w-full"
                  data-toolbar-overflow-target="menu"></div>
           <% end %>
         </div>

--- a/cypress/e2e/data-table-overflow-popover.cy.js
+++ b/cypress/e2e/data-table-overflow-popover.cy.js
@@ -1,0 +1,63 @@
+// El ⋯ es un popover: abrir uno de sus hijos no puede cambiarle el tamano. Lo hacia porque
+// el contenedor del menu forzaba `position: static` en todo `.dropdown-content` de adentro,
+// una decision tomada cuando el ⋯ ERA el modo de movil. Desde #842 la valvula salta a
+// cualquier ancho, asi que esa regla se aplicaba tambien en escritorio: medido en
+// /admin/studios a 1900px, el panel del ⋯ pasaba de 320x176 a 320x338 al abrir Views.
+//
+// Sobre por que la pagina es /admin/studios y no un preview, ver
+// data-table-toolbar-alignment.cy.js.
+const appOrigin = new URL(Cypress.config('baseUrl')).origin
+const estudios = () => cy.visit(`${appOrigin}/admin/studios`)
+
+const disparadorPuntos = () => cy.get('[data-toolbar-overflow-target="overflow"] .btn').first()
+const primerHijo = () =>
+  cy.get('[data-toolbar-overflow-target="menu"] .dropdown').first().find('.btn').first()
+const contenidoDelHijo = () =>
+  cy.get('[data-toolbar-overflow-target="menu"] .dropdown .dropdown-content').first()
+
+const caja = el => {
+  const b = el.getBoundingClientRect()
+  return { w: Math.round(b.width), h: Math.round(b.height) }
+}
+
+describe('DataTable: el popover del ⋯', () => {
+  it('no cambia de tamano cuando se abre uno de sus hijos', () => {
+    cy.viewport(1900, 1000)
+    estudios()
+    cy.get('[data-toolbar-overflow-target="overflow"]').should('not.have.class', 'hidden')
+    disparadorPuntos().click()
+    cy.get('[data-toolbar-overflow-target="menu"]').should('be.visible')
+
+    cy.get('[data-toolbar-overflow-target="menu"]').then($menu => {
+      const panel = $menu[0].closest('.dropdown-content')
+      const antes = caja(panel)
+
+      primerHijo().click()
+      contenidoDelHijo()
+        .should('be.visible')
+        .then($sub => {
+          expect(window.getComputedStyle($sub[0]).position, 'el hijo flota').to.equal('absolute')
+          expect(caja(panel), 'y el contenedor no se movio').to.deep.equal(antes)
+        })
+    })
+  })
+
+  // En un telefono apilar en flujo sigue siendo lo razonable, y es la razon por la que la
+  // regla existe: anidados y absolutos se posicionan contra el contenedor y se salen del
+  // viewport (medido: left -115px en 375px).
+  it('deja los hijos apilados en flujo en un telefono, sin salirse', () => {
+    cy.viewport(375, 800)
+    estudios()
+    cy.get('[data-toolbar-overflow-target="overflow"]').should('not.have.class', 'hidden')
+    disparadorPuntos().click()
+    primerHijo().click()
+
+    contenidoDelHijo().should($sub => {
+      expect(window.getComputedStyle($sub[0]).position).to.equal('static')
+
+      const b = $sub[0].getBoundingClientRect()
+      expect(b.left, 'no se sale por la izquierda').to.be.at.least(0)
+      expect(b.right, 'ni por la derecha').to.be.at.most(375)
+    })
+  })
+})


### PR DESCRIPTION
Cierra #879.

## Lo que se veía

Abrir Views / Columns / Group by **dentro** del popover del ⋯ hacía crecer al popover contenedor.

## Medido, en `/admin/studios` a 1900px

| | ancho | alto |
|---|---|---|
| panel del ⋯, antes | 320 | **176** |
| panel del ⋯, después de abrir Views | 320 | **338** |

`position` del contenido anidado: **`static`**.

## Causa

Es deliberado, y la razón que lo justificaba caducó. El contenedor del menú lleva:

```
[&_.dropdown-content]:!static [&_.dropdown-content]:!w-full
```

y el comentario de al lado lo explica: un dropdown anidado y absoluto se posiciona contra este contenedor y se sale del viewport — medido, `left: -115px` en un teléfono de 375px — así que en flujo quedan como secciones apiladas, **"que es lo razonable en un teléfono"**.

Cuando se escribió eso, el ⋯ **era** el modo de móvil. Desde #842 la válvula mide la fila y salta a cualquier ancho: en esta misma medición se lleva cuatro controles a 1900px. Así que la regla del teléfono estaba llegando al escritorio, donde apilar en flujo dentro de un popover es justamente lo que se ve mal.

## El arreglo

`max-sm:` sobre las dos utilidades. Abajo del breakpoint no cambia una coma; arriba el hijo vuelve a flotar.

## Verificación

| | escritorio (1900) | teléfono (375) |
|---|---|---|
| panel del ⋯ antes → después | 320x176 → **320x176** | apilado, como antes |
| `position` del hijo | `absolute` | `static` |
| ¿se sale del viewport? | no (1365..1653 de 1900) | no |

`cypress/e2e/data-table-overflow-popover.cy.js`, 2 casos — uno por cada lado del breakpoint, porque lo que hay que cuidar es que arreglar el escritorio no reintroduzca el `-115px` del teléfono. Minitest **3716**, Cypress **217/217**.

Un apunte que no toqué: `Bali::Dropdown` tiene un modo `popover:` con tippy que sí maneja colisiones, y sería mejor que el `absolute` de daisyUI para un anidado pegado al borde derecho. Pero es una opción de Ruby de cada dropdown, no algo que el contenedor pueda imponer, así que sería otro cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
