### PR TITLE
chore(deps): daisyUI 5.7.16 en el dummy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+
+- Updated daisyUI to 5.7.16 in the dummy app. The package's peer range (`>=5.7.0`) is unchanged.
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -29,7 +29,7 @@
     "ai": "^6.0.5",
     "bali-view-components": "link:../..",
     "chart.js": "^4.5.1",
-    "daisyui": "5.7.15",
+    "daisyui": "5.7.16",
     "date-fns": "^4.1.0",
     "docx": "^9.4.0",
     "flatpickr": "^4.6.13",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -988,10 +988,10 @@ crypto-js@^4.2.0:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
-daisyui@5.7.15:
-  version "5.7.15"
-  resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-5.7.15.tgz#7369a4dd6e6b37d3de284e7d35a16176dda53717"
-  integrity sha512-62W6wiH6AhFKJ2ZcpJVcuPGQXbIgwq8BZZx78iJ3/T8lqrdY+UpQlYWb4IQQQXZ81NMwyX+CKS2+8HaTOE3ctA==
+daisyui@5.7.16:
+  version "5.7.16"
+  resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-5.7.16.tgz#033e6f86ca4f9f2cdfeffd1752cb99a2c14c7780"
+  integrity sha512-V9CJxvrWIXTDuP/0tpijjWaKaKJNYo2IrULJfTWs3/DjW9rPqswk1n8NCLQRLrTutmlG2Ech7nkJDpCnF+6Dzw==
 
 date-fns@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Resumen

Sube daisyUI de `5.7.15` a `5.7.16` en el dummy app (`spec/dummy/package.json` + `yarn.lock`). Es la alineación de dependencias que manda el CLAUDE.md del repo ("Bali must stay on the latest Tailwind CSS and daisyUI") **antes** de arrancar el trabajo de la línea 3.1.

- El peer range del paquete (`daisyui >=5.7.0` en el `package.json` raíz) queda igual — es un patch, no mueve el piso.
- CSS reconstruido con `app:tailwindcss:build`: el bundle compila contra daisyUI 5.7.16 (`builds/` está gitignoreado, no va en el PR).
- `yarn.lock` solo cambia la entrada de daisyUI.

## Verificación

- Suite completa de Minitest en verde: 3768 runs, 6781 assertions, 0 failures, 0 errors, 0 skips.
- Cypress lo corre el CI del PR.

## Changelog

Entrada bajo `[Unreleased]` → `### Dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)