### PR TITLE
feat(data_table): la toolbar reserva el lugar de lo que puede colapsar (#878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Changed
+
+- **The `DataTable` toolbar reserves the space for what can collapse instead of showing it and taking it away.** On first load the row used to show every control and then, a full second later, drop four of them into the `⋯` at once. Measured on `/admin/studios`: 5 controls in the row and 0 in the menu at 195ms, 1 and 4 at 1208ms.
+
+  The cause is not that the row grows. It is that the toolbar the server sends is, by definition, the row *before* anything collapses, and nothing can collapse it until the controller exists: the page paints at 260ms and `connect()` does not run until 1189ms, which is how long a 4.8 MB bundle takes to finish executing. Collapsible controls now arrive with their box reserved and nothing drawn in it, and the controller reveals them at the end of its first `apply()`. `visibility: hidden` rather than `display: none`, so the measurement that decides the collapse still measures exactly what it did before. Without JavaScript a `<noscript>` rule reveals them, because the attribute has to come from the server — the flicker it prevents happens before any script runs — and so cannot depend on a script to go away.
+
 ## [v3.0.0.beta.2] - 2026-08-03
 
 ### Fixed

--- a/app/components/bali/data_table/component.html.erb
+++ b/app/components/bali/data_table/component.html.erb
@@ -3,6 +3,17 @@
       recuerda, derecha CÓMO se ve. Bajo el breakpoint el controlador `toolbar-overflow`
       MUEVE los controles secundarios al menú ⋯ (ver OVERFLOW_PRIORITIES) y los devuelve al
       subir. %>
+  <%# Sin JS no hay quién saque el atributo que reserva el lugar de los controles
+      colapsables, así que se destapan acá. Es la única forma de que la fila siga completa
+      para quien no ejecuta scripts: el atributo tiene que venir del servidor —el parpadeo
+      que evita ocurre ANTES de que el bundle corra— y por lo tanto no puede depender de JS
+      para irse. `!important` porque la utilidad que esconde vive en @layer utilities. %>
+  <% if show_toolbar? && overflow_menu? %>
+    <noscript>
+      <style>[data-toolbar-overflow-settling] [data-toolbar-overflow-target="item"] { visibility: visible !important }</style>
+    </noscript>
+  <% end %>
+
   <% if show_toolbar? %>
     <%= tag.div(**toolbar_attributes) do %>
       <%# Izquierda, primer subgrupo: el CONTENIDO de la vista — qué filas y qué columnas.

--- a/app/components/bali/data_table/component.rb
+++ b/app/components/bali/data_table/component.rb
@@ -449,6 +449,9 @@ module Bali
       # el de selección pueda esconderla mientras la barra contextual ocupa su lugar.
       def toolbar_attributes
         attrs = prepend_controller({ class: toolbar_classes }, "toolbar-overflow")
+        # El servidor lo pone y el controlador lo saca al terminar su primer `apply()`. Ver
+        # RESERVED_CLASSES. Sin JS lo destapa el `<noscript>` de la plantilla.
+        attrs[SETTLING_ATTRIBUTE] = "" if overflow_menu?
         # El umbral se EMITE: el gate del ⋯ y el corte que aplica el JS son el mismo número,
         # y con dos defaults independientes moverlo de un lado dejaba al otro pintando un
         # menú que nunca se llena. El default del controlador cubre solo markup a mano.
@@ -471,13 +474,32 @@ module Bali
 
       # Envoltorio de un control: a qué grupo vuelve y con qué prioridad (ver
       # OVERFLOW_PRIORITIES). Es el nodo que el JS MUEVE, nunca copia.
+      # Un control que puede colapsar arranca con el lugar RESERVADO y sin dibujarse, y lo
+      # revela el controlador al terminar su primer `apply()`. `visibility: hidden` y no
+      # `display: none` a propósito: conserva la caja, así que la medición que decide el
+      # colapso mide exactamente lo mismo que sin esto.
+      #
+      # Lo que evita, medido en /admin/studios: la página pinta a los 260ms con la fila
+      # entera —que es el HTML del servidor, o sea la fila SIN colapsar— y el controlador no
+      # corre hasta los 1189ms, cuando termina de ejecutarse un bundle de 4.8 MB. En ese
+      # segundo se veían cuatro controles que después desaparecían de golpe dentro del ⋯.
+      # Reservado, lo que se ve es un hueco que se llena una vez.
+      #
+      # La variante arbitraria y no una regla en index.css: así vive en @layer utilities, que
+      # es donde un host la puede pisar, y no en una hoja sin capa cuyo encabezado explica
+      # que está sin capa por otra razón.
+      SETTLING_ATTRIBUTE = "data-toolbar-overflow-settling"
+      RESERVED_CLASSES = "[[data-toolbar-overflow-settling]_&]:invisible"
+
       def overflow_item_attributes(key, group:, css_class: nil)
+        priority = overflow_priority(key)
+
         {
-          class: css_class,
+          class: class_names(css_class, (RESERVED_CLASSES if priority < OVERFLOW_THRESHOLD)),
           data: {
             toolbar_overflow_target: "item",
             toolbar_overflow_group: group,
-            toolbar_overflow_priority: overflow_priority(key)
+            toolbar_overflow_priority: priority
           }
         }
       end

--- a/app/components/bali/data_table/toolbar_overflow_controller.js
+++ b/app/components/bali/data_table/toolbar_overflow_controller.js
@@ -63,6 +63,27 @@ export default class extends Controller {
     // El layout inicial puede llegar ya angosto: no alcanza con escuchar el cruce.
     this.apply(this.mediaQuery.matches)
     this.recordMeasurements()
+    this.reveal()
+  }
+
+  /**
+   * Los controles colapsables llegan con el lugar reservado y sin dibujarse, y esto los
+   * destapa una vez que la fila ya está en su forma final. Ver RESERVED_CLASSES en el
+   * componente.
+   *
+   * Va acá y no detrás de un heurístico de "ya se asentó" porque la causa del parpadeo no
+   * es que la fila crezca: es que el servidor manda la fila SIN colapsar y nadie la puede
+   * colapsar hasta que este controlador existe. Medido en /admin/studios, la página pinta a
+   * los 260ms y `connect()` no corre hasta los 1189ms, cuando termina de ejecutarse el
+   * bundle. Al terminar el `apply()` de arriba la fila ya es la definitiva, así que no hay
+   * nada que esperar.
+   *
+   * Un `apply()` posterior —el que dispara un widget que se ensancha al montar— pasa con los
+   * controles ya visibles, que es lo correcto: a esa altura mover uno al ⋯ es una respuesta
+   * a algo que cambió, no un estado inicial equivocado.
+   */
+  reveal () {
+    this.element.removeAttribute('data-toolbar-overflow-settling')
   }
 
   disconnect () {

--- a/cypress/e2e/data-table-toolbar-reserve.cy.js
+++ b/cypress/e2e/data-table-toolbar-reserve.cy.js
@@ -1,0 +1,69 @@
+// La toolbar que manda el servidor es, por definicion, la fila SIN colapsar: nadie la puede
+// colapsar hasta que existe el controlador. Medido en /admin/studios, la pagina pinta a los
+// 260ms y `connect()` no corre hasta los 1189ms —lo que tarda en ejecutarse un bundle de
+// 4.8 MB—, asi que durante un segundo se veian cuatro controles que despues desaparecian de
+// golpe dentro del ⋯.
+//
+// Ahora los colapsables llegan con el lugar RESERVADO y sin dibujarse, y el controlador los
+// destapa al terminar su primer `apply()`. `visibility: hidden` y no `display: none`: la
+// caja se conserva, asi que la medicion que decide el colapso mide lo mismo que sin esto.
+//
+// Sobre por que la pagina es /admin/studios y no un preview, ver
+// data-table-toolbar-alignment.cy.js.
+const appOrigin = new URL(Cypress.config('baseUrl')).origin
+const url = `${appOrigin}/admin/studios`
+
+const ATRIBUTO = 'data-toolbar-overflow-settling'
+const toolbar = () => cy.get('[data-controller~="toolbar-overflow"]')
+
+describe('DataTable: la toolbar reserva el lugar de lo que puede colapsar', () => {
+  // Sobre el HTML crudo, que es lo que el navegador pinta antes de ejecutar nada. Sin
+  // timing: lo que se comprueba es el contrato del servidor, no una carrera.
+  it('lo manda reservado desde el servidor', () => {
+    cy.request(url).its('body').then(html => {
+      expect(html, 'la fila marcada').to.include(ATRIBUTO)
+      // El `&` de la variante arbitraria sale escapado en el atributo, asi que se busca el
+      // tramo que no lo lleva.
+      expect(html, 'y la utilidad que esconde').to.include(
+        `[[${ATRIBUTO}]_`
+      )
+      expect(html, 'con la salida para quien no ejecuta scripts').to.include('<noscript>')
+    })
+  })
+
+  it('lo destapa entero una vez que el controlador corrio', () => {
+    cy.viewport(1900, 1000)
+    cy.visit(url)
+    cy.get('[data-toolbar-overflow-target="overflow"]').should('not.have.class', 'hidden')
+
+    toolbar().should('not.have.attr', ATRIBUTO)
+    cy.get('[data-toolbar-overflow-target="item"]').each($item => {
+      expect(window.getComputedStyle($item[0]).visibility, 'ningun control queda escondido')
+        .to.equal('visible')
+    })
+  })
+
+  // Lo que separa este arreglo de un `display: none` que romperia la medicion. Se prueba
+  // volviendo a poner el atributo, porque el estado real dura lo que tarda el bundle.
+  it('reserva la caja en vez de sacarla del layout', () => {
+    cy.viewport(2600, 1000)
+    cy.visit(url)
+    cy.get('[data-controller~="toolbar-overflow"]').should('exist')
+    // A este ancho la fila entra entera, asi que los colapsables siguen en ella.
+    cy.get('[data-toolbar-overflow-target="menu"]').should($menu => {
+      expect($menu[0].children.length, 'nada colapso a este ancho').to.equal(0)
+    })
+
+    cy.get('[data-toolbar-overflow-priority="30"]').then($item => {
+      const antes = Math.round($item[0].getBoundingClientRect().width)
+      expect(antes, 'el control mide algo para empezar').to.be.greaterThan(0)
+
+      cy.get('[data-controller~="toolbar-overflow"]').invoke('attr', ATRIBUTO, '')
+      cy.get('[data-toolbar-overflow-priority="30"]').should($otra => {
+        expect(window.getComputedStyle($otra[0]).visibility).to.equal('hidden')
+        expect(Math.round($otra[0].getBoundingClientRect().width), 'y conserva su caja')
+          .to.equal(antes)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Cierra #878.

## Antes de nada: la causa no era la que decía el issue

El issue decía que el colapso llega tarde porque SlimSelect y flatpickr ensanchan la fila después del primer layout. **Medido, no es eso.** Instrumentando `ResizeObserver` sobre todos los descendientes de la toolbar, entre los 300ms y los 1184ms **no hay un solo resize**. Los que sí hay ocurren a los 1186ms, o sea DESPUÉS del colapso: son su consecuencia.

Lo que pasa es más simple y más incómodo:

| | |
|---|---|
| `domInteractive` | 49ms |
| **first-contentful-paint** | **260ms** |
| `application.js` | **4817 KB**, de 25 a 831ms |
| `domContentLoadedEventEnd` | **1189ms** |
| colapso | **1184ms** |

La toolbar que manda el servidor es, por definición, la fila **antes** de colapsar — nadie la puede colapsar hasta que existe el controlador. La página pinta a los 260ms y el controlador no corre hasta que termina de ejecutarse un bundle de 4.8 MB. Ese segundo es todo boot de JS.

(Es el bundle del dummy en desarrollo, sin minificar. En una app host minificada el número va a ser menor, pero la forma del problema es la misma y no depende del ancho.)

## El arreglo

El que elegiste: reservar y revelar una sola vez.

- Los controles colapsables llegan con la caja reservada y sin dibujarse.
- El controlador los destapa al terminar su primer `apply()` — no detrás de un heurístico de "ya se asentó", porque no hay nada que esperar: al terminar ese `apply()` la fila ya es la definitiva.
- **`visibility: hidden` y no `display: none`**: conserva la caja, así que la medición que decide el colapso mide exactamente lo mismo que sin esto. Verificado: los mismos 4 controles al ⋯.
- El atributo lo pone el **servidor**, porque el parpadeo que evita ocurre antes de que corra un script. Por eso mismo no puede depender de un script para irse: sin JS lo destapa un `<noscript>`.
- La regla es una variante arbitraria (`[[data-toolbar-overflow-settling]_&]:invisible`) y no una regla en `data_table/index.css` — así vive en `@layer utilities`, donde un host la puede pisar, y no en una hoja sin capa cuyo encabezado explica que está sin capa por otra razón.

## Verificación

| t | reservando | visibles | en el ⋯ |
|---|---|---|---|
| 199ms | sí | **1 / 5** | 0 |
| 1294ms | no | **5 / 5** | 4 |

Un hueco que se llena una vez, en vez de una fila que se vacía.

`cypress/e2e/data-table-toolbar-reserve.cy.js`, 3 casos: el contrato del servidor sobre el HTML crudo (sin timing, con `cy.request`), el estado final en el DOM, y el que separa esto de un `display: none` — que la caja se conserve.

`toolbar-overflow.cy.js` (10 casos) sigue en verde, que es lo que confirma que la medición no cambió. DataTable Minitest 115/0.

## Lo que esto NO arregla

Los 4.8 MB. El hueco dura lo que tarde el bundle, así que el arreglo de fondo es otro y es más grande. ¿Abro un issue para medir qué pesa ahí adentro? Me la juego a que es BlockNote/ProseMirror y que sale con un import dinámico, pero no lo medí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
