### PR TITLE
fix(navbar): un `transparency: true` nunca fue transparente (#887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Navbar`'s `color:` presets emit Bali classes instead of Tailwind utilities**, so a transparent navbar is finally transparent. `.navbar.is-transparent { @apply bg-transparent }` lives in `@layer components` and the preset put `bg-base-100` on the element as a utility, from a layer that outranks it: measured on `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`, the background stayed `oklch(1 0 0)` with `is-transparent` on. `Navbar::Component::COLORS` now maps to `navbar-base`, `navbar-primary` and the rest, and `navbar/index.css` declares them above the state rule — same layer, same specificity, so source order decides.
+
+  Two consequences worth knowing. A host that reads `COLORS`, or that has CSS matching `.navbar.bg-primary`, sees different classes on the element. And a host that wants to override the preset with a utility of its own now wins outright, instead of tying against `bg-base-100` and depending on the order of the compiled sheet.
+
 - **The "Navbar + Sidebar + Content" preview is one band of chrome, and says each destination once.** It is the reference app shell a host copies, and it read as three stacked white bands with the navigation printed twice.
 
   The navbar carried `Dashboard`, `Movies` and `Studios` as `start_item`s while the `SideMenu` beside it carried the same three. In this configuration the sidebar owns navigation and the navbar is the account bar, so those are gone. The command palette moves from the far right — wedged between the bell and the avatar — to the first position on the left, where a search field belongs, and its trigger is `style: :soft` instead of `:outline`: daisyUI mixes 8% of `base-content` into `base-100` for it, which reads as a filled well rather than a bordered button, with no loose utility to do it. The navbar also asks for `shadow: false` now, because its bottom border is already the divider.
@@ -36,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A transparent navbar is finally transparent, and shadowless.** `.navbar.is-transparent { @apply bg-transparent shadow-none }` had never had any effect. It lives in `@layer components`, and the `shadow-sm` the component put on the element itself is a utility, from a layer that outranks it — so with `is-transparent` on the element, box-shadow measured `0 1px 3px rgba(0,0,0,.1)` and the background measured `oklch(1 0 0)`, on `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`. The shadow half is fixed here, by moving the default into the sheet next to the state that overrides it, which is the rule the rest of the package follows. The background half is a separate defect and is not addressed by this change.
+- **A transparent navbar is finally transparent, and shadowless.** `.navbar.is-transparent { @apply bg-transparent shadow-none }` had never had any effect. It lives in `@layer components`, and the `shadow-sm` the component put on the element itself is a utility, from a layer that outranks it — so with `is-transparent` on the element, box-shadow measured `0 1px 3px rgba(0,0,0,.1)` and the background measured `oklch(1 0 0)`, on `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`. The shadow half is fixed here, by moving the default into the sheet next to the state that overrides it, which is the rule the rest of the package follows. The background half needed the `color:` presets to move the same way, and is under Changed above.
 
   The `@apply shadow-md` that had been sitting in `navbar/index.css` went with it. It lost the same way and had never rendered at all: the effective shadow was always the element's `shadow-sm`.
 

--- a/app/components/bali/navbar/component.rb
+++ b/app/components/bali/navbar/component.rb
@@ -16,12 +16,24 @@ module Bali
       # which outranks it.
       NO_SHADOW_CLASSES = "shadow-none"
 
+      # Clases de Bali y no utilidades de Tailwind, por la misma razón que la sombra: el
+      # preset tiene que vivir en la capa donde `.navbar.is-transparent` lo pueda pisar.
+      # Como utilidades sobre el elemento le ganaban a la regla de estado desde otra capa, y
+      # un navbar `transparency: true` no era transparente — medido sobre
+      # /lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true, con
+      # `is-transparent` puesto el fondo seguía en `oklch(1 0 0)`.
+      #
+      # Las declaraciones están en navbar/index.css, en @layer components y ARRIBA de la
+      # regla de `.is-transparent`: las dos son (0,2,0), así que decide el orden.
+      #
+      # De paso, un host que quiera pisar el color del preset con una utilidad ahora le gana
+      # limpio, en vez de empatar contra `bg-base-100` y depender del orden de la hoja.
       COLORS = {
-        base: "bg-base-100",
-        primary: "bg-primary text-primary-content",
-        secondary: "bg-secondary text-secondary-content",
-        accent: "bg-accent text-accent-content",
-        neutral: "bg-neutral text-neutral-content"
+        base: "navbar-base",
+        primary: "navbar-primary",
+        secondary: "navbar-secondary",
+        accent: "navbar-accent",
+        neutral: "navbar-neutral"
       }.freeze
 
       # Brand slot - accepts content block or name parameter

--- a/app/components/bali/navbar/index.css
+++ b/app/components/bali/navbar/index.css
@@ -26,6 +26,34 @@
     }
   }
 
+  /* Los presets de `color:`. Van acá y ARRIBA de `.is-transparent` por la misma razón
+   * que la sombra: los dos selectores son (0,2,0), así que a igual especificidad y en la
+   * misma capa decide el orden de origen, y el estado tiene que poder pisar al default.
+   * Como utilidades sobre el elemento —que es donde estaban— le ganaban desde
+   * @layer utilities y `bg-transparent` no se veía nunca. */
+  &.navbar-base {
+    @apply bg-base-100;
+  }
+
+  &.navbar-primary {
+    @apply bg-primary text-primary-content;
+  }
+
+  &.navbar-secondary {
+    @apply bg-secondary text-secondary-content;
+  }
+
+  &.navbar-accent {
+    @apply bg-accent text-accent-content;
+  }
+
+  &.navbar-neutral {
+    @apply bg-neutral text-neutral-content;
+  }
+
+  /* El color del texto NO se toca acá: un navbar transparente sobre una portada oscura
+   * sigue queriendo el `*-content` claro de su preset. Lo que se recupera bajo 1023px
+   * cuando el menú está abierto lo hace el bloque de abajo, que ya existía. */
   &.is-transparent {
     @apply bg-transparent shadow-none;
     transition: background-color 1s;

--- a/cypress/e2e/navbar-shadow.cy.js
+++ b/cypress/e2e/navbar-shadow.cy.js
@@ -39,12 +39,30 @@ describe('Navbar: la sombra', () => {
   // vive en @layer components y perdia contra el `shadow-sm` que el propio componente se
   // ponia como utilidad. Medido antes del arreglo sobre este mismo preview, con
   // `is-transparent` en el elemento, box-shadow seguia en `0 1px 3px rgba(0,0,0,.1)`.
-  it('un navbar transparente ya no la conserva', () => {
+  it('un navbar transparente ya no la conserva, y ahora es transparente', () => {
     cy.visit('/bali/navbar/with_sidebar_burger?transparency=true')
 
     cy.get('.navbar').should('have.class', 'is-transparent')
     cy.get('.navbar').should($n => {
-      expect(pinta(sombra($n)), 'transparente y sin sombra').to.equal(false)
+      const cs = window.getComputedStyle($n[0])
+
+      expect(pinta(sombra($n)), 'sin sombra').to.equal(false)
+      // El fondo perdía por lo mismo que la sombra, contra el `bg-base-100` que emitía el
+      // preset de `color:` como utilidad. Medido antes: `oklch(1 0 0)`.
+      expect(cs.backgroundColor, 'y sin fondo').to.match(/rgba\(0, 0, 0, 0\)|transparent/)
+    })
+  })
+
+  // El preset sigue pintando cuando el navbar NO es transparente — es lo que la mudanza a
+  // @layer components podría haber roto en silencio.
+  it('el preset de color sigue pintando el navbar opaco', () => {
+    cy.visit('/bali/navbar/default?color=primary')
+
+    cy.get('.navbar').should($n => {
+      expect($n[0].className, 'clase de Bali, no utilidad').to.match(/\bnavbar-primary\b/)
+      expect(window.getComputedStyle($n[0]).backgroundColor).to.not.match(
+        /rgba\(0, 0, 0, 0\)|transparent/
+      )
     })
   })
 })

--- a/test/bali/components/navbar_test.rb
+++ b/test/bali/components/navbar_test.rb
@@ -89,19 +89,19 @@ class BaliNavbarComponentTest < ComponentTestCase
 
   def test_renders_base_color_by_default
     render_inline(Bali::Navbar::Component.new)
-    assert_selector("nav.navbar.bg-base-100")
+    assert_selector("nav.navbar.navbar-base")
   end
 
   def test_skips_color_classes_for_unknown_symbol
     render_inline(Bali::Navbar::Component.new(color: :invalid))
     assert_selector("nav.navbar")
-    assert_no_selector("nav.navbar.bg-base-100")
+    assert_no_selector("nav.navbar.navbar-base")
   end
 
   def test_skips_color_classes_when_color_is_nil_allowing_custom_class
     render_inline(Bali::Navbar::Component.new(color: nil, class: "bg-indigo-600 text-white"))
     assert_selector("nav.navbar.bg-indigo-600.text-white")
-    assert_no_selector("nav.navbar.bg-base-100")
+    assert_no_selector("nav.navbar.navbar-base")
   end
 
   def test_accessibility_has_navigation_role


### PR DESCRIPTION
Cierra #887.

> Es la otra mitad del defecto que arregló #875, ya mergeado. Rebasado sobre `3.0`.

## Lo que estaba roto

`.navbar.is-transparent { @apply bg-transparent shadow-none }` **nunca hizo nada**. Vive en `@layer components` y el componente se pone sus dos declaraciones como utilidades sobre el elemento, desde una capa que le gana. Medido sobre `/lookbook/preview/bali/navbar/with_sidebar_burger?transparency=true`, con `is-transparent` puesto por el controlador:

```
classes:    navbar shadow-sm bg-base-100 sticky top-0 z-50 is-transparent
box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px, …
background: oklch(1 0 0)
```

Ni transparente ni sin sombra. #875 arregló la sombra; esto arregla el fondo, que quedó afuera porque los colores son dinámicos.

## El arreglo

`COLORS` pasa a mapear a **clases de Bali** — `navbar-base`, `navbar-primary`, `navbar-secondary`, `navbar-accent`, `navbar-neutral` — y `navbar/index.css` las declara **arriba** de la regla de estado. Los dos selectores son (0,2,0) y viven en la misma capa, así que decide el orden de origen y el estado pisa al default.

El color del texto **no** se toca en el estado transparente: un navbar sobre una portada oscura sigue queriendo el `*-content` de su preset. Lo que se recupera bajo 1023px con el menú abierto lo hace el bloque que ya existía.

## Lo que cambia para un host

- Un host que lea `Navbar::Component::COLORS`, o que tenga CSS contra `.navbar.bg-primary`, ve **otras clases** en el elemento. Está en el CHANGELOG.
- A cambio: un host que quiera pisar el color del preset con una utilidad propia ahora **le gana limpio**, en vez de empatar contra `bg-base-100` y depender del orden de la hoja compilada.

## Verificación

| | |
|---|---|
| navbar transparente, `background-color` | `rgba(0, 0, 0, 0)` (era `oklch(1 0 0)`) |
| navbar transparente, `box-shadow` | todas las capas en cero |
| navbar opaco `color: primary` | clase `navbar-primary`, fondo pintado |

`cypress/e2e/navbar-shadow.cy.js` sube a 4 casos — el nuevo cuida que la mudanza a `@layer components` no haya apagado el preset en silencio, que es la forma en que esto se podía romper sin que nada fallara. Minitest **3716 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
