### PR TITLE
fix(form_builder): el placeholder de slim_select por fin habla el idioma del host

### DIFF
--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -204,6 +204,7 @@ en:
         placeholder: "Search..."
         submit: "Search"
       slim_select:
+        placeholder: "Select value"
         search_placeholder: "Search"
         select_all: "Select all"
         deselect_all: "Deselect all"

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -203,6 +203,7 @@ es:
         placeholder: "Buscar..."
         submit: "Buscar"
       slim_select:
+        placeholder: "Selecciona una opción"
         search_placeholder: "Buscar"
         select_all: "Seleccionar todo"
         deselect_all: "Deseleccionar todo"

--- a/lib/bali/form_builder/slim_select_fields.rb
+++ b/lib/bali/form_builder/slim_select_fields.rb
@@ -98,6 +98,9 @@ module Bali
 
       def build_options(options)
         DEFAULT_OPTIONS.merge(options).merge(
+          placeholder: options.fetch(:placeholder) do
+            I18n.t("bali_view.form_builder.slim_select.placeholder")
+          end,
           search_placeholder: options.fetch(:search_placeholder) do
             I18n.t("bali_view.form_builder.slim_select.search_placeholder")
           end,
@@ -201,7 +204,10 @@ module Bali
       def stimulus_data(options, html_options)
         data = {
           controller: "slim-select",
-          slim_select_placeholder_value: html_options[:placeholder],
+          # `html: { placeholder: }` keeps priority — call sites that pass it must not
+          # change. The translated default only fills the gap where nothing was emitted
+          # and the Stimulus controller's English 'Select value' won by omission.
+          slim_select_placeholder_value: html_options[:placeholder] || options[:placeholder],
           slim_select_show_content_value: options[:show_content],
           slim_select_search_placeholder_value: options[:search_placeholder],
           slim_select_select_all_text_value: options[:select_all_text],

--- a/test/bali/form_builder/slim_select_fields_test.rb
+++ b/test/bali/form_builder/slim_select_fields_test.rb
@@ -212,6 +212,29 @@ class BaliFormBuilderSlimSelectFieldsTest < FormBuilderTestCase
     assert_html(result, 'div[data-slim-select-placeholder-value="Choose one"]')
   end
 
+  # The other six SlimSelect texts already go through `bali_view.form_builder.slim_select.*`;
+  # the placeholder was the odd one out — no data-attribute emitted, so the Stimulus
+  # controller's English default ('Select value') won on every call site that did not pass
+  # `html: { placeholder: }`.
+  def test_slim_select_field_placeholder_value_defaults_to_the_translated_placeholder
+    result = builder.slim_select_field(:status, Movie.statuses.to_a)
+    assert_html(result, 'div[data-slim-select-placeholder-value="Select value"]')
+  end
+
+  def test_slim_select_field_placeholder_value_default_is_translated
+    I18n.with_locale(:es) do
+      result = builder.slim_select_field(:status, Movie.statuses.to_a)
+      assert_html(result, 'div[data-slim-select-placeholder-value="Selecciona una opción"]')
+    end
+  end
+
+  def test_slim_select_field_html_placeholder_wins_over_the_translated_default
+    I18n.with_locale(:es) do
+      result = builder.slim_select_field(:status, Movie.statuses.to_a, html: { placeholder: "Choose one" })
+      assert_html(result, 'div[data-slim-select-placeholder-value="Choose one"]')
+    end
+  end
+
   def test_slim_select_field_stimulus_data_values_sets_add_items_value
     result = builder.slim_select_field(:status, Movie.statuses.to_a, add_items: true)
     assert_html(result, 'div[data-slim-select-add-items-value="true"]')


### PR DESCRIPTION
## fix(form_builder): el placeholder de slim_select por fin habla el idioma del host

Los otros seis textos de SlimSelect ya pasan por `bali_view.form_builder.slim_select.*`, pero el placeholder era la excepción: sin `html: { placeholder: }` el wrapper no emitía el data-attribute y ganaba el default inglés del controller Stimulus ('Select value') en cualquier host, sea cual sea su locale — en afal-apps se veía en co-responsables de iniciativa, responsables de tarea y los selects del form de historia.

El wrapper emite ahora el placeholder traducido como default (es: "Selecciona una opción"); `html: { placeholder: }` conserva la prioridad, así que ningún call site existente cambia. Tests: default EN, default ES y prioridad de `html:`.

Parte del hallazgo H-02 de la verificación E2E de afal-apps del 04/08.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqjUUwZkTWuHSyrG9Hqxb5
