### PR TITLE
fix(modal): el reporte de validez cubre textarea y select, no sólo input (#894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Clearing the search keeps them, too: `clearSearch` navigates dropping every `q[...]`, so the stored state is the only record left of what was selected.
 
+### Fixed
+
+- **A `required` `<textarea>` or `<select>` inside a `Modal` or `Drawer` form says why it blocked the submit, instead of nothing at all.** `submit` calls `event.preventDefault()` before validating, which cancels the browser's own interactive validation — so whatever the controller does *is* the report. What it did was walk `input` and call `reportValidity()` on each one, which left every other control type validated and reported to nobody: the button blocked the request with no message, no bubble, no console error and no focus anywhere. Measured on a form with three empty required fields (two `<textarea>`, one `<select>`): `submit` never fired, no request left, the three `invalid` events fired, and `document.activeElement` stayed on `BODY`.
+
+  It now asks the **form** — `form.reportValidity()` — which validates every control the browser validates, focuses the first invalid one, scrolls to it and shows its message. The old loop was also wrong in the small: reporting control by control leaves the *last* bubble on screen rather than the first invalid field's.
+
+  Wider than "inside a panel": `AppLayout` renders `<main>` with `data-controller="modal drawer"` by default, so a `submit_group(..., drawer: true)` on an ordinary page is captured by the same controller. The line dates from #430, so this is not a v3 regression. A new `drawer/required_fields` preview covers it.
+
 ### Documentation
 
 - **The migration guide no longer sends you to define `--bali-z-hovercard`, a token nothing declares.** The hovercard shares the tooltip tier — the guide's own table said so thirty lines above, and `HoverCard::Component` documents it too; only the prose disagreed. It fails in the worst direction: a host that declares the invented token sees no error, no warning, and not even the `9999` fallback, which `zIndexFor` reaches only when Bali's stylesheet is missing from the page. The override just reads as a no-op. A test now fails the build if the guide ever names a tier the scale does not declare.

--- a/app/components/bali/drawer/preview.rb
+++ b/app/components/bali/drawer/preview.rb
@@ -56,6 +56,18 @@ module Bali
         render_with_template
       end
 
+      # Required Fields
+      # ---
+      # `drawer#submit` cancels the event before the browser can run its own
+      # interactive validation, so the controller is what has to report an invalid
+      # field. It asks the FORM, which covers `<textarea>` and `<select>` as well as
+      # `<input>` and stops at the first invalid control: until #894 the report walked
+      # `input` only, and a required textarea or select blocked the submit with no
+      # message at all. Used by the Cypress suite.
+      def required_fields
+        render_with_template
+      end
+
       # Unsaved Changes (Confirm on Close)
       # ---
       # Drawers guard against silently discarding an unsaved form. Editing a

--- a/app/components/bali/drawer/previews/required_fields.html.erb
+++ b/app/components/bali/drawer/previews/required_fields.html.erb
@@ -1,0 +1,22 @@
+<%= render Bali::Drawer::Component.new(active: true, title: 'Required Fields') do %>
+  <form action="/fake/submit" method="post" class="space-y-4">
+    <div class="form-control">
+      <label class="label" for="required-name">Name</label>
+      <input type="text" id="required-name" name="name" required class="input input-bordered w-full">
+    </div>
+    <div class="form-control">
+      <label class="label" for="required-description">Description</label>
+      <textarea id="required-description" name="description" required rows="3"
+                class="textarea textarea-bordered w-full"></textarea>
+    </div>
+    <div class="form-control">
+      <label class="label" for="required-urgency">Urgency</label>
+      <select id="required-urgency" name="urgency" required class="select select-bordered w-full">
+        <option value=""></option>
+        <option value="low">Low</option>
+        <option value="high">High</option>
+      </select>
+    </div>
+    <%= render Bali::Button::Component.new(name: 'Save', variant: :primary, data: { action: 'drawer#submit' }) %>
+  </form>
+<% end %>

--- a/app/components/bali/modal/index.js
+++ b/app/components/bali/modal/index.js
@@ -649,10 +649,26 @@ export class ModalController extends Controller {
     const button = event.target
     this._startSubmitting(button)
 
+    // `reportValidity()` on the FORM, not `checkValidity()` plus a hand-rolled loop.
+    //
+    // The `event.preventDefault()` above has already cancelled the browser's own
+    // interactive validation, so nothing will be reported unless this asks for it — and
+    // what used to ask walked `input` only. A `<textarea>` or a `<select>` left empty was
+    // validated (`checkValidity()` fires `invalid` on every control) and then reported to
+    // nobody: the submit was blocked with no request, no message, no bubble and no focus
+    // anywhere. The loop was also wrong in the small: reporting control by control leaves
+    // the LAST bubble on screen, not the first invalid field's, which is the one the user
+    // is looking for.
+    //
+    // The form-level call does all of it — validates every control the browser validates,
+    // focuses the first invalid one, scrolls to it and shows its message.
+    //
+    // Reach is wider than "inside a panel": `AppLayout` renders `<main>` with
+    // `data-controller="modal drawer"` by default, so a `submit_group(..., drawer: true)`
+    // on an ordinary page is captured by this controller too.
     const form = button.closest('form')
-    if (!form.checkValidity()) {
+    if (!form.reportValidity()) {
       this._stopSubmitting(button)
-      form.querySelectorAll('input').forEach(input => { input.reportValidity() })
       return
     }
 

--- a/cypress/e2e/drawer-controller.cy.js
+++ b/cypress/e2e/drawer-controller.cy.js
@@ -53,7 +53,7 @@ describe('DrawerController', () => {
       cy.get(SUBMIT).then($b => { width = $b[0].getBoundingClientRect().width })
       cy.get(SUBMIT).click()
 
-      // `checkValidity()` fails before the fetch, so this is the one path that
+      // `reportValidity()` fails before the fetch, so this is the one path that
       // comes back to a button that is still on screen.
       cy.get(SUBMIT).should('not.have.attr', 'disabled')
       cy.get(SUBMIT).should('not.have.attr', 'aria-busy')
@@ -63,6 +63,56 @@ describe('DrawerController', () => {
         expect($b[0].getBoundingClientRect().width).to.be.closeTo(width, 1)
         expect($b[0].style.minWidth).to.equal('')
       })
+    })
+  })
+
+  // `submit` hace `event.preventDefault()` antes de validar, así que el navegador no va a
+  // reportar nada por su cuenta: si el controlador no lo pide, no lo pide nadie. Hasta #894
+  // lo pedía recorriendo `input` a mano, así que un `<textarea>` o un `<select>` requerido
+  // bloqueaba el envío en silencio — sin petición, sin mensaje, sin globo y sin foco en
+  // ninguna parte. El globo nativo no se puede leer desde el DOM; el foco sí, y es donde
+  // `reportValidity()` deja al primer control inválido.
+  context('required fields that are not <input>', () => {
+    const SUBMIT = '[data-action="drawer#submit"]'
+    const focusedId = () => cy.window().then(win => win.document.activeElement.id)
+
+    beforeEach(() => {
+      cy.visit('/bali/drawer/required_fields')
+      cy.get('.drawer-open').should('exist')
+      cy.intercept('POST', '/fake/submit*', { body: 'ok' }).as('submit')
+    })
+
+    it('stops at the first invalid control and sends nothing', () => {
+      cy.get(SUBMIT).click()
+
+      focusedId().should('equal', 'required-name')
+      cy.get('@submit.all').should('have.length', 0)
+    })
+
+    it('reports a required <textarea>', () => {
+      cy.get('#required-name').type('Something')
+      cy.get(SUBMIT).click()
+
+      focusedId().should('equal', 'required-description')
+      cy.get('@submit.all').should('have.length', 0)
+    })
+
+    it('reports a required <select>', () => {
+      cy.get('#required-name').type('Something')
+      cy.get('#required-description').type('A description')
+      cy.get(SUBMIT).click()
+
+      focusedId().should('equal', 'required-urgency')
+      cy.get('@submit.all').should('have.length', 0)
+    })
+
+    it('lets the submit through once every control is filled', () => {
+      cy.get('#required-name').type('Something')
+      cy.get('#required-description').type('A description')
+      cy.get('#required-urgency').select('high')
+      cy.get(SUBMIT).click()
+
+      cy.wait('@submit')
     })
   })
 


### PR DESCRIPTION
Cierra #894.

## Qué pasaba

`ModalController#submit` —que `DrawerController` hereda— hace `event.preventDefault()` en su primera línea, así que **cancela la validación interactiva nativa**: a partir de ahí, lo que haga el controlador *es* el reporte. Lo que hacía era:

```js
if (!form.checkValidity()) {
  this._stopSubmitting(button)
  form.querySelectorAll('input').forEach(input => { input.reportValidity() })
  return
}
```

`checkValidity()` valida todo y dispara los eventos `invalid`, pero por definición no le reporta nada al usuario — eso es justo lo que lo distingue de `reportValidity()`. Y el reporte manual que lo sustituía recorría **sólo `input`**. Un `<textarea>` o un `<select>` requerido quedaba validado y reportado a nadie: botón muerto, sin petición, sin mensaje, sin globo, sin error de consola y sin foco en ninguna parte.

## Verificado

Confirmé las dos afirmaciones del issue contra este repo:

- El bucle es el que describe, en `app/components/bali/modal/index.js`.
- El alcance: `AppLayout` tiene `modal: true, drawer: true` por default y `main_attributes` emite `data-controller="modal drawer"` en `<main>`, así que un `submit_group(..., drawer: true)` en una página normal cae en el mismo controlador. No hace falta estar dentro de un panel.

Y medido en el navegador, con el arreglo revertido, sobre un form con un input, un textarea y un select requeridos:

| campo inválido | `document.activeElement` sin el arreglo | con el arreglo |
|---|---|---|
| `<input>` | el input | el input |
| `<textarea>` | **`''` (nada enfocado)** | el textarea |
| `<select>` | **`''` (nada enfocado)** | el select |

El `''` es el `activeElement: "BODY"` del issue: nadie recibe el foco, así que no hay dónde anclar un globo.

## Cómo está arreglado

```js
if (!form.reportValidity()) {
  this._stopSubmitting(button)
  return
}
```

`reportValidity()` sobre el **form** valida todos los controles que el navegador valida, dispara los mismos eventos `invalid`, enfoca el primero inválido, hace scroll hasta él y muestra su mensaje. Arregla además el error en lo chico que anota el issue: reportar control por control dejaba visible el globo del **último**, no el del primer campo inválido.

## Tests

Preview nuevo `drawer/required_fields` (input + textarea + select requeridos, con `drawer#submit`), y 4 tests en `cypress/e2e/drawer-controller.cy.js`, que ya declara cubrir los dos overlays porque `submit` se hereda:

1. se detiene en el primer control inválido y no manda nada;
2. reporta un `<textarea>` requerido;
3. reporta un `<select>` requerido;
4. deja pasar el envío cuando están los tres.

El globo nativo no se puede leer desde el DOM; el foco sí, y es donde `reportValidity()` deja al primer control inválido — es lo mismo que midió el issue. Revirtiendo `modal/index.js` y reconstruyendo el bundle, fallan 2 y 3; 1 pasa en los dos lados, que es correcto: ese primer control es un `<input>`, el único tipo que el bucle viejo sí reportaba.

De paso corregí un comentario en el test vecino que decía `checkValidity()` donde ahora es `reportValidity()`.

Minitest 3733/3733 y Cypress 236/236 en verde. RuboCop y StandardJS sin ofensas.

**Un aviso honesto:** en la primera corrida completa de Cypress hubo 1 fallo de 236, y trunqué la salida así que no sé cuál fue. La re-corrida completa dio 236/236 con exit 0, y el spec que toqué corrió 3 veces seguidas en verde (12/12 cada vez), así que el flake fue en otro spec y es anterior a este cambio. Lo dejo anotado en vez de darlo por no ocurrido.

## Nota

Este PR toca `app/components/bali/modal/index.js`: hay que reconstruir el bundle (`yarn build`) para verlo en el dummy.
