### PR TITLE
fix(data_table): los grupos de la toolbar también alinean por abajo, y sin filtros el botón dice Buscar (#885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **Every control in the `DataTable` toolbar sits on the same line, not just the row's direct children.** Aligning the row itself fixed one level and left the other: the four groups that make it up align their own children, and the one holding the `SimpleFilters` block — which is twice the height of a single-line neighbour, because its captions sit above the controls — was centring them against it. Measured on `/admin/studios` at 2600px with the row already aligned: "Views" and the persistence marker sat level with the Filter button, while "Group by" and "Columns" sat **11px** above it. All four groups align to the end now; where every item is the same height the two alignments produce the same layout, so only that one group moves.
+
+- **A listing with a search box and no filters says "Search" on its button, not "Filter".** With nothing declared to filter by, the only thing the button submits is the search term. The string already shipped — `bali_view.filters.submit_search`, used until now only as the full filter panel's search `aria-label` — so no new translation is involved.
+
 ### Changed
 
 - **The `DataTable` toolbar reserves the space for what can collapse instead of showing it and taking it away.** On first load the row used to show every control and then, a full second later, drop four of them into the `⋯` at once. Measured on `/admin/studios`: 5 controls in the row and 0 in the menu at 195ms, 1 and 4 at 1208ms.

--- a/app/components/bali/data_table/component.html.erb
+++ b/app/components/bali/data_table/component.html.erb
@@ -16,12 +16,22 @@
 
   <% if show_toolbar? %>
     <%= tag.div(**toolbar_attributes) do %>
-      <%# Izquierda, primer subgrupo: el CONTENIDO de la vista — qué filas y qué columnas.
+      <%# Los cuatro grupos alinean por abajo, igual que la fila que los contiene: la línea
+          de controles es la que el ojo usa de referencia, y el bloque de `SimpleFilters`
+          mide el doble que sus vecinos porque lleva la etiqueta arriba. Alinear la fila y
+          dejar los grupos centrados corrige un nivel y deja el otro: medido en
+          /admin/studios a 2600px, "Views" y el marcador de persistencia quedaban a 0 del
+          botón Filter, pero "Group by" y "Columns" —que viven en ESTE grupo, el único que
+          contiene el bloque alto— quedaban 11px arriba. Con los items de igual alto las dos
+          alineaciones dan lo mismo, así que a los otros tres no les cambia nada; van igual
+          para que el próximo control que sea más alto que sus vecinos no reabra esto.
+
+          Izquierda, primer subgrupo: el CONTENIDO de la vista — qué filas y qué columnas.
           `flex-1` solo bajo `sm`: ahí la búsqueda tiene que llenar la fila, y arriba de `sm`
           es de ancho fijo (`sm:w-64`), así que creciendo empujaba la barrita y las vistas
           contra el view switch en vez de dejar el hueco donde va. %>
       <% if show_toolbar_left? %>
-        <%= tag.div(**overflow_group_attributes("left", css_class: "flex items-center gap-1 sm:gap-2 flex-1 sm:flex-initial min-w-0")) do %>
+        <%= tag.div(**overflow_group_attributes("left", css_class: "flex items-end gap-1 sm:gap-2 flex-1 sm:flex-initial min-w-0")) do %>
           <%# Se pregunta por el CONTENIDO y no por el slot: un control declarado que decide no
               pintar (p.ej. vistas guardadas sin store) dejaba un envoltorio vacío que el JS
               movía al ⋯, destapando un botón que abre un menú vacío. %>
@@ -77,7 +87,7 @@
       <%# Izquierda, segundo subgrupo: cómo se RECUERDA ese contenido — las vistas guardadas
           con nombre y el marcador que recuerda el último estado. %>
       <% if show_toolbar_memory? %>
-        <%= tag.div(**overflow_group_attributes("memory", css_class: "flex items-center gap-1 sm:gap-2 shrink-0")) do %>
+        <%= tag.div(**overflow_group_attributes("memory", css_class: "flex items-end gap-1 sm:gap-2 shrink-0")) do %>
           <% if control_content(:saved_views) %>
             <%= tag.div(**overflow_item_attributes(:saved_views, group: "memory")) do %>
               <%= control_content(:saved_views) %>
@@ -97,7 +107,7 @@
           ahí el JS ordena por prioridad descendente (10 contra 50) y quedaban a la derecha
           DEL view switch, que es lo único que puede ir pegado al borde. %>
       <% if show_toolbar_host? %>
-        <%= tag.div(**overflow_group_attributes("host", css_class: "flex items-center gap-1 sm:gap-2 shrink-0")) do %>
+        <%= tag.div(**overflow_group_attributes("host", css_class: "flex items-end gap-1 sm:gap-2 shrink-0")) do %>
           <% toolbar_buttons.each do |button| %>
             <%= tag.div(**overflow_item_attributes(:toolbar_buttons, group: "host")) do %>
               <%= button %>
@@ -110,7 +120,7 @@
           absorbe el espacio libre DESPUÉS de resolver grow/shrink, así que en móvil —donde la
           izquierda sí crece— es un no-op, y arriba de `sm` clava el switch contra el borde. %>
       <% if show_toolbar_right? %>
-        <%= tag.div(**overflow_group_attributes("right", css_class: "flex items-center gap-1 sm:gap-2 shrink-0 ml-auto")) do %>
+        <%= tag.div(**overflow_group_attributes("right", css_class: "flex items-end gap-1 sm:gap-2 shrink-0 ml-auto")) do %>
           <%= tag.div(**overflow_item_attributes(:view_switch, group: "right")) do %>
             <%= control_content(:view_switch) %>
           <% end %>

--- a/app/components/bali/data_table/simple_filters/component.rb
+++ b/app/components/bali/data_table/simple_filters/component.rb
@@ -198,7 +198,13 @@ module Bali
           end
         end
 
+        # Sin filtros declarados el botón no filtra nada: lo único que manda es el término
+        # de búsqueda, y "Filtrar" nombra algo que en esa pantalla no existe. La cadena
+        # para ese caso ya estaba en el paquete —`filters.submit_search`, hoy usada como
+        # `aria-label` del buscador del panel completo— así que no suma traducciones.
         def apply_button_text
+          return I18n.t("bali_view.filters.submit_search") if @filters.blank?
+
           I18n.t("bali_view.simple_filters.apply")
         end
 

--- a/cypress/e2e/data-table-toolbar-alignment.cy.js
+++ b/cypress/e2e/data-table-toolbar-alignment.cy.js
@@ -34,6 +34,32 @@ describe('DataTable: la fila de la toolbar se alinea por su linea de controles',
     })
   })
 
+  // Alinear la FILA corrige un nivel y deja el otro: los grupos que la componen tambien
+  // alinean a sus hijos, y el unico que contiene el bloque alto los centraba contra el.
+  // Medido con la fila alineada pero los grupos centrados, a 2600px: "Views" y el marcador
+  // de persistencia a 0 del boton Filter, pero "Group by" y "Columns" 11px arriba.
+  it('deja TODOS los controles de la toolbar en la misma linea', () => {
+    cy.viewport(2600, 1000) // ancho de sobra: nada colapsa y la fila de filtros no envuelve
+    estudios()
+    cy.get('[data-controller~="toolbar-overflow"]').should('exist')
+    cy.get('[data-toolbar-overflow-target="menu"]').should($m => {
+      expect($m[0].children.length, 'nada colapso a este ancho').to.equal(0)
+    })
+
+    cy.get('.data-table-component form button[type="submit"]').first().then($submit => {
+      const linea = abajo($submit[0])
+
+      cy.get('[data-controller~="toolbar-overflow"] [aria-label]').each($control => {
+        const el = $control[0]
+        if (el.getBoundingClientRect().height === 0) return // dentro de un dropdown cerrado
+        if ($submit[0].contains(el) || el.contains($submit[0])) return
+
+        expect(abajo(el), `${el.getAttribute('aria-label')} en la linea de controles`)
+          .to.equal(linea)
+      })
+    })
+  })
+
   // Los 4px de relleno que se quitaron para lograr esa alineacion eran el lugar del anillo
   // de foco del ultimo control: la fila era contenedor de scroll en TODOS los anchos
   // (`overflow-x-auto` sin condicion) y un contenedor de scroll recorta en su caja de

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -591,4 +591,18 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
     render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: [], search: @search, storage_id: "records_filters"))
     assert_selector('[data-controller="filter-persistence"]')
   end
+
+  # --- El rótulo del botón nombra lo que el botón hace ---
+
+  def test_the_button_says_search_when_there_is_nothing_to_filter
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: [], search: @search))
+
+    assert_selector("button[type=submit]", text: I18n.t("bali_view.filters.submit_search"))
+    assert_no_selector("button[type=submit]", text: I18n.t("bali_view.simple_filters.apply"))
+  end
+
+  def test_the_button_says_filter_as_soon_as_there_is_a_filter
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, search: @search))
+    assert_selector("button[type=submit]", text: I18n.t("bali_view.simple_filters.apply"))
+  end
 end


### PR DESCRIPTION
Cierra #885.

## 1. El desfase: la mitad ya estaba, faltaba el nivel de adentro

Cuando escribiste el issue, la toolbar era `items-center` y el desfase medido en bali-auth era **9px**. Eso se corrigió en #877 / PR #881, que es tu dirección (2): la fila pasó a alinear por abajo.

Verificado sobre `3.0` ya mergeado, en `/admin/studios` a 2600px — ancho de sobra, así que nada colapsa ni envuelve:

| control | `bottom` | vs botón Filter |
|---|---|---|
| Filter | 238 | — |
| **Remember filters** | 238 | **0** ✅ |
| Views | 238 | 0 ✅ |
| **Group by** | 227 | **−11** ❌ |
| **Columns** | 227 | **−11** ❌ |

O sea: **el marcador de persistencia, que es el que reportaste, ya estaba en 0.** Pero aparecieron dos que no.

La causa es el mismo defecto un nivel más adentro. Alinear la fila alinea sus hijos directos, que son los **grupos**; y cada grupo alinea a los suyos. El grupo izquierdo —el único que contiene el bloque alto— seguía en `items-center`, así que centraba "Group by" y "Columns" contra él. `Views` y el marcador viven en el grupo `memory`, cuyos items miden todos lo mismo, y por eso ya salían bien.

Los cuatro grupos pasan a `items-end`. Con items de igual alto las dos alineaciones dan el mismo layout, así que sólo se mueve el grupo izquierdo; los otros tres van igual para que el próximo control más alto que sus vecinos no reabra esto.

**No tomé las direcciones (1) ni (3).** `caption: false` es API nueva y (3) gasta aire en todas las tablas; alinear por la línea de controles resuelve el desfase sin tocar ni el rótulo ni su papel accesible, que es lo que el issue pedía cuidar.

## 2. El botón

`apply_button_text` devuelve `filters.submit_search` cuando `@filters` está vacío, exactamente como sugeriste. Sin API nueva y sin traducciones nuevas.

## Verificación

- `cypress/e2e/data-table-toolbar-alignment.cy.js` sube a 4 casos. El nuevo recorre **todos** los `[aria-label]` de la toolbar y exige que compartan la línea del botón Filter, así que cubre los que aparezcan después y no sólo los cuatro de hoy.
- Minitest: dos casos en `simple_filters_test.rb` — con filtros dice Filtrar, sin filtros dice Buscar. 55 runs en ese archivo, 0 fallas.

## Lo que este PR NO toca

#882, que es el otro lado del mismo rótulo: hoy no hay forma de pedir "sin rótulo" porque el `||` de `simple_filters_config` deriva uno. Va aparte porque toca `FilterForm`, no el componente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
