### PR TITLE
fix(pagination): el summary decía "de 1 items" — item_name ahora pluraliza

### DIFF
--- a/app/components/bali/data_table/component.rb
+++ b/app/components/bali/data_table/component.rb
@@ -297,7 +297,9 @@ module Bali
       # @param pagy [Pagy] Optional Pagy object for pagination
       # @param show_summary [Boolean] Show summary (default: true when pagy present)
       # @param summary_position [Symbol] :bottom (default) or :top
-      # @param item_name [String] Name for items in summary (i18n default)
+      # @param item_name [String, Symbol, Hash] Name for items in summary. A Symbol is an
+      #   i18n key resolved with `count:` (full CLDR plurals); a Hash picks `one:`/`other:`
+      #   by count; a String is used verbatim, invariant with the count (i18n default)
       # @param table_class [String] CSS class for the content scroll wrapper
       # @param display_mode [Symbol] Modo de visualización pedido por el host (típicamente
       #   `params[:view]`). NO elige slot (hay uno solo): el host decide qué contenido

--- a/app/components/bali/pagination/pagy_adapter.rb
+++ b/app/components/bali/pagination/pagy_adapter.rb
@@ -55,7 +55,7 @@ module Bali
           from: from,
           to: to,
           count: count,
-          item_name: item_name.presence || I18n.t("bali_view.pagination.default_item_name")
+          item_name: resolved_item_name(item_name)
         )
       end
 
@@ -77,6 +77,22 @@ module Bali
       end
 
       private
+
+      # "1 items" is not a sentence, and the count is already right there in the call.
+      #
+      # Symbol → an i18n key, resolved with `count:` — Rails' full CLDR plural rules, for
+      #   locales that go beyond one/other.
+      # Hash   → `{one:, other:}` picked by count. Enough for es/en, no locale file needed.
+      # String → used verbatim, invariant with the count: the behaviour every existing call
+      #   site already has.
+      # nil/"" → the gem's default, which is a plural hash now, so it pluralizes too.
+      def resolved_item_name(item_name)
+        case item_name
+        when Symbol then I18n.t(item_name, count: count)
+        when Hash   then item_name[count == 1 ? :one : :other] || item_name[:other]
+        else item_name.presence || I18n.t("bali_view.pagination.default_item_name", count: count)
+        end
+      end
 
       def pagy_url_options
         @fragment ? { fragment: @fragment } : {}

--- a/app/components/bali/pagination_footer/component.rb
+++ b/app/components/bali/pagination_footer/component.rb
@@ -49,7 +49,9 @@ module Bali
       renders_one :controls
 
       # @param pagy [Pagy] Pagy object for pagination
-      # @param item_name [String] Name for items in summary (i18n default)
+      # @param item_name [String, Symbol, Hash] Name for items in summary. A Symbol is an
+      #   i18n key resolved with `count:` (full CLDR plurals); a Hash picks `one:`/`other:`
+      #   by count; a String is used verbatim, invariant with the count (i18n default)
       # @param show_summary [Boolean] Whether to show summary text (default: true)
       # @param show_pagination [Boolean] Whether to show pagination controls (default: true)
       # @param size [Symbol] Button size forwarded to Pagination - :xs, :sm, :md, :lg

--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -305,7 +305,9 @@ en:
       next_page: Next page
       page: "Page %{page}"
       summary: "Showing %{from}-%{to} of %{count} %{item_name}"
-      default_item_name: items
+      default_item_name:
+        one: item
+        other: items
     chart:
       loading: Loading...
       default_label: Chart

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -304,7 +304,9 @@ es:
       next_page: Página siguiente
       page: "Página %{page}"
       summary: "Mostrando %{from}-%{to} de %{count} %{item_name}"
-      default_item_name: elementos
+      default_item_name:
+        one: elemento
+        other: elementos
     chart:
       loading: Cargando...
       default_label: Gráfica

--- a/test/bali/components/data_table_test.rb
+++ b/test/bali/components/data_table_test.rb
@@ -1024,6 +1024,13 @@ class BaliDataTableComponentTest < ComponentTestCase
     assert_text("Showing 1-10 of 47 items")
   end
 
+  def test_footer_picks_the_singular_from_a_hash_item_name
+    render_with_pagy(Pagy::Offset.new(count: 1, page: 1, limit: 10),
+      item_name: { one: "movie", other: "movies" })
+
+    assert_text("Showing 1-1 of 1 movie")
+  end
+
   # Con cero resultados el listado decía "Showing 0-0 of 0 movies" debajo de una tabla vacía.
   def test_footer_says_nothing_without_results
     render_with_pagy(Pagy::Offset.new(count: 0, page: 1, limit: 10), item_name: "movies")

--- a/test/bali/components/pagination/pagy_adapter_test.rb
+++ b/test/bali/components/pagination/pagy_adapter_test.rb
@@ -85,6 +85,23 @@ class BaliPaginationPagyAdapterTest < ActiveSupport::TestCase
     end
   end
 
+  def test_summary_pluralizes_the_default_item_name_by_count
+    pagy = Pagy::Offset.new(count: 1, page: 1, limit: 10)
+    assert_equal "Showing 1-1 of 1 item", adapter(pagy).summary
+  end
+
+  def test_summary_picks_one_or_other_from_a_hash_item_name
+    one = Pagy::Offset.new(count: 1, page: 1, limit: 10)
+    assert_equal "Showing 1-1 of 1 movie", adapter(one).summary(one: "movie", other: "movies")
+    assert_equal "Showing 21-30 of 100 movies", adapter.summary(one: "movie", other: "movies")
+  end
+
+  def test_summary_resolves_a_symbol_item_name_through_i18n_with_count
+    I18n.backend.store_translations(:en, movies_for_test: { one: "movie", other: "movies" })
+    one = Pagy::Offset.new(count: 1, page: 1, limit: 10)
+    assert_equal "Showing 1-1 of 1 movie", adapter(one).summary(:movies_for_test)
+  end
+
   # --- series -------------------------------------------------------------------------
 
   # Pagy keeps `series` protected; this is the shape the template's `case` depends on.

--- a/test/bali/components/pagination_footer_test.rb
+++ b/test/bali/components/pagination_footer_test.rb
@@ -29,6 +29,14 @@ class BaliPaginationFooterComponentTest < ComponentTestCase
     assert_text("Showing 1-10 of 47 studios")
   end
 
+  def test_picks_the_singular_from_a_hash_item_name
+    single_pagy = Pagy::Offset.new(count: 1, page: 1, limit: 10)
+    render_inline(Bali::PaginationFooter::Component.new(
+      pagy: single_pagy, item_name: { one: "movie", other: "movies" }
+    ))
+    assert_text("Showing 1-1 of 1 movie")
+  end
+
   def test_hides_summary_when_show_summary_is_false
     render_inline(Bali::PaginationFooter::Component.new(pagy: @pagy, show_summary: false))
     assert_no_text("Showing")


### PR DESCRIPTION
## fix(pagination): el summary decía "de 1 items" — item_name ahora pluraliza

`PagyAdapter#summary` ya pasaba `count:` a `I18n.t`, pero la clave es un string plano y el `item_name` se interpolaba tal cual, invariante con el conteo: en afal-apps el pie decía "Mostrando 1-15 de 15 usuario" y "1-1 de 1 programas" según qué forma pasara la vista.

El adapter resuelve ahora el item_name según su tipo — **Symbol**: clave i18n resuelta con `count:` (CLDR completo de Rails); **Hash** `{one:, other:}`: elegido por conteo, sin archivo de locale; **String**: verbatim, el comportamiento de todos los call sites existentes; **nil/""**: el default de la gema, que pasa a hash plural en ambos locales. Un solo método cubre PaginationFooter y DataTable (solo transportan el valor).

Tests: 3 nuevos del adapter (default pluralizado, hash, symbol) + 1 de integración por componente. Los 4 tests existentes del summary siguen verdes sin tocarse — esa es la prueba de retrocompatibilidad.

Cierra el hallazgo H-01 de la verificación E2E de afal-apps del 04/08.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqjUUwZkTWuHSyrG9Hqxb5
