### PR TITLE
docs(block-editor): fila de Troubleshooting para el loop de render de BlockNote <= 0.52.1 (#908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Troubleshooting entry for the BlockNote <= 0.52.1 render loop (#908).** The BlockEditor guide (`docs/api/block-editor.md`) now documents the `Maximum update depth exceeded` console error: it appears while typing (or when closing a drawer/modal holding the editor) when a browser extension that rewrites the page's DOM (Dark Reader, Grammarly, page translators) is active, because BlockNote <= 0.52.1 node views do not ignore non-content mutations (TypeCellOS/BlockNote#2818, fixed upstream by #2912 — merged but not yet released). No data is lost; the `@blocknote/*` bump lands separately once upstream publishes a release containing the fix.
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/docs/api/block-editor.md
+++ b/docs/api/block-editor.md
@@ -1189,6 +1189,7 @@ The FormBuilder helpers live outside this directory, in `lib/bali/form_builder/r
 | Comments never appear | `comments:` was given something other than a non-empty Hash | See [Comments](#comments) |
 | `TypeError: ....then is not a function` while parsing content | BlockNote older than 0.51 (or third-party code chaining `.then` onto a now-synchronous parser) | Upgrade to `>= 0.52.1`, the declared and tested range |
 | A menu never opens, or content silently fails to serialise, with no error | `@blocknote/*` packages installed at different versions | Pin them all to the same version -- see [Step 1](#step-1----npm-packages) |
+| Console: `Maximum update depth exceeded` while typing, or when closing a drawer/modal that holds the editor -- yet the content saves correctly | A browser extension that rewrites the editor's DOM (Dark Reader, Grammarly, page translators) feeds attribute mutations into ProseMirror's DOM observer, and in BlockNote <= 0.52.1 the node views do not ignore non-content mutations, so the side menus re-render in a loop until React cuts it off ([TypeCellOS/BlockNote#2818](https://github.com/TypeCellOS/BlockNote/issues/2818); fixed upstream by [#2912](https://github.com/TypeCellOS/BlockNote/pull/2912), merged but not yet released) | No data is lost -- the hidden input is written outside React. Disable the extension for the app, or upgrade every `@blocknote/*` package (same version, as always) once a release containing the fix ships |
 
 ---
 


### PR DESCRIPTION
## Resumen

PR 1 de #908 (referencia, **no lo cierra** — el PR 2, el bump de `@blocknote/*`, queda bloqueado hasta que upstream publique un release con el fix).

Agrega una fila a la tabla **Troubleshooting** de `docs/api/block-editor.md` documentando el síntoma observado en la verificación E2E post-v3:

- **Síntoma:** consola con `Maximum update depth exceeded` mientras se escribe o al cerrar un drawer/modal con el editor; **el contenido se guarda bien** (el hidden input se escribe fuera de React).
- **Causa:** una extensión del navegador que reescribe el DOM del editor (Dark Reader, Grammarly, traductores) mete mutaciones de atributos por el DOM observer de ProseMirror, y en BlockNote <= 0.52.1 los node views no ignoran mutaciones que no son de contenido → loop de re-render de los side menus hasta que React lo corta. Upstream TypeCellOS/BlockNote#2818; fix TypeCellOS/BlockNote#2912, mergeado el 03/08 pero **sin release** (npm sigue en 0.52.1).
- **Mitigación:** no hay pérdida de datos; desactivar la extensión sobre la app, o subir todos los `@blocknote/*` (en set, como siempre) cuando salga la versión que incluya el fix.

Sigue el plan de `docs/plans/v3.1/quality-bugs.md` (sección #908, PR 1): fila calcada al estilo de las 13 existentes, en inglés, con las extensiones nombradas para que el síntoma sea diagnosticable.

## Cambios

- `docs/api/block-editor.md` — fila nueva en la tabla Troubleshooting.
- `CHANGELOG.md` — entrada bajo `[Unreleased]` (`### Added`).

## Tests

Ninguno: cambio solo de documentación (según el propio plan del issue).

Refs #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)