### PR TITLE
fix(actions_dropdown): el preview del trigger custom pintaba doble borde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **The `actions_dropdown/with_custom_trigger` preview stops drawing two borders.** It nested its own `<button class="btn btn-outline">` inside the trigger slot, but the slot already renders `Dropdown::Trigger` — a `.btn`-dressed `div[role="button"][tabindex="0"]` carrying the wiring — so the preview painted two bordered boxes and offered two tab stops. Measured before/after: 2 `.btn` boxes → 1, 2 tab stops → 1, wiring intact and the menu still opens. The preview now shows the intended shape (`with_trigger(variant: :outline, class: 'btn-sm') { 'Actions ▾' }`), and its notes say why nesting a second button is the wrong one — the reference implementation is what hosts copy.
+
 ## [v3.0.0.beta.4] - 2026-08-04
 
 ### Added

--- a/app/components/bali/actions_dropdown/preview.rb
+++ b/app/components/bali/actions_dropdown/preview.rb
@@ -33,8 +33,11 @@ module Bali
 
       # With Custom Trigger
       # ---------------
-      # Override the default ellipsis icon with a custom trigger button.
-      # Use `with_trigger` slot to provide any element as the dropdown trigger.
+      # Replace the default ellipsis with a labelled trigger. The `with_trigger` slot
+      # renders `Dropdown::Trigger` — it already IS the button (chrome, wiring, role,
+      # tabindex), so dress it with `variant:` / `class:` and pass the label as content.
+      # Do not nest your own `<button class="btn">` in it: that paints a second bordered
+      # box inside the first and adds a second tab stop.
       def with_custom_trigger
         render_with_template
       end

--- a/app/components/bali/actions_dropdown/previews/with_custom_trigger.html.erb
+++ b/app/components/bali/actions_dropdown/previews/with_custom_trigger.html.erb
@@ -1,8 +1,10 @@
 <div class="flex justify-center items-center min-h-[200px] p-8">
+  <%# The slot IS the trigger: Dropdown::Trigger renders the `.btn` chrome, the wiring
+      (`data-dropdown-target`, role, tabindex, aria) and takes the label as content.
+      Nesting your own `<button class="btn">` inside it paints two bordered boxes and
+      leaves two tab stops — the wrapper is already the interactive element. %>
   <%= render Bali::ActionsDropdown::Component.new do |c|
-    c.with_trigger do
-      tag.button('Actions ▾', type: 'button', tabindex: 0, class: 'btn btn-sm btn-outline')
-    end
+    c.with_trigger(variant: :outline, class: 'btn-sm') { 'Actions ▾' }
     c.with_item(name: 'Edit', icon: 'edit', href: '#')
     c.with_item(name: 'Export', icon: 'file-export', href: '#')
     c.with_item(name: 'Delete', icon: 'trash', href: '#', method: :delete)


### PR DESCRIPTION
El preview `with_custom_trigger` anidaba su propio `<button class="btn btn-sm btn-outline">` dentro del slot `with_trigger` — pero el slot **ya es** el trigger: `Dropdown::Trigger` renderiza el `div.btn[role=button][tabindex=0]` con el wiring completo. Resultado: dos cajas `.btn` anidadas (el doble borde del reporte) y **dos tab stops** con semántica de botón anidado.

## Medición (Lookbook, antes → después)

| | antes | después |
|---|---|---|
| Cajas `.btn` en el trigger | **2** (div.btn exterior 1px + button.btn-outline interior 1px) | **1** (`btn btn-outline btn-sm`) |
| Tab stops | **2** | **1** |
| Botones anidados | 1 | 0 |
| Wiring (`data-dropdown-target`, `role`, `aria-haspopup`) | ✓ | ✓ intacto |
| Menú abre con foco (`:focus-within`) | ✓ | ✓ (verificado con captura: Edit/Export/Delete visibles) |

El patrón corregido es el que ya usan todos los previews de `Dropdown` (`with_trigger(variant:, class:) { 'texto' }`); el docstring del escenario ahora explica por qué anidar un segundo botón es la forma incorrecta — este preview es la referencia que los hosts copian. Sin cambios de comportamiento: sólo template de preview + docstring (el Cypress de dropdown corre sobre `actions_dropdown/default`, que no se toca).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bsV38mNKbpFcVbwphPMQU