### PR TITLE
fix(filter_form): la persistencia también guarda y restaura los filtros simplificados (#852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **"Remember filters" covers the simple filters, not just the quick search.** The marker was never dead — it governs the search box — and that made it worse than if it had been: the user turns it on, comes back to the listing with a clean URL, and the search returns while their selects do not. Nothing in the UI tells apart a control that is remembered from one that is not; both sit in the same toolbar row.
+
+  The inconsistency was internal, which is what settled which side was wrong: a **saved view** over that same listing did restore them — `PAYLOAD_KEYS` has always listed `simple_filters` — so one component carried two definitions of "the filter state". A simple filter's value never becomes an ActiveModel attribute (it lives in `@q_params` and goes straight to Ransack), so `attributes.to_h` never carried it along by accident. The fix reuses the saved-view round trip instead of opening a second path: `active_simple_filters` writes, `apply_simple_filter_state` restores, `current_simple_filter_value` reads — one key throughout.
+
+  The same gap made a shared link mean different things to different people, which is the half that bites without persistence being involved at all. `has_filter_params` did not count the simple filters, so a URL asking only for one fell into the *restore* branch and the cache outranked the URL. Measured on `/admin/studios` over `?q[country_eq]=USA`: **9 rows** with the persistence cookie on — a cached search the URL never mentions applied on top of it — against **10** with it off. They are counted now as an *origin* rather than a value, the same distinction `group_by` already makes: the SimpleFilters form submits every control it renders, so emptying a select arrives as `q[size_eq]=`, an explicit choice whose value is blank. Reading only the values would have made clearing a filter indistinguishable from asking for nothing, and the restore branch would have handed back the filter the user had just cleared.
+
+  Clearing the search keeps them, too: `clearSearch` navigates dropping every `q[...]`, so the stored state is the only record left of what was selected.
+
 ### Documentation
 
 - **The migration guide no longer sends you to define `--bali-z-hovercard`, a token nothing declares.** The hovercard shares the tooltip tier — the guide's own table said so thirty lines above, and `HoverCard::Component` documents it too; only the prose disagreed. It fails in the worst direction: a host that declares the invented token sees no error, no warning, and not even the `9999` fallback, which `zIndexFor` reaches only when Bali's stylesheet is missing from the page. The override just reads as a no-op. A test now fails the build if the guide ever names a tier the scale does not declare.

--- a/cypress/e2e/filter-persistence-simple-filters.cy.js
+++ b/cypress/e2e/filter-persistence-simple-filters.cy.js
@@ -1,0 +1,105 @@
+// El marcador "Recordar filtros" gobierna la búsqueda rápida pero no cubría los filtros
+// simplificados, y una vista guardada sobre EL MISMO listado sí los restauraba: dos
+// mecanismos del mismo componente con dos definiciones de "el estado de los filtros" (#852).
+//
+// Vive contra `/admin/studios` y no contra un preview de Lookbook porque el defecto necesita
+// el round-trip completo: la cookie de persistencia, el form GET de SimpleFilters que manda
+// TODOS sus controles, y la caché del server entre dos requests. Nada de eso existe en un
+// preview.
+describe('La persistencia de filtros cubre los filtros simplificados', () => {
+  // El dummy vive arriba del path de previews al que apunta `baseUrl`, así que el origen se
+  // deriva de él. Un `http://localhost:3001` literal ignora CYPRESS_BASE_URL y prueba en
+  // silencio el server de otro checkout.
+  const appOrigin = new URL(Cypress.config('baseUrl')).origin
+  const listing = `${appOrigin}/admin/studios`
+
+  // El total sale del pie de la paginación, no de contar `<tr>`: la tabla pagina de a 10, así
+  // que las filas no distinguen 9 de 34.
+  const total = () =>
+    cy.contains(/of \d+ studios/i).invoke('text').then(text => Number(/of (\d+) studios/i.exec(text)[1]))
+
+  // El submit navega, así que hay que esperar la URL nueva antes de leer nada: sin eso
+  // `total()` lee el DOM viejo una sola vez y no reintenta. Se afirma sobre el nombre
+  // codificado (`q%5Bsize_eq%5D`) porque es lo que un GET pone en la barra.
+  const submitFiltersAndWaitFor = param => {
+    cy.get('form[data-turbo-frame="_top"] button[type="submit"]').first().click()
+    cy.location('search').should('include', param)
+  }
+
+  beforeEach(() => {
+    cy.viewport(1600, 1000)
+    // Lo que el marcador de la toolbar escribe. Cypress limpia las cookies entre tests, y con
+    // ellas la sesión — que es lo que namespacea la caché (ver ApplicationController#filter_context).
+    cy.setCookie('bali_persist_admin_studios', '1')
+  })
+
+  it('devuelve el filtro simplificado al volver con la URL limpia, aplicado y pintado', () => {
+    cy.visit(listing)
+
+    total().then(everything => {
+      cy.get('input[name="q[size_eq]"][value="large"]').check()
+      submitFiltersAndWaitFor('q%5Bsize_eq%5D=large')
+
+      total().then(filtered => {
+        expect(filtered, 'el filtro tiene que recortar').to.be.lessThan(everything)
+
+        // La vuelta al listado: sin `q` en la URL, la caché es la única fuente del estado.
+        cy.visit(listing)
+        cy.location('search').should('eq', '')
+
+        // Las dos mitades: que RECORTE y que se VEA. Afirmar solo el radio pasaría con un
+        // control pintado sobre un listado sin filtrar.
+        total().should('eq', filtered)
+        cy.get('input[name="q[size_eq]"][value="large"]').should('be.checked')
+      })
+    })
+  })
+
+  it('no lo restaura con el marcador apagado', () => {
+    // El arreglo amplía lo que el marcador CUBRE; no puede cambiar lo que el marcador significa.
+    cy.visit(listing)
+    total().then(everything => {
+      cy.get('input[name="q[size_eq]"][value="large"]').check()
+      submitFiltersAndWaitFor('q%5Bsize_eq%5D=large')
+      total().should('be.lessThan', everything)
+
+      cy.clearCookie('bali_persist_admin_studios')
+      cy.visit(listing)
+      total().should('eq', everything)
+      cy.get('input[name="q[size_eq]"][value="large"]').should('not.be.checked')
+    })
+  })
+
+  it('deja que la URL le gane a la caché: un enlace compartido no arrastra una búsqueda guardada', () => {
+    // Como `has_filter_params` no contaba los simplificados, una URL que solo pedía uno caía
+    // en el branch de RESTAURAR y la caché le ganaba a la URL: el mismo enlace rendía distinto
+    // según una cookie de quien lo abría (9 filas contra 10, medido sobre `?q[country_eq]=USA`).
+    cy.visit(`${listing}?q[name_cont]=a`)
+    cy.get('input[name="q[name_cont]"]').should('have.value', 'a')
+
+    cy.visit(`${listing}?q[country_eq]=USA`)
+    // La prueba directa: la búsqueda vieja se veía en la caja, y nadie la escribió en la URL.
+    cy.get('input[name="q[name_cont]"]').should('have.value', '')
+
+    total().then(withPersistence => {
+      cy.clearCookie('bali_persist_admin_studios')
+      cy.visit(`${listing}?q[country_eq]=USA`)
+      total().should('eq', withPersistence)
+    })
+  })
+
+  it('limpiar la búsqueda no se lleva los filtros simplificados', () => {
+    // `clearSearch` navega descartando TODOS los `q[...]`, así que si el estado guardado no
+    // los conserva —o los conserva y no los aplica— los selects se vacían con la búsqueda.
+    cy.visit(`${listing}?q[size_eq]=large&q[name_cont]=a`)
+
+    total().then(searchedAndFiltered => {
+      cy.get('input[name="q[name_cont]"]').should('have.value', 'a')
+
+      cy.visit(`${listing}?clear_search=true`)
+      cy.get('input[name="q[name_cont]"]').should('have.value', '')
+      cy.get('input[name="q[size_eq]"][value="large"]').should('be.checked')
+      total().should('be.greaterThan', searchedAndFiltered)
+    })
+  })
+})

--- a/lib/bali/filter_form.rb
+++ b/lib/bali/filter_form.rb
@@ -268,6 +268,15 @@ module Bali
       # simple filter values bypass ActiveModel and go straight to Ransack.
       @q_params = q_params.permit(perm_attrs) if self.simple_filters_enabled?
 
+      # ORIGEN vs VALOR, la misma distinción que `@group_by_requested` hace para la
+      # agrupación, y por el mismo motivo: el form de SimpleFilters manda TODOS sus
+      # controles, así que vaciar un select llega como `q[genre_eq]=` — una elección
+      # explícita cuyo valor es vacío. Mirando solo los valores no se distingue de "no vino
+      # nada", y con la persistencia encendida eso cae al branch de restaurar, que le
+      # devolvía al usuario el filtro que acababa de limpiar. Se captura ANTES de aplicar
+      # una vista guardada, que reemplaza `@q_params` con el estado de la vista.
+      @simple_filters_requested = simple_filter_params?(@q_params)
+
       # Vista guardada aplicada por URL (?saved_view=<id>): su payload REEMPLAZA el estado
       # que hubiera venido en q — una vista es un estado completo, no un merge. Va ANTES de
       # la persistencia para que el estado de la vista se escriba como "último estado" del
@@ -520,7 +529,8 @@ module Bali
     def fetch_stored_filter_state(attributes, groupings, combinator, search_value, force_write: false)
       return [ attributes, groupings, combinator, search_value ] unless Object.const_defined?("Rails")
 
-      has_filter_params = force_write || attributes.present? || groupings.present? || search_value.present?
+      has_filter_params = force_write || attributes.present? || groupings.present? ||
+                          search_value.present? || @simple_filters_requested
 
       if has_filter_params
         # User submitted new filters → always save complete state. `group_by` viaja con el
@@ -531,7 +541,12 @@ module Bali
                             groupings: groupings,
                             combinator: combinator,
                             search_value: search_value,
-                            group_by: @group_by
+                            group_by: @group_by,
+                            # Misma llave y misma forma que `PAYLOAD_KEYS` de las vistas
+                            # guardadas: el round-trip es el que ya existe (`active_simple_filters`
+                            # escribe, `apply_simple_filter_state` restaura,
+                            # `current_simple_filter_value` lee), no una segunda ruta.
+                            simple_filters: active_simple_filters
                           })
         [ attributes, groupings, combinator, search_value ]
       elsif @clear_filters
@@ -545,7 +560,12 @@ module Bali
         # por la que reaparecen filtros que la URL ya no describe.
         stored = @persist_enabled ? Rails.cache.fetch(cache_key) : nil
         if stored.is_a?(Hash)
+          # Los simplificados sobreviven al merge —solo `search_value` se anula— y salen por
+          # el efecto: limpiar la búsqueda no puede llevarse los selects. `clearSearch` navega
+          # descartando todos los `q[...]` (ver preservedParamsUrl), así que la caché es la
+          # ÚNICA fuente de lo que el usuario tenía elegido.
           Rails.cache.write(cache_key, stored.merge(search_value: nil))
+          restore_simple_filter_state(stored)
           [ stored[:attributes] || {}, stored[:groupings], stored[:combinator], nil ]
         else
           [ {}, nil, nil, nil ]
@@ -565,6 +585,7 @@ module Bali
         elsif stored.key?(:group_by)
           @group_by = resolve_group_by(stored[:group_by])
         end
+        restore_simple_filter_state(stored)
         [
           stored[:attributes] || {},
           stored[:groupings],
@@ -577,6 +598,20 @@ module Bali
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    # Los simplificados se restauran por un EFECTO y no por la tupla, porque su valor nunca es
+    # un atributo de ActiveModel: vive en `@q_params` y va directo a Ransack. Es exactamente lo
+    # que ya hace una vista guardada, así que se reusa su camino en vez de abrir un segundo.
+    #
+    # `apply_simple_filter_state` REEMPLAZA `@q_params`, no mergea — un estado restaurado es
+    # completo, igual que una vista. Por eso solo se llega acá desde los branches donde la URL
+    # no pidió ningún simplificado (`@simple_filters_requested` los manda al branch de
+    # escribir): si no, esto pisaría el filtro recién elegido con el viejo.
+    def restore_simple_filter_state(stored)
+      return unless simple_filters_enabled?
+
+      apply_simple_filter_state(stored[:simple_filters])
+    end
 
     # Formato viejo de la caché: solo los atributos, sin las llaves del estado completo. Se
     # normaliza en la entrada para que el resto del branch hable una sola forma — restaurar y

--- a/lib/bali/filter_form/simple_filters_configuration.rb
+++ b/lib/bali/filter_form/simple_filters_configuration.rb
@@ -180,6 +180,23 @@ module Bali
         active_simple_filters.any?
       end
 
+      # Whether the request carried a simple filter FIELD, with or without a value.
+      #
+      # This is about ORIGIN, not value, and the two do not coincide: the SimpleFilters
+      # form is a plain GET that submits every control it renders, so emptying a select
+      # arrives as `q[genre_eq]=` — an explicit choice whose value happens to be blank.
+      # {#active_simple_filters} cannot tell that apart from a URL that mentioned no
+      # filter at all, and the difference decides whether the request is storing state
+      # or restoring it.
+      #
+      # @param params [ActionController::Parameters, Hash] the `q` params as they arrived
+      # @return [Boolean]
+      def simple_filter_params?(params)
+        return false if params.blank?
+
+        simple_filter_param_names.any? { |key| params.key?(key) }
+      end
+
       # Replace the simple filter values with the ones a saved view carries. A view
       # is a complete state and not a merge, so whatever came in the URL is dropped
       # — the same contract {FilterForm#apply_saved_view_state} applies to the
@@ -215,6 +232,14 @@ module Bali
         keys
       end
 
+      # The same keys, flattened for lookup. {#simple_filters_permitted_keys} is shaped for
+      # `permit`, where a toggle group is a `{key => []}` entry rather than a bare name.
+      #
+      # @return [Array<String>]
+      def simple_filter_param_names
+        simple_filters_permitted_keys.flat_map { |key| key.is_a?(Hash) ? key.keys : key }.map(&:to_s)
+      end
+
       private
 
       # Resolve type and predicate from a filter hash, normalizing to symbols.
@@ -246,13 +271,29 @@ module Bali
         value = @q_params[key] || @q_params[key.to_sym] if defined?(@q_params) && @q_params.present?
 
         # 2. Try instance attribute (for persisted/restored values)
-        value ||= send(key) if respond_to?(key)
+        value ||= send(key) if attributes_initialized? && respond_to?(key)
 
         if value.is_a?(Array)
           return value.compact_blank
         end
 
         value
+      end
+
+      # Whether this form has run ActiveModel's own initializer yet.
+      #
+      # `respond_to?` on an ActiveModel raises before it has: the dispatch reads
+      # `@attributes`, which `super(attributes)` sets at the very END of
+      # {FilterForm#initialize}. The persistence write asks for the active simple filters
+      # from inside `fetch_stored_filter_state`, which necessarily runs before that — what
+      # it writes is part of what it then hands to `super`.
+      #
+      # Nothing is lost by skipping the fallback there: at that point everything the request
+      # carries still lives in `@q_params`, which step 1 already read. The fallback exists
+      # for the render that comes after, where a value restored into a declared attribute is
+      # the only copy left.
+      def attributes_initialized?
+        defined?(@attributes) && !@attributes.nil?
       end
 
       # Get current min/max values for a number_range filter from params

--- a/test/bali/filter_form_test.rb
+++ b/test/bali/filter_form_test.rb
@@ -36,6 +36,16 @@ class SearchableMovieFilterForm < Bali::FilterForm
   filter_attribute :genre, type: :select, options: [ %w[Action action], %w[Comedy comedy] ]
 end
 
+# El listado que reportó #852: búsqueda rápida y filtros simplificados sobre el mismo form,
+# que es donde los dos mecanismos de "estado" (la persistencia y las vistas guardadas) se
+# cruzan. Las opciones valen lo mismo que la columna para poder afirmar sobre el recorte.
+class SearchableSimpleFilterForm < Bali::FilterForm
+  search_fields :name, :genre
+
+  filter_attribute :genre, type: :select, simple: true, advanced: false,
+                   options: [ %w[Action Action], %w[Comedy Comedy] ], blank: "All Genres"
+end
+
 # Test form declaring simple-UI-only filters
 class SimpleFilterableMovieFilterForm < Bali::FilterForm
   filter_attribute :genre, type: :select, simple: true, advanced: false,
@@ -737,6 +747,121 @@ class BaliFilterFormPersistenceTest < ActiveSupport::TestCase
 
     assert_nil(@form.search_value, "la vista vacía debe ganarle a la búsqueda vieja en caché")
     assert_equal([], @form.filter_groups)
+  end
+
+  # --- #852: la persistencia cubre los filtros simplificados, igual que las vistas guardadas ---
+  #
+  # El marcador "Recordar filtros" no estaba muerto —gobierna la búsqueda rápida—, y por eso
+  # era peor: el usuario volvía al listado y la búsqueda aparecía, pero sus selects no. Una
+  # vista guardada SOBRE EL MISMO LISTADO sí los restauraba (`PAYLOAD_KEYS` los incluye), o
+  # sea que el mismo componente tenía dos definiciones de "el estado de los filtros".
+
+  def test_persists_and_restores_an_active_simple_filter
+    SearchableSimpleFilterForm.new(Movie.all, params(genre_eq: "Action"), storage_id: "movies")
+
+    stored = Rails.cache.read(cache_key_for(SearchableSimpleFilterForm))
+    assert_equal({ "genre_eq" => "Action" }, stored[:simple_filters])
+
+    restored = SearchableSimpleFilterForm.new(
+      Movie.all, ActionController::Parameters.new, storage_id: "movies", persist_enabled: true
+    )
+    assert_equal({ "genre_eq" => "Action" }, restored.active_simple_filters)
+    assert_equal("Action", restored.ransack_params["genre_eq"],
+                 "restaurar tiene que llegar hasta Ransack, no solo pintar el select")
+  end
+
+  def test_a_restored_simple_filter_narrows_the_result
+    tenant = Tenant.create(name: "Restore Studio")
+    tenant.movies.create(name: "Iron Man", genre: "Action")
+    tenant.movies.create(name: "Snatch", genre: "Comedy")
+
+    SearchableSimpleFilterForm.new(Movie.all, params(genre_eq: "Action"), storage_id: "movies")
+    restored = SearchableSimpleFilterForm.new(
+      Movie.all, ActionController::Parameters.new, storage_id: "movies", persist_enabled: true
+    )
+
+    names = restored.result.pluck(:name)
+    assert_includes(names, "Iron Man")
+    refute_includes(names, "Snatch")
+  end
+
+  def test_a_simple_filter_is_not_restored_when_persistence_is_off
+    # El marcador gobierna: si apagado restaurase, el arreglo habría cambiado lo que el
+    # marcador significa en vez de ampliar lo que cubre.
+    SearchableSimpleFilterForm.new(Movie.all, params(genre_eq: "Action"), storage_id: "movies")
+
+    restored = SearchableSimpleFilterForm.new(
+      Movie.all, ActionController::Parameters.new, storage_id: "movies", persist_enabled: false
+    )
+    assert_empty(restored.active_simple_filters)
+  end
+
+  def test_a_simple_filter_from_the_url_beats_the_persisted_state
+    # La otra mitad, y la más grave: como `has_filter_params` no contaba los simplificados,
+    # una URL que solo pedía uno caía en el branch de RESTAURAR y la caché le ganaba a la URL.
+    # Medido en /admin/studios sobre `?q[country_eq]=USA`: 9 filas con la cookie de
+    # persistencia en 1 —se colaba una búsqueda guardada que la URL no menciona— contra 10 con
+    # la cookie en 0. Un enlace compartido rendía distinto según una cookie de quien lo abría.
+    SearchableSimpleFilterForm.new(Movie.all, params(name_or_genre_cont: "iron"), storage_id: "movies")
+
+    deep_link = SearchableSimpleFilterForm.new(
+      Movie.all, params(genre_eq: "Action"), storage_id: "movies", persist_enabled: true
+    )
+    assert_nil(deep_link.search_value, "la URL manda: no puede colarse una búsqueda que no nombra")
+    assert_equal({ "genre_eq" => "Action" }, deep_link.active_simple_filters)
+  end
+
+  def test_clearing_a_simple_filter_is_not_undone_by_the_persisted_one
+    # El form de SimpleFilters manda TODOS sus controles, así que vaciar el select llega como
+    # `q[genre_eq]=`: valor vacío, elección explícita. Sin distinguir eso de "no vino nada"
+    # —la misma distinción que `@group_by_requested`—, restaurar le devolvía al usuario el
+    # filtro que acababa de limpiar.
+    SearchableSimpleFilterForm.new(Movie.all, params(genre_eq: "Action"), storage_id: "movies")
+
+    cleared = SearchableSimpleFilterForm.new(
+      Movie.all, params(genre_eq: ""), storage_id: "movies", persist_enabled: true
+    )
+    assert_empty(cleared.active_simple_filters)
+
+    returning = SearchableSimpleFilterForm.new(
+      Movie.all, ActionController::Parameters.new, storage_id: "movies", persist_enabled: true
+    )
+    assert_empty(returning.active_simple_filters, "limpiar tiene que sobrevivir al próximo request")
+  end
+
+  def test_clearing_the_search_keeps_the_simple_filters
+    # `clearSearch` navega descartando TODOS los `q[...]` (ver preservedParamsUrl), así que la
+    # caché es la única fuente de lo que había elegido: si el merge o la tupla se los lleva,
+    # limpiar la búsqueda limpia también los selects.
+    SearchableSimpleFilterForm.new(
+      Movie.all, params(genre_eq: "Action", name_or_genre_cont: "iron"), storage_id: "movies"
+    )
+
+    cleared = SearchableSimpleFilterForm.new(
+      Movie.all, ActionController::Parameters.new(clear_search: true),
+      storage_id: "movies", persist_enabled: true
+    )
+    assert_nil(cleared.search_value)
+    assert_equal({ "genre_eq" => "Action" }, cleared.active_simple_filters)
+
+    stored = Rails.cache.read(cache_key_for(SearchableSimpleFilterForm))
+    assert_equal({ "genre_eq" => "Action" }, stored[:simple_filters],
+                 "y tienen que sobrevivir al merge que anula la búsqueda")
+  end
+
+  def test_a_form_without_simple_filters_stores_an_empty_simple_filter_state
+    # El payload crece para todos, y el branch de restaurar lo lee sin condicionar: un form
+    # sin simplificados no puede quedar leyendo una llave que nunca se escribió.
+    SearchableMovieFilterForm.new(
+      Movie.all, params(name_or_genre_or_tenant_name_cont: "Iron"), storage_id: "movies"
+    )
+
+    stored = Rails.cache.read(cache_key_for(SearchableMovieFilterForm))
+    assert_empty(stored[:simple_filters])
+
+    restored = SearchableMovieFilterForm.new(Movie.all, params({}), storage_id: "movies",
+                                             persist_enabled: true)
+    assert_equal("Iron", restored.search_value)
   end
 end
 


### PR DESCRIPTION
Cierra #852.

## Qué pasaba

El marcador "Recordar filtros" **nunca estuvo muerto** —gobierna la búsqueda rápida— y por eso era peor que si lo estuviera: el usuario lo prendía, volvía al listado con la URL limpia, y la búsqueda volvía pero sus selects no. Nada en la UI distingue un control que se recuerda de uno que no; los dos viven en la misma barra.

La inconsistencia interna es lo que decide qué lado estaba mal: una **vista guardada** sobre ese mismo listado sí los restauraba (`PAYLOAD_KEYS` incluye `simple_filters` desde siempre). Un solo componente con dos definiciones de "el estado de los filtros".

Y había una segunda mitad, más grave, que no depende de la persistencia para molestar: como `has_filter_params` no contaba los simplificados, llegar por una URL que solo pide uno caía en el branch de **restaurar**, y ahí la caché le ganaba a la URL.

## Medido en `/admin/studios`

A/B sobre el mismo server, misma secuencia, con `bali_persist_admin_studios=1`:

| paso | sin el arreglo | con el arreglo |
|---|---|---|
| elige `size=large` | 9 studios | 9 studios |
| vuelve con la URL limpia | **34** (se perdió) | **9** (vuelve) |
| aplica la búsqueda `a` | 26 | 26 |
| abre `?q[country_eq]=USA` | **9** | **10** |

Las últimas dos filas son el enlace compartido: con el bug, la URL rendía 9 porque se le aplicaba encima una búsqueda guardada que la URL no menciona; sin persistencia daba 10. El mismo enlace significaba dos cosas según una cookie de quien lo abriera. Ahora da 10 en los dos casos, y la caja de búsqueda llega vacía.

Verificado además en el navegador: al volver con la URL limpia el radio `large` vuelve **marcado**, no solo aplicado.

## Cómo está arreglado

Se reusa el camino que ya existe para las vistas guardadas en vez de abrir una segunda ruta — las llaves del round-trip ya coincidían:

- `active_simple_filters` escribe → `apply_simple_filter_state` restaura → `current_simple_filter_value` lee.

Tres sitios en `FilterForm#fetch_stored_filter_state`:

1. El `Rails.cache.write` suma `simple_filters:`.
2. `has_filter_params` los cuenta **como ORIGEN, no como valor** — la misma distinción que `@group_by_requested` hace con la agrupación. El form de SimpleFilters manda todos sus controles, así que vaciar un select llega como `q[size_eq]=`: valor vacío, elección explícita. Mirando solo los valores, limpiar un filtro era indistinguible de no pedir nada y el branch de restaurar se lo devolvía.
3. El branch `elsif @clear_search` los conserva en el merge y los aplica como efecto. `clearSearch` navega descartando **todos** los `q[...]`, así que el estado guardado es el único registro de lo elegido.

Restaurar corre como efecto y no por la tupla porque el valor de un simplificado nunca es un atributo de ActiveModel: vive en `@q_params` y va directo a Ransack. `apply_simple_filter_state` **reemplaza** `@q_params`, no mergea — por eso solo se llega ahí desde los branches donde la URL no pidió ninguno.

## Una desviación del diagnóstico

El diagnóstico no lo anticipaba y apareció al implementarlo: `active_simple_filters` no se podía llamar desde `fetch_stored_filter_state` tal cual. Su fallback `respond_to?(key)` revienta con `NoMethodError: undefined method 'to_hash' for nil`, porque ActiveModel no corrió su propio initializer todavía — `super(attributes)` está al final de `FilterForm#initialize` y la escritura necesariamente pasa antes (lo que escribe es parte de lo que después le pasa a `super`).

Se guarda ese fallback con `attributes_initialized?`. No se pierde nada: en ese punto todo lo que trae el request sigue en `@q_params`, que el paso 1 ya leyó. El fallback existe para el render posterior.

## Tests

- 7 tests nuevos en `test/bali/filter_form_test.rb`. Revirtiendo `lib/bali/filter_form.rb`, 5 fallan; los otros 2 son guardas de no-regresión (con el marcador apagado no se restaura; limpiar un filtro no se deshace) y tienen que seguir pasando.
- `cypress/e2e/filter-persistence-simple-filters.cy.js`, 4 tests contra `/admin/studios` — el round-trip completo que un unit test no alcanza: la cookie, el form GET de SimpleFilters y la caché del server entre dos requests. Revirtiendo el arreglo, 3 de 4 fallan.

Minitest 3731/3731 y Cypress 226/226 en verde. Rubocop y StandardJS sin ofensas.
