### PR TITLE
docs(t3): esqueleto de la guía de migración v3.0 → v3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New migration guide skeleton: `docs/guides/migration-v3-to-v31.md`.** Migration notes
+  for the 3.1 line live in a new per-release document instead of growing the v2 → v3 guide.
+  The skeleton states the upgrade policy — five announced markup/behaviour changes admitted
+  as a block (#903, #641, #722, #729, #902) — and reserves one section per change; each
+  section's details land with its PR.
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/docs/guides/migration-v3-to-v31.md
+++ b/docs/guides/migration-v3-to-v31.md
@@ -1,0 +1,53 @@
+# Migrating from Bali v3.0 to v3.1
+
+This guide is for hosts on **v3.0.x** upgrading to **v3.1**. If you are coming from v2 (or
+v1), read [Migrating from Bali v2 to v3](migration-v2-to-v3.md) first — everything there
+still applies, and this guide only covers what changes *after* it.
+
+v3.1 is an additive release with one deliberate exception: **five announced changes of
+markup or behaviour, admitted as a block**. The policy behind them: the universe of hosts
+on v3 is closed, pinned and measured — every blast radius below was quantified against real
+host code before the change was approved, and each change ships with an explicit CHANGELOG
+entry. The alternative (deferring all five to v4) was considered and rejected once, for all
+five together, so no individual PR relitigates it.
+
+The five sections below are placeholders on purpose. This document is the vehicle; each PR
+brings its own section — what breaks, what replaces it, and the measurement that sized it.
+Until a section says otherwise, the v3.0 behaviour it describes is still what ships.
+
+## Residual daisyUI 4 classes outside the FormBuilder (#903)
+
+v3.0 moved the library to daisyUI 5, but a handful of daisyUI 4 class names survived
+outside the FormBuilder. v3.1 removes them.
+
+*Lands with the #903 PR; details land with it.*
+
+## `ActionsDropdown` POST items become `button_to` (#641)
+
+Dropdown items that trigger a non-GET request (POST/PATCH/DELETE) stop being links with
+`data-turbo-method` and become real `button_to` forms.
+
+*Lands with the #641 PR; details land with it.*
+
+## Tabs: `options` reach the `<a>` (#722)
+
+Options passed to a tab item start landing on the `<a>` element itself instead of its
+wrapper, alongside the rest of what #722 adds to `Bali::Tabs`.
+
+*Lands with the #722 PR; details land with it.*
+
+## Card root becomes an `<a>` when given `href:` (#729)
+
+A `Bali::Card` (and `Bali::StatCard`) constructed with `href:` renders its root element as
+an `<a>` instead of wrapping a link inside a `<div>`.
+
+*Lands with the #729 PR; details land with it.*
+
+## Five shadowed icons change their drawing (#902)
+
+Five icon names that Bali's legacy SVGs were shadowing resolve to their Lucide drawing
+instead: the name keeps working, the glyph changes. The full before/after table lands here
+— and also in [the v2 → v3 guide](migration-v2-to-v3.md), because it affects anyone
+migrating from v1/v2 as well.
+
+*Lands with the #902 PR; details land with it.*


### PR DESCRIPTION
## Resumen

Decisión **T3** del roadmap v3.1: las notas de migración de la línea 3.1 viven en un documento nuevo por release — `docs/guides/migration-v3-to-v31.md` — en vez de engordar `migration-v2-to-v3.md` (que ya ronda las 3000 líneas y cubre otro salto).

Este PR crea el **esqueleto** del doc:

- **Intro**: a quién aplica (hosts en v3.0.x subiendo a 3.1) y la política **T1** — los cinco cambios anunciados de markup/comportamiento se admiten en bloque, con la justificación decidida una sola vez (universo de hosts cerrado, pineado y medido; ningún PR relitiga el semver).
- **Una sección placeholder por cambio**, cada una marcada *"Lands with the #NNN PR; details land with it."*:
  - **#903** — clases daisyUI-4 residuales fuera del FormBuilder
  - **641-D1** — items POST del `ActionsDropdown` pasan a `button_to`
  - **#722** — `options` de los tabs llegan al `<a>`
  - **#729** — la raíz de `Card`/`StatCard` se vuelve `<a>` con `href:`
  - **#902** — 5 iconos sombreados cambian de dibujo (con la nota de que su tabla también aterriza en el doc v2→v3, la única excepción de T3)

El esqueleto fija el vehículo; **no inventa detalle técnico** que aún no existe — cada PR de los cinco traerá su sección con el qué rompe, el reemplazo y la medición.

## Cambios

- `docs/guides/migration-v3-to-v31.md` (nuevo)
- `CHANGELOG.md` — entrada bajo `[Unreleased]` (### Added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
