### PR TITLE
docs(migration): la guía mandaba a definir `--bali-z-hovercard`, que no existe (#851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Documentation
+
+- **The migration guide no longer sends you to define `--bali-z-hovercard`, a token nothing declares.** The hovercard shares the tooltip tier — the guide's own table said so thirty lines above, and `HoverCard::Component` documents it too; only the prose disagreed. It fails in the worst direction: a host that declares the invented token sees no error, no warning, and not even the `9999` fallback, which `zIndexFor` reaches only when Bali's stylesheet is missing from the page. The override just reads as a no-op. A test now fails the build if the guide ever names a tier the scale does not declare.
+
 ### Changed
 
 - **The `DataTable` toolbar reserves the space for what can collapse instead of showing it and taking it away.** On first load the row used to show every control and then, a full second later, drop four of them into the `⋯` at once. Measured on `/admin/studios`: 5 controls in the row and 0 in the menu at 195ms, 1 and 4 at 1208ms.

--- a/docs/guides/migration-v2-to-v3.md
+++ b/docs/guides/migration-v2-to-v3.md
@@ -1186,8 +1186,20 @@ Nothing about escaping the scale got harder.
 **`Bali::HoverCard::Component::DEFAULT_Z_INDEX` is gone, and `z_index:` now defaults to
 `nil`.** The constant was `9999`. Referencing it raises `NameError`, and there is deliberately
 nothing to replace it with: hardcoding the scale's top value in Ruby is exactly what breaks
-the moment a host moves the scale. `z_index: nil` means "read `--bali-z-hovercard` at
+the moment a host moves the scale. `z_index: nil` means "read `--bali-z-tooltip` at
 connect", which is what you want; pass a number only to pin one hovercard outside the scale.
+
+**The hovercard has no tier of its own** — it shares the tooltip's, which is what the table
+above says and what `HoverCard::Component` documents. The scale is exactly these seven, and
+nothing else in it is named after a component that is not on this list:
+
+`--bali-z-dropdown`, `--bali-z-popover`, `--bali-z-tooltip`, `--bali-z-drawer`,
+`--bali-z-modal`, `--bali-z-command`, `--bali-z-toast`.
+
+Inventing a name outside that list does nothing at all: no error, no warning, and not even
+the `9999` fallback, which `zIndexFor` only reaches when Bali's stylesheet is missing from
+the page. The override reads as a no-op with nothing to say why. `test/bali/z_index_tokens_test.rb`
+fails the build if this guide ever names a tier the scale does not declare.
 
 ```bash
 grep -rn "DEFAULT_Z_INDEX" app/

--- a/test/bali/z_index_tokens_test.rb
+++ b/test/bali/z_index_tokens_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Un token de la escala que no existe falla EN SILENCIO y hacia el lado equivocado: un host
+# que declara `--bali-z-hovercard` porque la guía se lo dijo no ve ningún error, y tampoco ve
+# el `9999` de respaldo —`zIndexFor` sólo cae ahí cuando la hoja de Bali no está en la
+# página—, así que se queda con el valor del tier que sí existe y concluye que su override
+# "no hace nada" sin saber por qué. Eso fue #851: la prosa de la guía de migración mandaba a
+# definir un token que la gema nunca declaró, mientras su propia tabla, treinta líneas más
+# arriba, decía lo correcto.
+class BaliZIndexTokensTest < ActiveSupport::TestCase
+  ENGINE_ROOT = Pathname.new(File.expand_path("../..", __dir__))
+  SCALE = ENGINE_ROOT.join("app/assets/stylesheets/bali/z_index.css")
+
+  # Sólo `docs/`, y a propósito: lo que se cuida es que la documentación no le PROMETA a un
+  # host un token que nadie declara. El CHANGELOG es un registro de lo que pasó —incluida la
+  # entrada que cuenta que este token equivocado se fue— y ahí nombrarlo es correcto.
+  PROSE = Dir[ENGINE_ROOT.join("docs/**/*.md")].sort.freeze
+
+  def declared_tokens
+    SCALE.read.scan(/--bali-z-([a-z-]+)\s*:/).flatten.uniq.sort
+  end
+
+  def test_the_scale_declares_the_tiers_the_package_reads
+    # Si esta lista cambia, cambió el contrato: el nombre de un tier es API para el host.
+    assert_equal(
+      %w[command drawer dropdown modal popover toast tooltip],
+      declared_tokens
+    )
+  end
+
+  def test_the_documentation_names_no_token_the_scale_does_not_declare
+    known = declared_tokens
+    offenders = PROSE.flat_map do |path|
+      relative = Pathname.new(path).relative_path_from(ENGINE_ROOT)
+      File.readlines(path).each_with_index.filter_map do |line, index|
+        tokens = line.scan(/--bali-z-([a-z-]+)/).flatten.uniq - known
+        "  #{relative}:#{index + 1} — --bali-z-#{tokens.first}" if tokens.any?
+      end
+    end
+
+    assert_empty(
+      offenders,
+      "La documentación promete tokens que la escala no declara. Los tiers son " \
+      "#{known.join(', ')}; un nombre fuera de esa lista no lo lee nadie y no avisa.\n" +
+      offenders.join("\n")
+    )
+  end
+end


### PR DESCRIPTION
Cierra #851.

`z_index: nil` lee `--bali-z-tooltip`. La tabla de la propia guía ya lo decía bien treinta líneas más arriba, y `HoverCard::Component` también; el outlier era la prosa de una línea.

Como apuntabas, falla **en silencio y hacia el lado equivocado**: quien declara el token inventado no ve error, no ve warning, y tampoco ve el `9999` de respaldo —`zIndexFor` sólo cae ahí cuando la hoja de Bali no está en la página—, así que se queda con el valor del tier que sí existe y concluye que su override "no hace nada".

## Además del arreglo, un guard

`test/bali/z_index_tokens_test.rb`, dos casos:

1. La escala declara exactamente `command, drawer, dropdown, modal, popover, tooltip, toast`. Si esa lista cambia, cambió el contrato: el nombre de un tier es API para el host.
2. **Ningún `.md` de `docs/` nombra un token que la escala no declare.** Verificado que falla con el texto anterior:

```
docs/guides/migration-v2-to-v3.md:1192 — --bali-z-hovercard
```

Dos decisiones de redacción que el guard forzó, y que vale explicitar:

- **La frase nueva no escribe el token inexistente.** Lo puse primero como "no existe `--bali-z-hovercard`" y el guard lo cazó — con la mención adentro no puede ser absoluto. Preferí el guard fuerte; quien busque "hovercard" cae igual en ese párrafo.
- **El guard mira `docs/` y no el CHANGELOG.** El CHANGELOG es un registro de lo que pasó, incluida la entrada que cuenta que este token equivocado se fue, y ahí nombrarlo es correcto. Lo que se cuida es que la documentación no le PROMETA a un host algo que nadie declara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
