### PR TITLE
feat(engine): Bali.engine_controller_concerns — punto de extensión de auth del host (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v3.0.0] - 2026-08-05
+### Added
+
+- **`Bali.engine_controller_concerns` — the official way for a host to teach its context to the engine's controllers.** `isolate_namespace` means `Bali::ApplicationController` inherits from `ActionController::Base`, not from the host's `ApplicationController`, so `current_user` and friends never existed inside the engine — every host worked around it by monkey-patching `Bali::SavedViewsController` from a `to_prepare` initializer, once per controller, once per app. Every module in the new array is now included into `Bali::ApplicationController` (and therefore into every engine controller at once) on each `to_prepare`, idempotently and surviving code reloads. The concern must stay passive — identity, not access: the gate remains the `Bali.*_authorize` lambdas. The new [Engines guide](docs/guides/engines.md) documents the `isolate_namespace` gotcha in one place, the authorize-lambdas doctrine, and the bali-auth recipe (`include BaliAuth::Authentication` + `allow_unauthenticated_access`). (#710)
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to
 the stable channel: `3.0` merges into `main`, `main` becomes the v3 line, and the next

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ In your CSS entry point (e.g., `app/assets/tailwind/application.css`):
 | [FormBuilder](docs/guides/form-builder.md) | Enhanced form helpers |
 | [Accessibility](docs/guides/accessibility.md) | WCAG 2.1 compliance |
 | [Overlays and the top layer](docs/guides/overlays-and-the-top-layer.md) | What the z-index scale orders, and what it cannot |
+| [Engines](docs/guides/engines.md) | Host integration for Bali's controllers (`Bali.engine_controller_concerns`) |
 | [Migrating v2 → v3](docs/guides/migration-v2-to-v3.md) | Breaking changes to the index page (DataTable) |
 | [Troubleshooting](docs/guides/troubleshooting.md) | Common issues and solutions |
 

--- a/docs/guides/engines.md
+++ b/docs/guides/engines.md
@@ -1,0 +1,143 @@
+# Engines: host integration for Bali's controllers
+
+Bali is a Rails engine with `isolate_namespace`. Besides components, it ships real
+controllers — today `Bali::SavedViewsController` (saved views storage) and
+`Bali::BlockEditorUploadsController` (editor uploads), with more arriving as the
+documents engine grows. This guide explains why your app's authentication does not
+reach those controllers on its own, and the one supported way to teach it to them:
+`Bali.engine_controller_concerns`.
+
+## Why your `ApplicationController` hooks don't apply
+
+`Bali::ApplicationController` inherits from `ActionController::Base`, **not** from your
+app's `ApplicationController`:
+
+```ruby
+module Bali
+  class ApplicationController < ActionController::Base
+  end
+end
+```
+
+That is what `isolate_namespace` engines do, and it is deliberate — the engine cannot
+know what your base controller requires. The consequences, all of them by design:
+
+- Your `before_action`s (authentication, tenant scoping, locale) never run for engine
+  requests.
+- `current_user`, `Current.user`, session helpers — none of them exist inside an engine
+  controller. `controller.try(:current_user)` returns `nil`.
+- Your rescue handlers and layout don't apply either.
+
+Before this extension point existed, every host worked around it with the same
+monkey-patch: re-open the engine controller from a `config.to_prepare` initializer and
+`include` the auth concern by hand, once per controller, once per app. With the engine
+growing more controllers, that multiplies — hence `Bali.engine_controller_concerns`.
+
+## The real gate: the `Bali.*_authorize` lambdas
+
+Injecting a concern is about **identity** (teaching the engine who the user is), not
+about **access**. Access is decided by the engine's own configurable lambdas, which run
+inside each controller and respond `403 Forbidden` on their own:
+
+| Config | Guards | Default |
+|---|---|---|
+| `Bali.saved_views_owner` | who owns a saved view | `->(controller) { controller.try(:current_user) }` |
+| `Bali.saved_views_authorize` | saved views mutations | owner present, else 403 |
+| `Bali.block_editor_upload_authorize` | editor uploads | unset — uploads allowed; configure it |
+
+New engine controllers follow the same doctrine: a whitelist plus an authorize lambda
+is the defense, and it works even for a request that carries no session at all. The
+injected concern only makes the defaults useful — `try(:current_user)` starts returning
+someone.
+
+## `Bali.engine_controller_concerns`
+
+An array of modules. Every module is included into `Bali::ApplicationController` — and
+therefore into every engine controller at once — during `to_prepare`, so it survives
+code reloads in development and runs before eager loading in production. The include is
+idempotent: a module already in the ancestors is skipped, so a plain module's
+`included` hook fires once per loaded class, not once per reload.
+
+```ruby
+# config/initializers/bali.rb
+Bali.engine_controller_concerns = [MySessionConcern]
+```
+
+Timing: the assignment just stores the array. The include happens on the next
+`to_prepare` pass — at boot that is *after* initializers run, so don't expect the
+module in `Bali::ApplicationController.ancestors` from inside the initializer itself.
+
+### Keep the concern passive
+
+**Never inject a concern whose `before_action`s stay active.** An `authenticate_user!`
+that redirects to login would shadow the engine's own `403`s — the browser lands on
+your sign-in page instead of surfacing the real answer, and some auth concerns render
+views the engine does not have in its view path (a `500`). Teach identity, then disable
+the concern's own gate, and let the engine's lambdas decide.
+
+### The bali-auth recipe
+
+With [bali-auth](https://github.com/Grupo-AFAL/bali-auth), the wrapper is five lines:
+include the same `Authentication` concern the host already uses (cookie, session token,
+impersonation — zero duplication), then `allow_unauthenticated_access` to switch off
+its `before_action`s:
+
+```ruby
+# config/initializers/bali.rb
+module EngineAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    include BaliAuth::Authentication
+    allow_unauthenticated_access
+  end
+end
+
+Bali.engine_controller_concerns = [EngineAuthentication]
+```
+
+Why `allow_unauthenticated_access` is not optional here: `authenticate_user!` would
+redirect to login (shadowing the engine's 403), and `check_role_access` renders a
+BaliAuth view the engine's view path does not include (500). The tradeoff — an expired
+cookie can still, say, save a personal view until the next host page expires it — is
+accepted: the engine's authorize lambdas remain the gate.
+
+A packaged `BaliAuth::EngineAuthentication` concern with exactly this shape is planned
+on the bali-auth side (refs #710); once it ships, the initializer collapses to the
+single assignment line.
+
+### Hosts without bali-auth
+
+Any way of resolving the user works, as long as it is passive. For a hand-rolled
+session:
+
+```ruby
+module EngineAuthentication
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+end
+
+Bali.engine_controller_concerns = [EngineAuthentication]
+```
+
+(A Devise host usually needs nothing here: Devise registers its helpers on
+`ActionController::Base` through `on_load(:action_controller)`, which the engine's
+controllers inherit from.)
+
+Or skip the concern entirely and configure the lambdas directly — they receive the
+controller, so anything reachable from the request works:
+
+```ruby
+Bali.saved_views_owner = ->(controller) {
+  User.find_by(id: controller.session[:user_id])
+}
+```
+
+## Testing with an injected concern
+
+In the engine's own suite, `test/requests/engine_controller_concerns_test.rb` shows the
+pattern: assign the array in `setup`, run `Rails.application.reloader.prepare!` to
+trigger the include (tests don't reload code, so `to_prepare` won't fire on its own),
+and restore the original array in `teardown`. Remember Ruby cannot un-include a module —
+neutralize the concern's state instead of expecting it to disappear.

--- a/lib/bali.rb
+++ b/lib/bali.rb
@@ -153,6 +153,25 @@ module Bali
   # Example: ->(controller, owner) { owner&.can?("tdflow.access") }
   mattr_accessor :saved_views_authorize, default: ->(_controller, owner) { owner.present? }
 
+  # Concerns the host injects into every controller of this engine (#710).
+  #
+  # `isolate_namespace` means `Bali::ApplicationController` inherits from
+  # `ActionController::Base`, NOT from the host's `ApplicationController` — so the
+  # host's authentication (`current_user`, session helpers, `Current`) does not
+  # exist inside the engine's controllers unless the host teaches it. Every module
+  # in this array is included into `Bali::ApplicationController` on each
+  # `to_prepare` (idempotent, and it survives code reloads in development), which
+  # covers saved views, block editor uploads and every controller the engine grows
+  # later, all at once.
+  #
+  # Keep the injected concern PASSIVE: it should teach context (`current_user`),
+  # not enforce access — an active `authenticate_user!` before_action would
+  # redirect to login and shadow the engine's own 403s. The real gate stays in the
+  # `Bali.*_authorize` lambdas. Full guide, including the bali-auth recipe:
+  # docs/guides/engines.md.
+  # Example: Bali.engine_controller_concerns = [EngineAuthentication]
+  mattr_accessor :engine_controller_concerns, default: []
+
   # Every deprecation this gem emits goes through here. The engine registers it
   # as `app.deprecators[:bali]`, so a host silences, logs or raises Bali's
   # warnings with the same `config.active_support.deprecation` it already uses

--- a/lib/bali/engine.rb
+++ b/lib/bali/engine.rb
@@ -65,6 +65,18 @@ module Bali
       ActionController::Base.helper(Bali::BlockEditorHelper)
     end
 
+    # Host-injected controller concerns (#710) — see docs/guides/engines.md. In a
+    # to_prepare the constant resolves to the freshly-loaded class, so the include
+    # survives code reloads in development; the `<` guard keeps a repeated prepare
+    # pass from re-firing a plain module's `included` hook on the same class. Rails
+    # runs :run_prepare_callbacks BEFORE :eager_load!, so engine controllers defined
+    # later inherit whatever the concern registered on the base class.
+    config.to_prepare do
+      Bali.engine_controller_concerns.each do |concern|
+        Bali::ApplicationController.include(concern) unless Bali::ApplicationController < concern
+      end
+    end
+
     # No initializer adds config/locales here on purpose. Rails::Engine already
     # registers it through `paths["config/locales"]`, in an order that puts every
     # engine BEFORE the app — which is what lets a host override a Bali string.

--- a/test/requests/engine_controller_concerns_test.rb
+++ b/test/requests/engine_controller_concerns_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# #710 — Bali.engine_controller_concerns: el punto de extensión para que el host inyecte
+# concerns a los controllers del engine. Por isolate_namespace, Bali::ApplicationController
+# NO hereda del ApplicationController del host, así que `current_user` no existe ahí solo;
+# el engine incluye cada módulo del array en un to_prepare. Aquí el prepare! se dispara a
+# mano, igual que lo dispara un reload en development o el boot en producción.
+class BaliEngineControllerConcernsTest < ActionDispatch::IntegrationTest
+  # Concern realista: enseña `current_user`, que es justo lo que el default de
+  # `Bali.saved_views_owner` intenta leer. Módulo plano a propósito (sin
+  # ActiveSupport::Concern): un módulo plano re-dispararía su hook `included` en cada
+  # to_prepare si el engine no guardara la inclusión — el contador lo delata.
+  module HostSession
+    class << self
+      attr_accessor :user, :included_count
+    end
+    self.included_count = 0
+
+    def self.included(_base)
+      self.included_count += 1
+    end
+
+    def current_user
+      HostSession.user
+    end
+  end
+
+  STORAGE = "movies_index"
+
+  def setup
+    @orig_concerns = Bali.engine_controller_concerns
+    @orig_owner = Bali.saved_views_owner
+    # El default real del engine — el que devuelve nil cuando nadie enseñó current_user.
+    Bali.saved_views_owner = ->(controller) { controller.try(:current_user) }
+    HostSession.user = User.create!(name: "Ana")
+  end
+
+  def teardown
+    Bali.engine_controller_concerns = @orig_concerns
+    Bali.saved_views_owner = @orig_owner
+    # Ruby no des-incluye módulos: HostSession queda en los ancestors del controller para
+    # el resto de la suite. Con `user` en nil, `current_user` vuelve a devolver nil y el
+    # comportamiento observable de los demás tests no cambia.
+    HostSession.user = nil
+  end
+
+  def test_an_injected_concern_teaches_current_user_to_the_engine_controllers
+    Bali.engine_controller_concerns = [ HostSession ]
+    Rails.application.reloader.prepare!
+
+    assert_operator Bali::ApplicationController, :<, HostSession
+
+    assert_difference "Bali::SavedView.count", 1 do
+      post bali.saved_views_path(storage_id: STORAGE), params: {
+        name: "Mías", payload: { "attributes" => {} }.to_json
+      }
+    end
+    assert_response :redirect
+    assert_equal HostSession.user, Bali::SavedView.last.owner
+  end
+
+  def test_assignment_alone_does_not_include_until_to_prepare_runs
+    probe = Module.new
+    Bali.engine_controller_concerns = [ probe ]
+
+    refute_operator Bali::ApplicationController, :<, probe
+
+    Rails.application.reloader.prepare!
+
+    assert_operator Bali::ApplicationController, :<, probe
+  end
+
+  def test_the_include_is_idempotent_across_repeated_to_prepare_runs
+    counter = Module.new do
+      @included_count = 0
+
+      def self.included(_base)
+        @included_count += 1
+      end
+
+      def self.included_count
+        @included_count
+      end
+    end
+    Bali.engine_controller_concerns = [ counter ]
+
+    2.times { Rails.application.reloader.prepare! }
+
+    assert_equal 1, counter.included_count
+  end
+end


### PR DESCRIPTION
## Qué hace

Refs #710 — primer PR del cluster documents-engine (el punto de extensión va antes de #706-#709 para que todo controller nuevo nazca integrado).

- **`Bali.engine_controller_concerns`** (`lib/bali.rb`): array de módulos, default `[]`. En un `to_prepare` propio del engine (`lib/bali/engine.rb`), cada módulo se incluye en `Bali::ApplicationController` — y por herencia en todos los controllers del engine de una vez — con guard de idempotencia (`unless Bali::ApplicationController < concern`), sobreviviendo reloads en development. Rails corre `:run_prepare_callbacks` antes de `:eager_load!`, así que las subclases heredan lo que el concern registre en la base.
- **`docs/guides/engines.md`** (nueva, enlazada desde el README): el gotcha de `isolate_namespace` en UN solo lugar (hoy vive repetido en initializers de las apps), la doctrina "el gate real son las lambdas `Bali.*_authorize`" (el concern inyectado es identidad, no acceso), el timing del array, la advertencia de before_actions activos (redirect a login tapando los 403 del engine), la receta bali-auth (`include BaliAuth::Authentication` + `allow_unauthenticated_access`) y la variante sin bali-auth.
- **Tests** (`test/requests/engine_controller_concerns_test.rb`): un concern de prueba inyectado por config enseña `current_user` y el default de `Bali.saved_views_owner` lo ve (round-trip real por `POST bali.saved_views_path`); la asignación sola no incluye hasta el `to_prepare`; la inclusión es idempotente tras doble `prepare!` (módulo plano con contador en su hook `included`).

## Qué NO entra (a propósito)

- Hook imperativo `Bali.configure_engine_controller`: dos APIs para lo mismo; el array + módulos con `included` cubre todos los casos (spec §710).
- PR a bali-auth (`BaliAuth::EngineAuthentication`): va DESPUÉS de que este PR mergee; mientras, la guía documenta el wrapper de 5 líneas que escribe el host.
- Migración del initializer de afal-apps: PR de validación en su repo, tras el merge.

## Verificación

- `bundle exec rails test test/requests/engine_controller_concerns_test.rb` — 3 runs, 0 failures.
- `test/requests/saved_views_test.rb` + el nuevo en el mismo proceso (orden compartido, sin contaminación) — 10 runs, 0 failures.
- Rubocop limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)