### PR TITLE
feat(filter_form): `label: false` pide un filtro simplificado SIN rótulo (#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Added
+
+- **`label: false` on a filter attribute means "no caption" in the `SimpleFilters` row.** There was no way to ask for one without: `simple_filters_config` derived the label with a `||`, and `nil` and `false` are both falsy, so both fell through to the derivation. The template already knew not to paint an empty one — what could not reach it was a label.
+
+  It matters because the derived one is often worse than none: it humanises the **Ransack** attribute name, not the field's, so `filter_attribute :roles_name` without a label paints "Roles name" — the predicate, humanised, in English — in a Spanish UI, and the I18n fallback does not reach it either, because `roles_name` is a path through an association rather than a column. The advanced popover keeps a label regardless; a row there needs a name.
+
 ### Changed
 
 - **The `DataTable` toolbar reserves the space for what can collapse instead of showing it and taking it away.** On first load the row used to show every control and then, a full second later, drop four of them into the `⋯` at once. Measured on `/admin/studios`: 5 controls in the row and 0 in the menu at 195ms, 1 and 4 at 1208ms.

--- a/lib/bali/filter_form.rb
+++ b/lib/bali/filter_form.rb
@@ -86,9 +86,15 @@ module Bali
       # @param type [Symbol] Data type: :text, :number, :date, :datetime,
       #   :select, :boolean. Drives the advanced UI operators and the default
       #   simple widget.
-      # @param label [String, Proc] Human-readable label (defaults to humanized key).
+      # @param label [String, Proc, false] Human-readable label (defaults to humanized key).
       #   Zero-arity procs are resolved per-instance with instance_exec (useful
       #   for I18n lookups that must not be frozen at class-load time).
+      #   `false` means "no caption" in the SimpleFilters row, for a control that
+      #   already names itself through its blank option ("All roles"). It is not
+      #   the same as omitting it: omitted derives one from the Ransack attribute
+      #   name, which for a path through an association is the predicate humanized
+      #   in English. The advanced popover keeps a label either way — a row there
+      #   needs a name.
       # @param options [Array, Proc] For select types, array of [label, value]
       #   pairs or a zero-arity proc resolved per-instance with instance_exec —
       #   inside it you can use `scope` (the relation the controller passed in,

--- a/lib/bali/filter_form/simple_filters_configuration.rb
+++ b/lib/bali/filter_form/simple_filters_configuration.rb
@@ -120,7 +120,7 @@ module Bali
             attribute: filter[:attribute],
             collection: resolve_collection(filter[:collection]),
             blank: resolve_definition_value(filter[:blank]),
-            label: resolve_definition_value(filter[:label]) || infer_simple_filter_label(filter[:attribute]),
+            label: simple_filter_label(filter),
             default: filter[:default],
             type: type,
             predicate: predicate,
@@ -271,6 +271,35 @@ module Bali
       end
 
       # Infer label from attribute name using I18n or humanization
+      # `label: false` es "no quiero rótulo"; `nil` o ausente sigue siendo "derivalo". Con
+      # el `||` que había acá los dos eran falsy y los dos caían a la derivación, así que
+      # no había forma de pedir un filtro sin caption. La plantilla sí sabe no pintarlo
+      # —`if filter[:label].present?`— lo que no dejaba llegar un rótulo vacío era esto.
+      #
+      # Importa porque lo derivado suele ser peor que nada: `infer_simple_filter_label`
+      # humaniza el nombre del atributo RANSACK, no el del campo, así que un
+      # `simple_filter :roles_name` sin `label:` pinta "Roles name" —el predicado,
+      # humanizado y en inglés— en una UI en español; el fallback de I18n tampoco alcanza
+      # ahí, porque `roles_name` no es un atributo del modelo sino un camino por una
+      # asociación.
+      #
+      # El centinela es `false` y NO la ausencia de la clave, aunque distinguir "no me la
+      # pasaron" sería más elegante: no se puede. `simple_filter` delega en
+      # `filter_attribute`, que guarda `explicit_label: label` siempre, y
+      # `defined_simple_filters` reconstruye el hash con `label:` fijo. O sea que
+      # `filter.key?(:label)` es SIEMPRE true y, usado como condición, dejaría a todos los
+      # filtros sin rótulo. `explicit_label` sí conserva el `false`, que es lo que hace
+      # que este camino funcione.
+      #
+      # El rótulo del panel avanzado no se toca: `filter_attributes` guarda
+      # `label: label || key.to_s.humanize` aparte, así que una fila del popover sigue
+      # teniendo nombre, que es lo que ahí hace falta.
+      def simple_filter_label(filter)
+        return nil if filter[:label] == false
+
+        resolve_definition_value(filter[:label]) || infer_simple_filter_label(filter[:attribute])
+      end
+
       def infer_simple_filter_label(attribute)
         # Try model-specific I18n first
         if respond_to?(:scope) && scope.respond_to?(:model)

--- a/test/bali/filter_form_test.rb
+++ b/test/bali/filter_form_test.rb
@@ -49,6 +49,15 @@ class SimpleFilterableMovieFilterForm < Bali::FilterForm
                    default: "done"
 end
 
+# El caso de #882 escrito con la API que v3 promueve: un filtro cuyo control ya se nombra
+# solo con su opción en blanco, declarado con `label: false` para que no lleve caption.
+class UncaptionedSimpleFilterForm < Bali::FilterForm
+  filter_attribute :genre, type: :select, simple: true, advanced: false,
+                   options: [ %w[Action action] ],
+                   blank: "Todos los géneros",
+                   label: false
+end
+
 # Test simple filter inheritance
 class ExtendedSimpleFilterForm < SimpleFilterableMovieFilterForm
   filter_attribute :indie, type: :select, simple: true, advanced: false,
@@ -822,6 +831,49 @@ class BaliFilterFormTestSimpleFilters < ActiveSupport::TestCase
     config = @form.simple_filters_config
     status_config = config.find { |c| c[:attribute] == :status }
     assert_equal("Movie Status", status_config[:label])
+  end
+
+  # `label: false` es "no quiero rótulo". Antes no existía la distinción: `nil` y `false`
+  # son los dos falsy, así que el `||` mandaba a los dos a la derivación y no había forma
+  # de pedir un filtro sin caption. La plantilla ya sabía no pintarlo.
+  def test_simple_filters_config_honours_an_explicit_label_false
+    form = Bali::FilterForm.new(
+      Movie.all, params({}),
+      simple_filters: [ { attribute: :genre, collection: [ %w[A a] ], blank: "All", label: false } ]
+    )
+
+    assert_nil(form.simple_filters_config.first[:label])
+  end
+
+  # Y lo derivado sigue llegando cuando no se pide nada, que es el caso de siempre.
+  def test_simple_filters_config_still_infers_when_no_label_is_given
+    form = Bali::FilterForm.new(
+      Movie.all, params({}),
+      simple_filters: [ { attribute: :genre, collection: [ %w[A a] ], blank: "All" } ]
+    )
+
+    assert_equal("Genre", form.simple_filters_config.first[:label])
+  end
+
+  # El mismo caso por la API que v3 promueve, `filter_attribute`, que es por donde va a
+  # llegar de un host.
+  def test_filter_attribute_honours_an_explicit_label_false_for_the_simple_row
+    form = UncaptionedSimpleFilterForm.new(Movie.all, params({}))
+
+    assert_nil(form.simple_filters_config.first[:label])
+    assert_equal("Todos los géneros", form.simple_filters_config.first[:blank])
+  end
+
+  # El centinela NO puede ser la ausencia de la clave: `simple_filter` delega en
+  # `filter_attribute`, que guarda `explicit_label:` siempre, así que `defined_simple_filters`
+  # devuelve la clave `:label` puesta aunque nadie la haya escrito. Con `key?` como
+  # condición, TODOS los filtros declarados por el DSL se quedarían sin rótulo.
+  def test_the_dsl_always_carries_the_label_key_so_key_presence_cannot_be_the_sentinel
+    genre = SimpleFilterableMovieFilterForm.defined_simple_filters
+                                           .find { |f| f[:attribute] == :genre }
+
+    assert(genre.key?(:label), "la clave viene puesta")
+    assert_nil(genre[:label], "y sin valor, porque el DSL no recibió ninguno")
   end
 
   def test_simple_filters_config_returns_nil_when_simple_filters_not_enabled


### PR DESCRIPTION
Cierra #882.

`label: false` en un `filter_attribute` (o en un hash de `simple_filters:`) significa "sin rótulo" en la fila de `SimpleFilters`. `nil` y la ausencia siguen derivando uno, como siempre.

## Una corrección sobre la sugerencia del issue

Proponías dos variantes y decías que la segunda era más limpia:

```ruby
label: filter.key?(:label) ? resolve_definition_value(filter[:label]) : infer_simple_filter_label(filter[:attribute]),
```

**Esa no funciona, y falla en silencio hacia el lado peor: deja a TODOS los filtros sin rótulo.** `simple_filter` delega en `filter_attribute`, que guarda `explicit_label: label` siempre, y `defined_simple_filters` reconstruye el hash con la clave `:label` fija:

```ruby
# simple_filters_configuration.rb:47
label: attr[:explicit_label],
```

O sea que `filter.key?(:label)` es **siempre true**, se haya escrito o no. Lo verifiqué y quedó fijado en un test, para que la idea no vuelva:

```ruby
def test_the_dsl_always_carries_the_label_key_so_key_presence_cannot_be_the_sentinel
  assert(genre.key?(:label), "la clave viene puesta")
  assert_nil(genre[:label], "y sin valor, porque el DSL no recibió ninguno")
end
```

Así que va la primera: el centinela es `false`. `explicit_label` sí lo conserva, que es lo que hace que el camino funcione.

## Lo que NO cambia

El rótulo del **panel avanzado**. `filter_attributes` guarda su propio `label: label || key.to_s.humanize`, así que una fila del popover sigue teniendo nombre — que es lo que ahí hace falta, y que es distinto de la fila inline, donde el control ya se nombra con su opción en blanco.

Y no cambia nada para quien no escribe `label:`: sigue recibiendo la derivación.

## Verificación

Cuatro casos en `filter_form_test.rb`:

- `label: false` por el hash de instancia → `nil`
- `label: false` por `filter_attribute`, que es la API que v3 promueve → `nil`, y el `blank:` intacto
- sin `label:` → sigue derivando `"Genre"`
- la forma del hash del DSL, que es lo que descarta el centinela por `key?`

Minitest completo: **3720 / 0**.

## Nota sobre el workaround

El que estabas usando —`filters: @filter_form.simple_filters_config.map { |f| f.merge(label: nil) }`— se puede tirar: `label: false` en la declaración hace lo mismo sin renunciar a `with_simple_filters` pelado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
