### PR TITLE
fix(block_editor): el preview `with_comments` abre con comentarios (#863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Added
+
+- **`comments: { threads: [...] }` seeds a `BlockEditor` whose comments do not persist**, so a demo or a preview can open with threads already in the sidebar. Ignored when `url:` is given — there the REST store fetches the list and owns it, so a seed would be gone on the first poll.
+
+### Fixed
+
+- **The `block_editor/with_comments` preview opens with comments in it.** It rendered zero threads, which is not cosmetic: it is what made #832 — a thread card wider than the sidebar holding it — invisible. Reproducing that needed a comment created by hand through the UI first, and the preview sweep counted the page as a 200 either way. A preview that does not exercise what it announces covers nothing.
+
+  A comment lives in **two** places and needs both to be a real one: a thread in the store, and a `comment` mark on the text it anchors to. Seeding only the store gets threads into the sidebar, each labelled "Original content deleted" — measured — because nothing in the document points at them.
+
+  The mark cannot travel in the blocks array `initial_content` usually takes: BlockNote's comment mark declares `blocknoteIgnore`, so the block serializer skips it by design and no array of blocks can carry one. It travels in the **other** shape `initial_content` already accepts — ProseMirror JSON, the `{ type: "doc" }` form the component detects and loads through `setContent` precisely because it preserves comment marks. The preview now passes that shape, with a focused document instead of the shared showcase content.
+
+  Two threads, because the sidebar's width is what breaks: a short one, and one whose comment carries a URL with nothing to break on. Measured after the change: 2 threads, 2 marks, 0 orphans, and the sidebar's `scrollWidth` equal to its `clientWidth`. Cypress now covers all of it, so #832 stays covered without anyone typing a comment first.
+
 ## [v3.0.0.beta.3] - 2026-08-03
 
 ### Fixed

--- a/app/components/bali/block_editor/BlockNoteEditorWrapper.jsx
+++ b/app/components/bali/block_editor/BlockNoteEditorWrapper.jsx
@@ -90,6 +90,7 @@ export default function BlockNoteEditorWrapper ({
   commentsUsers,
   commentsUsersUrl,
   commentsPollInterval,
+  commentsThreads,
   // Rails-supplied UI strings, keyed as in config/locales/bali_view.*.yml. The
   // hooks below used to hardcode them in English regardless of the app's locale.
   translations = {}
@@ -193,6 +194,7 @@ export default function BlockNoteEditorWrapper ({
     commentsUsersUrl: commentsEnabled ? commentsUsersUrl : undefined,
     commentsUrl: commentsEnabled ? commentsUrl : undefined,
     commentsPollInterval: commentsEnabled ? commentsPollInterval : undefined,
+    commentsThreads: commentsEnabled ? commentsThreads : undefined,
     translations
   })
 

--- a/app/components/bali/block_editor/InMemoryThreadStore.js
+++ b/app/components/bali/block_editor/InMemoryThreadStore.js
@@ -1,5 +1,39 @@
 import { ThreadStore, DefaultThreadStoreAuth } from '@blocknote/core/comments'
 
+// Seeded threads arrive as JSON, where a timestamp is a string. BlockNote reads
+// `createdAt`/`updatedAt` as Date objects and calls Date methods on them, so a string
+// left as-is throws while rendering the thread — inside React's render, which takes the
+// whole editor down rather than just the sidebar. Missing dates get "now", which is the
+// only defensible guess and keeps a hand-written seed from having to carry them.
+function toDate (value) {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date() : date
+}
+
+function normalizeSeed (threads) {
+  if (!Array.isArray(threads)) return []
+
+  return threads.filter(thread => thread?.id).map(thread => ({
+    type: 'thread',
+    resolved: false,
+    metadata: {},
+    ...thread,
+    id: String(thread.id),
+    createdAt: toDate(thread.createdAt),
+    updatedAt: toDate(thread.updatedAt ?? thread.createdAt),
+    comments: (thread.comments ?? []).map(comment => ({
+      type: 'comment',
+      reactions: [],
+      metadata: {},
+      ...comment,
+      id: String(comment.id),
+      userId: String(comment.userId),
+      createdAt: toDate(comment.createdAt),
+      updatedAt: toDate(comment.updatedAt ?? comment.createdAt)
+    }))
+  }))
+}
+
 /**
  * In-memory ThreadStore implementation for BlockNote comments.
  *
@@ -9,13 +43,25 @@ import { ThreadStore, DefaultThreadStoreAuth } from '@blocknote/core/comments'
  * Use this for previews, demos, or single-user note-taking where comments
  * don't need to survive page reloads. For persistent comments, host apps
  * should implement their own ThreadStore backed by a REST API.
+ *
+ * `seedThreads` gives the store a starting set. It is what lets a demo open with
+ * threads already in the sidebar: the comments sidebar reads its threads from the
+ * STORE, not from the document, so a seeded thread shows without the text carrying
+ * a `comment` mark. That distinction is not a shortcut — BlockNote's comment mark
+ * declares `blocknoteIgnore`, so it is deliberately absent from the block JSON and
+ * cannot be expressed in `initial_content` at all. Seeded threads are therefore
+ * anchorless: they list and read, and clicking one highlights nothing.
  */
 export class InMemoryThreadStore extends ThreadStore {
-  constructor (userId, role = 'editor') {
+  constructor (userId, role = 'editor', seedThreads = []) {
     super(new DefaultThreadStoreAuth(userId, role))
     this._userId = userId
     this._threads = new Map()
     this._subscribers = new Set()
+
+    for (const thread of normalizeSeed(seedThreads)) {
+      this._threads.set(thread.id, thread)
+    }
   }
 
   _generateId () {

--- a/app/components/bali/block_editor/component.rb
+++ b/app/components/bali/block_editor/component.rb
@@ -95,6 +95,7 @@ module Bali
         @comments_user  = comments_config&.fetch(:user, nil)
         @comments_users = comments_config&.fetch(:users, nil)
         @comments_users_url = comments_config&.fetch(:users_url, nil)
+        @comments_threads = comments_config&.fetch(:threads, nil)
         # -1 stands for "not configured": 0 is a real value that turns polling off,
         # so it cannot double as the unset marker.
         @comments_poll_interval = comments_config&.fetch(:poll_interval, nil) || -1
@@ -209,6 +210,7 @@ module Bali
           comments_user: serialized_comments_user,
           comments_users: serialized_comments_users,
           comments_users_url: @comments_users_url || "",
+          comments_threads: serialized_comments_threads,
           comments_poll_interval: @comments_poll_interval
         }
       end
@@ -285,6 +287,21 @@ module Bali
           else m.respond_to?(:to_h) ? m.to_h : { name: m.to_s }
           end
         end.to_json
+      end
+
+      # Threads the in-memory store opens with. Only for a store that does not persist:
+      # with `url:` the REST store fetches the list and owns it, so a seed there would be
+      # gone on the first poll (see useComments).
+      #
+      # A seeded thread lists and reads, but anchors to nothing in the text. That is not a
+      # gap in this method — BlockNote's `comment` mark declares `blocknoteIgnore`, so it
+      # is deliberately absent from the block JSON and there is no way to express one in
+      # `initial_content`. The comments sidebar reads the STORE, which is why a thread
+      # still shows.
+      def serialized_comments_threads
+        return "[]" if @comments_threads.blank?
+
+        Array(@comments_threads).map { |thread| thread.respond_to?(:to_h) ? thread.to_h : thread }.to_json
       end
 
       def serialized_comments_user

--- a/app/components/bali/block_editor/index.js
+++ b/app/components/bali/block_editor/index.js
@@ -33,6 +33,7 @@ export class BlockEditorController extends Controller {
     commentsUser: { type: Object, default: {} },
     commentsUsers: { type: Array, default: [] },
     commentsUsersUrl: { type: String, default: '' },
+    commentsThreads: { type: Array, default: [] },
     // 0 turns polling off; -1 means "unset", so RESTThreadStore's own 5000 ms
     // default stays the single place that number is written down.
     commentsPollInterval: { type: Number, default: -1 },
@@ -98,6 +99,7 @@ export class BlockEditorController extends Controller {
         commentsUser: Object.keys(this.commentsUserValue).length > 0 ? this.commentsUserValue : undefined,
         commentsUsers: this.commentsUsersValue.length > 0 ? this.commentsUsersValue : undefined,
         commentsUsersUrl: this.commentsUsersUrlValue || undefined,
+        commentsThreads: this.commentsThreadsValue.length > 0 ? this.commentsThreadsValue : undefined,
         commentsPollInterval: this.commentsPollIntervalValue >= 0 ? this.commentsPollIntervalValue : undefined,
         translations: this.translationsValue
       }

--- a/app/components/bali/block_editor/preview.rb
+++ b/app/components/bali/block_editor/preview.rb
@@ -158,8 +158,9 @@ module Bali
       def with_comments(editable: true)
         render BlockEditor::Component.new(
           editable: editable,
-          comments: { user: sample_comments_user, users: sample_comments_users },
-          initial_content: sample_content.to_json
+          comments: { user: sample_comments_user, users: sample_comments_users,
+                      threads: sample_comment_threads },
+          initial_content: commented_document.to_json
         )
       end
 
@@ -219,6 +220,107 @@ module Bali
           { id: '3', username: 'Carlos Rivera', avatar_url: '' },
           { id: '4', username: 'Diana Park', avatar_url: '' }
         ]
+      end
+
+      # A comment lives in TWO places and needs both to render as a real one: a thread in
+      # the store, and a `comment` mark on the text it is anchored to. Seeding only the
+      # store gets threads in the sidebar, each labelled "Original content deleted" —
+      # measured — because nothing in the document points at them.
+      #
+      # The mark cannot travel in the blocks array `initial_content` usually takes:
+      # BlockNote's comment mark declares `blocknoteIgnore`, so the block serializer skips
+      # it by design. It travels in the OTHER shape `initial_content` accepts — ProseMirror
+      # JSON, the `{ type: "doc" }` form the component detects and loads through
+      # `setContent` precisely because it preserves comment marks. Hence this document
+      # rather than `sample_content`.
+      #
+      # The ids are fixed so the two halves can refer to each other from Ruby.
+      def commented_document
+        pm_doc(
+          pm_block("preview-block-1", pm_heading(2, [ pm_text("Comments") ])),
+          pm_block("preview-block-2", pm_paragraph([
+                                                     pm_text("Select any text and use the comment button in the toolbar to " \
+                                                             "start a thread. The two threads in the sidebar arrived with " \
+                                                             "the document.")
+                                                   ])),
+          pm_block("preview-block-3", pm_paragraph([
+                                                     pm_text("Keyboard shortcuts are listed in the slash menu.",
+                                                             thread_id: "preview-thread-1")
+                                                   ])),
+          pm_block("preview-block-4", pm_paragraph([
+                                                     pm_text("The export formats follow the spec.",
+                                                             thread_id: "preview-thread-2")
+                                                   ]))
+        )
+      end
+
+      # The ProseMirror shape BlockNote reads: every block is wrapped in a `blockContainer`
+      # inside one `blockGroup`. Taken from `_tiptapEditor.getJSON()` on a real document
+      # rather than written from the schema, so it stays the shape the editor emits.
+      PM_BLOCK_ATTRS = {
+        backgroundColor: "default", textColor: "default", textAlignment: "left"
+      }.freeze
+
+      def pm_doc(*containers)
+        { type: "doc", content: [ { type: "blockGroup", content: containers } ] }
+      end
+
+      def pm_block(id, node)
+        { type: "blockContainer", attrs: { id: id }, content: [ node ] }
+      end
+
+      def pm_paragraph(runs)
+        { type: "paragraph", attrs: PM_BLOCK_ATTRS, content: runs }
+      end
+
+      def pm_heading(level, runs)
+        { type: "heading", attrs: PM_BLOCK_ATTRS.merge(level: level, isToggleable: false), content: runs }
+      end
+
+      def pm_text(text, thread_id: nil)
+        run = { type: "text", text: text }
+        return run if thread_id.nil?
+
+        run.merge(marks: [ { type: "comment", attrs: { orphan: false, threadId: thread_id } } ])
+      end
+
+      # A preview called "With Comments" that opens with none exercises nothing, and the
+      # preview sweep still counts it a 200. It is what made #832 — a thread card wider
+      # than the sidebar it sits in — invisible: reproducing that needed a comment created
+      # by hand through the UI first.
+      #
+      # Two threads on purpose, because the sidebar's width is what breaks: a short one
+      # that fits, and one carrying a long URL with nothing to break on, which is the
+      # string that overflows a fixed-width card.
+      def sample_comment_threads
+        [
+          {
+            id: 'preview-thread-1',
+            comments: [
+              comment_body('preview-comment-1', '2',
+                           'Should this section mention the keyboard shortcuts too?')
+            ]
+          },
+          {
+            id: 'preview-thread-2',
+            comments: [
+              comment_body('preview-comment-2', '3',
+                           'Reference for the spec we agreed on: ' \
+                           'https://example.com/very/long/path/that/never/breaks/' \
+                           'because-it-has-no-spaces-anywhere-in-it-at-all'),
+              comment_body('preview-comment-3', '1', 'Linked, thanks.')
+            ]
+          }
+        ]
+      end
+
+      # The body of a comment is a BlockNote document, not a string.
+      def comment_body(id, user_id, text)
+        {
+          id: id,
+          userId: user_id,
+          body: [ paragraph(text) ]
+        }
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/app/components/bali/block_editor/useComments.js
+++ b/app/components/bali/block_editor/useComments.js
@@ -28,12 +28,14 @@ function writeUser (store, user) {
  * @param {string} options.commentsUsersUrl - Remote endpoint for user resolution
  * @param {string} options.commentsUrl     - REST API base URL for thread persistence
  * @param {number} options.commentsPollInterval - Poll period in ms; 0 disables polling
+ * @param {Array}  options.commentsThreads - Threads to seed the in-memory store with;
+ *   ignored when commentsUrl is set (the REST store owns the list)
  * @param {Object} options.translations   - Rails-supplied UI strings
  * @returns {{ extension: Object, threadStore: ThreadStore } | null}
  */
 export function useComments ({
   commentsUser, commentsUsers, commentsUsersUrl, commentsUrl, commentsPollInterval,
-  translations = {}
+  commentsThreads, translations = {}
 }) {
   const threadStoreRef = useRef(null)
   // The name shown on a comment whose author id resolves to nothing. It is the
@@ -63,9 +65,12 @@ export function useComments ({
     }
 
     const userId = String(commentsUser.id)
+    // `threads:` seeds the in-memory store only. With a `url:` the REST store owns the
+    // list and fetches it, so a seed there would be overwritten on the first poll —
+    // it is ignored rather than half-applied.
     const threadStore = commentsUrl
       ? new RESTThreadStore(userId, commentsUrl, pollOptions(commentsPollInterval))
-      : new InMemoryThreadStore(userId, 'editor')
+      : new InMemoryThreadStore(userId, 'editor', commentsThreads)
 
     threadStoreRef.current = threadStore
 
@@ -193,5 +198,8 @@ export function useComments ({
     }
 
     return { extension, threadStore, attachUserStore }
-  }, [commentsUser, commentsUsers, commentsUsersUrl, commentsUrl, commentsPollInterval, userFallback])
+  }, [
+    commentsUser, commentsUsers, commentsUsersUrl, commentsUrl, commentsPollInterval,
+    commentsThreads, userFallback
+  ])
 }

--- a/cypress/e2e/block-editor-comments.cy.js
+++ b/cypress/e2e/block-editor-comments.cy.js
@@ -35,7 +35,7 @@ describe('BlockEditor: comentarios', () => {
   beforeEach(() => {
     cy.viewport(1280, 900)
     cy.visit('/bali/block_editor/with_comments')
-    cy.get('.bn-with-comments > .bn-container > .bn-editor').should('contain.text', 'Block Editor')
+    cy.get('.bn-with-comments > .bn-container > .bn-editor').should('contain.text', 'Keyboard shortcuts')
 
     cy.get('.bn-with-comments > .bn-container').then($container => {
       const doc = $container[0].ownerDocument
@@ -73,6 +73,39 @@ describe('BlockEditor: comentarios', () => {
 
       expect(anchos[0], 'corta y larga miden igual').to.equal(anchos[1])
       expect(anchos[0], 'y ese ancho es el declarado').to.equal(320)
+    })
+  })
+})
+
+// El preview se llama `with_comments` y no traia ninguno (#863). No era cosmetico: es lo
+// que hizo invisible a #832 — para reproducir el desborde del hilo hubo que crear un
+// comentario a mano por la UI, y el barrido de previews contaba la pagina como 200.
+//
+// Un comentario vive en DOS lados y necesita los dos para ser uno de verdad: el hilo en el
+// store, y la marca `comment` sobre el texto al que ancla. Sembrar solo el store deja los
+// hilos en la barra pero rotulados "Original content deleted" — medido.
+describe('BlockEditor: el preview de comentarios abre con comentarios', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 900)
+    cy.visit('/bali/block_editor/with_comments')
+    // La barra lateral se puebla desde el store cuando el editor monta.
+    cy.get('.bn-threads-sidebar .bn-thread', { timeout: 20000 }).should('have.length', 2)
+  })
+
+  it('los hilos estan anclados al texto, no huerfanos', () => {
+    // La marca es la mitad que el JSON de bloques no puede llevar: viaja en la forma
+    // ProseMirror de `initial_content`. Sin ella la barra pinta hilos que no apuntan a nada.
+    cy.get('.bn-editor .bn-thread-mark').should('have.length', 2)
+    cy.get('.bn-threads-sidebar').should('not.contain.text', 'Original content deleted')
+  })
+
+  it('mantiene el ancho de la barra con una URL larga sin cortes', () => {
+    // El caso de #832, ahora ejercitado por el preview en vez de a mano: un hilo cuyo
+    // comentario lleva una URL que no tiene donde partirse. Se mide el desborde real del
+    // contenedor, no las clases.
+    cy.get('.bn-threads-sidebar').should($sidebar => {
+      const el = $sidebar[0]
+      expect(el.scrollWidth, 'la barra no desborda horizontalmente').to.equal(el.clientWidth)
     })
   })
 })

--- a/test/bali/components/block_editor_test.rb
+++ b/test/bali/components/block_editor_test.rb
@@ -177,6 +177,29 @@ class BaliBlockEditorComponentTest < ComponentTestCase
     assert_selector('[data-block-editor-comments-url-value=""]')
   end
 
+  # `threads:` is what lets a store that does not persist open with something in it — the
+  # comments sidebar reads the STORE, so a seeded thread lists without the document having
+  # to say anything. Anchoring it is the other half, and travels in the ProseMirror form of
+  # `initial_content` (#863).
+  def test_with_comments_serializes_seed_threads_as_json_array
+    threads = [
+      { id: "t1", comments: [ { id: "c1", userId: "2", body: [ { type: "paragraph" } ] } ] }
+    ]
+    render_inline(Bali::BlockEditor::Component.new(
+                    comments: { user: { id: "1", username: "Alice" }, threads: threads }
+                  ))
+
+    parsed = JSON.parse(page.find("[data-block-editor-comments-threads-value]")[:"data-block-editor-comments-threads-value"])
+    assert_equal(1, parsed.size)
+    assert_equal("t1", parsed.first["id"])
+    assert_equal("c1", parsed.first["comments"].first["id"])
+  end
+
+  def test_with_comments_defaults_seed_threads_to_an_empty_array
+    render_inline(Bali::BlockEditor::Component.new(comments: { user: { id: "1", username: "Alice" } }))
+    assert_selector('[data-block-editor-comments-threads-value="[]"]')
+  end
+
   def test_export_functionality_does_not_render_export_buttons_by_default
     render_inline(Bali::BlockEditor::Component.new)
     assert_no_selector('[data-action*="exportPdf"]')


### PR DESCRIPTION
Cierra #863.

## Qué pasaba

Medido sobre el preview recién cargado, tal cual lo reportaste: `.bn-thread` → **0**. Un preview llamado `with_comments` que no muestra ninguno.

## Lo que encontré, que cambia la receta del issue

Un comentario vive en **dos** lados y necesita los dos para ser uno de verdad: el **hilo en el store** y la **marca `comment`** sobre el texto al que ancla. Eso se ve midiendo cada mitad por separado:

| | |
|---|---|
| `with_persistent_comments` tras recargar | `hilos=1`, `marcas_dom=0`, `doc_json_menciona_comment=false` |

O sea que la barra lateral pinta hilos que salen **sólo del store** — la marca no hace falta para que un hilo aparezca. Pero sin ella el hilo sale rotulado **"Original content deleted"**, que lo medí al sembrar sólo el store: 2 hilos, 2 huérfanos.

Y acá está la parte que corrige el issue. Decías "que `initial_content` traiga marcas de comentario". Por el camino que `initial_content` suele tomar —el array de bloques— **no se puede**: el mark de BlockNote declara

```js
extendMarkSchema(e) { return e.name === "comment" ? { blocknoteIgnore: true } : {} }
```

así que el serializador de bloques lo omite por diseño.

Pero `initial_content` acepta **dos** formas, y la otra sí lo lleva. `BlockNoteEditorWrapper` detecta `{ type: "doc" }` y lo carga con `setContent`, con este comentario ya en el código:

> Restore ProseMirror JSON content (**preserves comment marks**).

O sea que el mecanismo ya existía y era público; lo que faltaba era usarlo. Tu intuición era correcta, el camino era el otro.

## Cómo está arreglado

**Mitad 1 — el hilo.** `comments: { threads: [...] }` siembra el store en memoria. Se ignora con `url:`: ahí el store REST trae la lista y es su dueño, así que una semilla desaparecería en el primer poll. Las fechas se normalizan a `Date` en el store, porque una semilla llega como JSON y BlockNote llama métodos de `Date` mientras renderiza — un string ahí revienta dentro del render de React y se lleva el editor entero, no sólo la barra.

**Mitad 2 — la marca.** El preview pasa `initial_content` en forma ProseMirror, con las marcas apuntando a los ids sembrados. La forma exacta no la escribí desde el esquema: la saqué de `_tiptapEditor.getJSON()` sobre un documento real al que le apliqué las marcas por cirugía de ProseMirror en el navegador, y está construida en Ruby con helpers legibles (`pm_doc` / `pm_block` / `pm_text`) en vez de un literal gigante.

Va con un documento propio y enfocado en vez del `sample_content` compartido: el preview es sobre comentarios, y el showcase largo no ayuda a leerlos. Los otros previews siguen con `sample_content`.

## Medido, antes y después

| | sin el arreglo | con el arreglo |
|---|---|---|
| hilos en la barra | **0** | **2** |
| marcas en el documento | 0 | **2** |
| hilos huérfanos ("Original content deleted") | — | **0** |
| `scrollWidth`/`clientWidth` de la barra | 288/288 (sano por vacío) | **288/288 (sano con la URL larga adentro)** |

Dos hilos y no uno porque lo que se rompe es el ancho: uno corto, y uno cuyo comentario lleva una URL sin dónde partirse. Esa última fila es #832 quedando cubierto de forma permanente, que es el punto del issue.

## Tests

- `cypress/e2e/block-editor-comments.cy.js`: un `describe` nuevo con dos tests — que los hilos están anclados y no huérfanos, y que la barra no desborda con la URL larga. Revirtiendo `preview.rb`, el `beforeEach` falla con `Expected to find element .bn-threads-sidebar .bn-thread, but never found it`.
- `test/bali/components/block_editor_test.rb`: dos tests para la serialización de `threads:` (con y sin). Revirtiendo `component.rb`, fallan los dos.

Tuve que tocar una línea del spec que ya existía: su `beforeEach` esperaba el texto `'Block Editor'` como señal de "la página cargó", y el documento del preview cambió. Ahora espera `'Keyboard shortcuts'`. Los dos tests viejos siguen pasando sin más cambios — montan sus tarjetas sintéticas en su propio host y no chocan con los hilos reales.

Minitest 3741/3741 y Cypress 238/238 en verde. RuboCop y StandardJS sin ofensas.

## Nota

Toca JS del paquete: hay que reconstruir el bundle (`yarn build`) para verlo en el dummy. Y como es posterior a `v3.0.0.beta.3`, la entrada del CHANGELOG queda bajo `[Unreleased]`.
