### PR TITLE
fix(simple-filters): "Limpiar" no limpiaba nada con la persistencia encendida

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versiones `v2.x` de más abajo son la línea estable de `main`. Ver
 > [Release channels](docs/guides/release-channels.md).
 
+### Fixed
+
+- **El link "Limpiar" de los filtros simples no limpiaba nada con la persistencia encendida.** Navegaba a la URL pelada, y para el server eso es indistinguible de "no vino ningún filtro" — con `persist_enabled` ese es justo el caso que RESTAURA lo guardado, así que el listado le devolvía al usuario el filtro que acababa de limpiar, con el select repoblado. Ahora manda `clear_filters=true`, el único param que dispara el borrado de la caché (`Rails.cache.delete(cache_key)`); las otras dos rutas de limpieza (`Filters::AppliedTags#clear_all_url` y `clearFiltersAndClose` del JS) ya lo mandaban y ésta se había quedado afuera. El param se AGREGA al query string en vez de reemplazarlo, así una `url:` con params propios del host los conserva.
+
+  Medido en un host, sobre cuatro listados y con caché real: filtrar dejaba 9 de 69 elementos y limpiar seguía mostrando 9; ahora vuelve a 69. Con la persistencia apagada el link ya funcionaba, que es lo que hacía tan fácil no verlo.
+
+  Los dos tests que cubrían este link asertaban su href contra la URL pelada — fijaban el bug como contrato y habrían seguido en verde para siempre. Se corrigen, y el caso pasa a probarse SIGUIENDO el link: el href renderizado se parsea y se le entrega al `FilterForm` igual que haría el server con el request del click, asertando el estado resultante del listado y que la caché quedó borrada, no la forma de la URL.
+
 ## [v3.0.0.beta.5] - 2026-08-04
 
 ### Changed

--- a/app/components/bali/data_table/simple_filters/component.html.erb
+++ b/app/components/bali/data_table/simple_filters/component.html.erb
@@ -194,7 +194,7 @@
       <% if show_clear? %>
         <%= render Bali::Link::Component.new(
           name: clear_button_text,
-          href: @url,
+          href: clear_href,
           variant: :ghost,
           size: :sm,
           icon: 'x',

--- a/app/components/bali/data_table/simple_filters/component.rb
+++ b/app/components/bali/data_table/simple_filters/component.rb
@@ -17,6 +17,8 @@ module Bali
       #   ])
       #
       class Component < ApplicationViewComponent
+        include Utils::Url
+
         # Min-width for slim_select dropdowns. Triggers in SimpleFilters are narrow
         # (~13rem), so we let the dropdown grow past the trigger to fit long labels
         # without wrapping.
@@ -210,6 +212,20 @@ module Bali
 
         def clear_button_text
           I18n.t("bali_view.simple_filters.clear")
+        end
+
+        # Navegar a la URL pelada NO limpia: para el server es indistinguible de "no vino
+        # ningún filtro", y con la persistencia encendida ese es justo el caso que RESTAURA
+        # lo guardado — el usuario limpiaba y el listado le devolvía el filtro. `clear_filters`
+        # es lo único que dispara el borrado de la caché (`FilterForm`: `Rails.cache.delete`).
+        # Las otras dos rutas de limpieza ya lo mandaban (`AppliedTags#clear_all_url` y
+        # `clearFiltersAndClose` del JS); ésta se había quedado afuera.
+        #
+        # Se AGREGA al query string en vez de reemplazarlo: la `url:` del listado puede traer
+        # params propios del host (`request.fullpath`, un scope), y perderlos al limpiar
+        # mandaría al usuario a otra vista.
+        def clear_href
+          add_query_param(@url, :clear_filters, true)
         end
       end
     end

--- a/test/bali/components/data_table/filter_persistence_test.rb
+++ b/test/bali/components/data_table/filter_persistence_test.rb
@@ -82,3 +82,63 @@ class BaliDataTableFilterPersistenceTest < ComponentTestCase
     assert_selector('[data-filter-persistence-storage-id-value="explicit_movies"]', count: 1)
   end
 end
+
+class ClearLinkMovieFilterForm < Bali::FilterForm
+  filter_attribute :genre, type: :select, options: [ %w[Drama drama] ], simple: true
+  attribute :genre_eq
+end
+
+# El link "Limpiar" de los filtros simples se SIGUE, no se mira: asertar sólo su href deja
+# pasar un link que no limpia nada, que es exactamente como este bug llegó a producción (dos
+# tests fijaban la URL pelada como si fuera el contrato). Acá el href renderizado se parsea y
+# se le entrega al FilterForm igual que haría el server con el request del click: lo que se
+# aserta es el ESTADO RESULTANTE del listado, no la forma de la URL.
+class BaliDataTableSimpleFiltersClearTest < ComponentTestCase
+  CACHE_KEY = "clear_link_movie_filter_forms;;movies"
+
+  def setup
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+  end
+
+  def teardown
+    Rails.cache = @original_cache
+  end
+
+  def sample_filters
+    [ { attribute: :genre, collection: [ %w[Drama drama] ], blank: "All", label: "Genre" } ]
+  end
+
+  # Los params que el server recibiría al seguir el href del link "Limpiar".
+  def params_from_clear_link
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(
+                    url: "/movies", filters: sample_filters, show_clear: true))
+    href = page.find("a[aria-label='Clear'], a[aria-label='Limpiar']")[:href]
+    ActionController::Parameters.new(Rack::Utils.parse_nested_query(URI(href).query.to_s))
+  end
+
+  def test_following_the_clear_link_leaves_the_listing_unfiltered
+    ClearLinkMovieFilterForm.new(Movie.all, ActionController::Parameters.new(q: { genre_eq: "drama" }),
+                                 storage_id: "movies")
+
+    cleared = ClearLinkMovieFilterForm.new(Movie.all, params_from_clear_link,
+                                           storage_id: "movies", persist_enabled: true)
+
+    assert_empty(cleared.attributes.to_h.compact_blank,
+                 "limpiar dejó filtros vivos: el listado sigue filtrado después del click")
+  end
+
+  def test_following_the_clear_link_drops_the_stored_state
+    ClearLinkMovieFilterForm.new(Movie.all, ActionController::Parameters.new(q: { genre_eq: "drama" }),
+                                 storage_id: "movies")
+    assert(Rails.cache.read(CACHE_KEY), "premisa: el filtro quedó guardado")
+
+    ClearLinkMovieFilterForm.new(Movie.all, params_from_clear_link,
+                                 storage_id: "movies", persist_enabled: true)
+
+    # Sin borrar la caché el filtro reaparece en la visita SIGUIENTE, no en ésta: el síntoma
+    # se corre un request y el test de arriba solo lo dejaría pasar.
+    assert_nil(Rails.cache.read(CACHE_KEY))
+  end
+end

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -67,9 +67,15 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
     assert_selector("select[name='q[status_eq]']")
   end
 
+  # `clear_filters` NO es cosmético: es el único param que en el server borra la caché de
+  # filtros (`Rails.cache.delete(cache_key)`). Sin él, el link navega a la URL pelada, que
+  # con la persistencia encendida es indistinguible de "no vino ningún filtro" — y el
+  # listado restaura lo que el usuario acaba de limpiar. Las otras dos rutas de limpieza
+  # (AppliedTags#clear_all_url y clearFiltersAndClose del JS) sí lo mandan; ésta se había
+  # quedado afuera, y estos tests fijaban la URL pelada como si fuera el contrato.
   def test_shows_clear_button_when_show_clear_is_true
     render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, show_clear: true))
-    assert_link(href: "/test")
+    assert_link(href: "/test?clear_filters=true")
   end
 
   def test_hides_clear_button_when_show_clear_is_false
@@ -264,7 +270,18 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
   def test_search_parameter_shows_clear_button_when_show_clear_is_true_with_search
     search_with_value = @search.merge(value: "test")
     render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters, search: search_with_value, show_clear: true))
-    assert_link(href: "/test")
+    assert_link(href: "/test?clear_filters=true")
+  end
+
+  # Una `url:` con query string es el caso normal cuando el host pasa `request.fullpath` o un
+  # path helper con params: el param se AGREGA, sin pisar lo que ya viajaba ni duplicarse.
+  def test_the_clear_link_keeps_the_params_the_listing_url_already_carried
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(
+                    url: "/test?scope=mine", filters: @filters, show_clear: true))
+
+    href = page.find("a[href*='clear_filters']")[:href]
+    assert_equal("true", Rack::Utils.parse_query(URI(href).query)["clear_filters"])
+    assert_equal("mine", Rack::Utils.parse_query(URI(href).query)["scope"])
   end
 
   def test_search_parameter_does_not_show_clear_button_when_show_clear_is_false_even_with_search_value


### PR DESCRIPTION
El link **"Limpiar"** de los filtros simples no limpia nada cuando el listado tiene la persistencia encendida: navega a la URL **pelada**, y para el server eso es indistinguible de "no vino ningún filtro" — que con `persist_enabled` es justo el caso que **restaura** lo guardado. El usuario limpia y el listado le devuelve el mismo filtro, con el select repoblado.

Reportado por un usuario sobre los tres listados del admin de bali-auth; medido después en cuatro listados de un host.

## Causa raíz

`app/components/bali/data_table/simple_filters/component.html.erb:197`

```erb
href: @url,
```

`clear_filters` no es cosmético: es el **único** param que dispara el borrado de la caché de filtros (`FilterForm` → `Rails.cache.delete(cache_key)`). Las otras dos rutas de limpieza ya lo mandaban:

- `Filters::AppliedTags#clear_all_url` → `add_query_param(url, :clear_filters, true)`
- `filters_controller.js#clearFiltersAndClose` → `url.searchParams.set('clear_filters', 'true')`

O sea que no había un criterio distinto: había una tercera ruta que se quedó afuera.

Con la persistencia **apagada** el link ya funcionaba (sin la bandera no se restaura nada), y eso es lo que hacía tan fácil no verlo: el bug sólo aparece donde el listado promete recordar.

## El arreglo

`href: clear_href`, que agrega el param en vez de reemplazar el query string — la `url:` del listado puede traer params propios del host (`request.fullpath`, un scope), y perderlos al limpiar mandaría al usuario a otra vista.

## Los tests fijaban el bug como contrato

Los dos que cubrían este link asertaban `href: "/test"`, o sea la URL pelada. Habrían seguido en verde para siempre. Se corrigen, y el caso pasa a probarse **siguiendo** el link en vez de mirarlo: el href renderizado se parsea y se le entrega al `FilterForm` igual que haría el server con el request del click, asertando el **estado resultante del listado** y que la caché quedó borrada — no la forma de la URL.

Los dos asertos van aparte a propósito: sin borrar la caché el filtro reaparece en la visita **siguiente**, y el primer test dejaría pasar ese síntoma corrido un request.

## Verificación

**RED verificado** antes del arreglo:

```
limpiar dejó filtros vivos: el listado sigue filtrado después del click.
Expected {"genre_eq" => "drama"} to be empty.
```

- Suite completa **3768 runs / 6781 assertions / 0 failures**; rubocop limpio.
- **En un host real** (afal-apps apuntado a este clon, con la identidad de la gema asertada en el HTML servido y caché real), filtrar → clic en Limpiar:

| Listado | Total | Filtrado | Tras limpiar |
|---|---|---|---|
| `audit_logs` | 69 | 9 | **69** ✅ |
| `roles` | 19 | 2 | **19** ✅ |
| `sessions` | 17 | 2 | **17** ✅ |
| `deliverables` | 3 | 1 | **3** ✅ |

- La persistencia normal sigue viva: filtrar 9, volver sin query 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
