### PR TITLE
feat(block_note): libs puras Bali::BlockNote::Text/Diff/Chunker + dependencia diff-lcs (#708 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v3.0.0] - 2026-08-05
+### Added
+
+- **`Bali::BlockNote::Text`, `Bali::BlockNote::Diff` and `Bali::BlockNote::Chunker` — pure-Ruby BlockNote content libs** (#708, PR 1 of 2). Ported from gobierno-corporativo's `Document::BlockNoteText` / `Document::ContentDiff` / `Document::Chunker` and generalized under the engine so every host shares one walker for BlockNote JSON:
+  - `Text` extracts plain text from BlockNote block structures — inline `text` and `entityReference` nodes, table blocks in both the legacy `tableRow` and current `tableContent` shapes, nested children — and `Text.normalize` accepts Array/Hash/JSON-string content, unwrapping legacy v1 `blockGroup`/`blockContainer` layers.
+  - `Diff` compares two contents at section level (`changed_sections` / `summary`, grouped by heading with an id-stripped structural fingerprint) and at block level (`annotated_blocks` marks each block `added`/`removed`/`modified`/`unchanged` by BlockNote UUID; modified blocks carry `_diff_spans` from a word-level LCS diff). Removed blocks and sections appear inline at their original position.
+  - `Chunker` splits a document into heading-delimited chunks for search indexing / RAG (target 1600 chars, 300-char overlap, ~4 chars/token estimate). Embeddings and vector storage stay host-side on purpose — no pgvector in the engine.
+
+  The libs live in `app/lib/` (autoloaded, no new eager-load path) and are deliberately free of ActiveSupport core extensions: they load and run under plain Ruby. New runtime dependency: `diff-lcs` (~> 1.5, MIT, no transitive deps) for the word-level spans. Entity-reference extraction, registry and controller arrive in PR 2.
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to
 the stable channel: `3.0` merges into `main`, `main` becomes the v3 line, and the next

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   specs:
     bali_view_components (3.0.0)
       caxlsx
+      diff-lcs (~> 1.5)
       lucide-rails (>= 0.3.0, < 0.8)
       rails (>= 8.1, < 9.0)
       ransack
@@ -130,6 +131,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     device_detector (1.1.3)
+    diff-lcs (1.6.2)
     dotenv (3.2.0)
     drb (2.2.3)
     erb (6.0.6)
@@ -437,6 +439,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   device_detector (1.1.3) sha256=c5fe3fe42cab2e8aa01f193b2074b8bb1510373ce47127206f28c7dea75a9c79
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5

--- a/app/lib/bali/block_note/chunker.rb
+++ b/app/lib/bali/block_note/chunker.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Bali
+  module BlockNote
+    # Splits a BlockNote JSON document into semantic chunks respecting heading
+    # structure. Useful for search indexing and RAG pipelines — embeddings and
+    # vector storage stay host-side (this lib is pure Ruby, no pgvector).
+    #
+    # Strategy:
+    #   1. Group blocks by heading boundaries — each heading starts a new chunk.
+    #   2. If a group's text exceeds TARGET_CHARS, subdivide with OVERLAP_CHARS
+    #      overlap.
+    #   3. Token count is approximated at 4 chars/token (typical for Spanish
+    #      text).
+    #
+    # Returns an Array of hashes:
+    #   { content: String, section_title: String|nil, position: Integer,
+    #     token_count: Integer }
+    class Chunker
+      TARGET_CHARS  = 1_600  # ~400 tokens at 4 chars/token
+      OVERLAP_CHARS = 300    # ~80 tokens overlap between subdivisions
+
+      def initialize(blocks)
+        @blocks = blocks
+      end
+
+      def call
+        blocks = Bali::BlockNote::Text.normalize(@blocks)
+        return [] if blocks.empty?
+
+        sections = split_into_sections(blocks)
+        chunks = sections.flat_map { |section| subdivide(section) }
+        chunks.each_with_index.map do |chunk, idx|
+          chunk.merge(position: idx)
+        end
+      end
+
+      private
+
+      # Groups blocks into sections delimited by heading blocks.
+      # Returns Array of { title: String|nil, blocks: Array }
+      def split_into_sections(blocks)
+        sections = []
+        current_title = nil
+        current_blocks = []
+
+        blocks.each do |block|
+          if block["type"] == "heading"
+            sections << { title: current_title, blocks: current_blocks } if current_blocks.any?
+            current_title = Bali::BlockNote::Text.extract_text(block)
+            current_blocks = [ block ]
+          else
+            current_blocks << block
+          end
+        end
+
+        sections << { title: current_title, blocks: current_blocks } if current_blocks.any?
+        sections
+      end
+
+      # Subdivides a section into chunks of TARGET_CHARS with OVERLAP_CHARS
+      # overlap when the section text exceeds TARGET_CHARS. Snaps to word
+      # boundaries.
+      def subdivide(section)
+        title = section[:title]
+        text  = Bali::BlockNote::Text.blocks_to_text(section[:blocks])
+
+        return [] if text.empty?
+
+        if text.length <= TARGET_CHARS
+          return [ build_chunk(text, title) ]
+        end
+
+        parts = []
+        start = 0
+
+        while start < text.length
+          target_end = start + TARGET_CHARS
+          slice_end = snap_to_word_boundary(text, target_end)
+          parts << build_chunk(text[start...slice_end], title)
+          break if slice_end >= text.length
+
+          start = slice_end - OVERLAP_CHARS
+        end
+
+        parts
+      end
+
+      def snap_to_word_boundary(text, target_end)
+        return text.length if target_end >= text.length
+
+        pos = text.rindex(" ", target_end)
+        pos && pos > target_end - OVERLAP_CHARS ? pos : target_end
+      end
+
+      def build_chunk(content, section_title)
+        {
+          content: content,
+          section_title: section_title,
+          token_count: estimate_tokens(content)
+        }
+      end
+
+      def estimate_tokens(text)
+        (text.length / 4.0).ceil
+      end
+    end
+  end
+end

--- a/app/lib/bali/block_note/diff.rb
+++ b/app/lib/bali/block_note/diff.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require "diff/lcs"
+require "digest"
+require "json"
+require "set"
+
+module Bali
+  module BlockNote
+    # Computes a diff between two BlockNote JSON content arrays at two
+    # granularities:
+    #
+    # - Section level (changed_sections / summary): groups blocks by heading,
+    #   reports which sections were added, modified, removed, or unchanged.
+    #   Used for badge summaries in diff views.
+    #
+    # - Block level (annotated_blocks): compares individual blocks by their
+    #   BlockNote UUID. Within a modified section, blocks with the same ID are
+    #   marked :unchanged or :modified based on content equality; new IDs are
+    #   :added; removed IDs appear inline at their original position.
+    #
+    #   Modified blocks also carry "_diff_spans" — an array of {type, text}
+    #   hashes from a word-level LCS diff, so a view can show exactly what
+    #   changed inline.
+    #
+    # Pure Ruby (no ActiveSupport, no database). The word-level diff rides the
+    # diff-lcs gem, declared as a dependency of the engine's gemspec.
+    #
+    # Usage:
+    #   diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    #   diff.changed_sections # => [{ heading: "Scope", status: :modified }, ...]
+    #   diff.summary          # => { added: 1, modified: 2, removed: 0, unchanged: 3 }
+    #   diff.annotated_blocks # => blocks with "_diff_status" and optional "_diff_spans"
+    class Diff
+      Section = Data.define(:heading, :level, :blocks, :fingerprint)
+
+      attr_reader :old_content, :new_content
+
+      def initialize(old_content, new_content)
+        @old_content = Bali::BlockNote::Text.normalize(old_content)
+        @new_content = Bali::BlockNote::Text.normalize(new_content)
+      end
+
+      # Returns an array of hashes describing each section's change status.
+      # Each hash: { heading:, level:, status: :added | :removed | :modified | :unchanged }
+      def changed_sections
+        @changed_sections ||= compute_changed_sections
+      end
+
+      def summary
+        @summary ||= compute_summary
+      end
+
+      def changes?
+        changed_sections.any? { |s| s[:status] != :unchanged }
+      end
+
+      # Returns annotated blocks for rendering: each block gets a
+      # "_diff_status" key ("added", "removed", "modified", or "unchanged").
+      # Modified blocks also carry "_diff_spans" for word-level inline diff
+      # rendering. Removed blocks/sections appear inline at their original
+      # position.
+      def annotated_blocks
+        @annotated_blocks ||= compute_annotated_blocks
+      end
+
+      private
+
+      def old_sections
+        @old_sections ||= extract_sections(old_content)
+      end
+
+      def new_sections
+        @new_sections ||= extract_sections(new_content)
+      end
+
+      def extract_sections(blocks)
+        sections = []
+        current_heading = nil
+        current_level = 0
+        current_blocks = []
+
+        blocks.each do |block|
+          if block["type"] == "heading"
+            # Save previous section
+            if current_heading || current_blocks.any?
+              sections << build_section(current_heading, current_level, current_blocks)
+            end
+            current_heading = extract_text(block)
+            current_level = block.dig("props", "level") || 2
+            current_blocks = [ block ]
+          else
+            current_blocks << block
+          end
+        end
+
+        # Final section
+        if current_heading || current_blocks.any?
+          sections << build_section(current_heading, current_level, current_blocks)
+        end
+
+        sections
+      end
+
+      def build_section(heading, level, blocks)
+        Section.new(heading: heading || "", level: level, blocks: blocks,
+                    fingerprint: section_fingerprint(blocks))
+      end
+
+      # Structural fingerprint that hashes the section's JSON shape with block
+      # IDs stripped. ID-stripping keeps two logically-identical sections equal
+      # even when BlockNote regenerates UUIDs; preserving the rest of the shape
+      # catches edits that share visible text but differ structurally — e.g.
+      # swapping a plain word for an `entityReference` chip of the same name.
+      def section_fingerprint(blocks)
+        Digest::SHA256.hexdigest(JSON.generate(structural_signature(blocks)))
+      end
+
+      def structural_signature(value)
+        case value
+        when Array
+          value.map { |v| structural_signature(v) }
+        when Hash
+          value.each_with_object({}) do |(k, v), out|
+            next if k == "id" || k.start_with?("_diff")
+            out[k] = structural_signature(v)
+          end
+        else
+          value
+        end
+      end
+
+      def extract_text(block)
+        Bali::BlockNote::Text.extract_text(block)
+      end
+
+      def compute_changed_sections
+        # Use a queue per heading to handle duplicate section headings without
+        # data loss.
+        old_queue = old_sections.each_with_object({}) do |sec, hash|
+          (hash[sec.heading] ||= []) << sec
+        end
+
+        result = []
+
+        new_sections.each do |new_sec|
+          old_sec = old_queue[new_sec.heading]&.shift
+          status = if old_sec.nil?
+            :added
+          elsif old_sec.fingerprint == new_sec.fingerprint
+            :unchanged
+          else
+            :modified
+          end
+          result << { heading: new_sec.heading, level: new_sec.level, status: status }
+        end
+
+        # Remaining entries are old sections with no counterpart in new
+        # (removed or extra duplicates).
+        old_queue.each_value do |remaining|
+          remaining.each do |old_sec|
+            result << { heading: old_sec.heading, level: old_sec.level, status: :removed }
+          end
+        end
+
+        result
+      end
+
+      def compute_summary
+        counts = changed_sections.group_by { |s| s[:status] }.transform_values(&:size)
+        { added: counts.fetch(:added, 0),
+          modified: counts.fetch(:modified, 0),
+          removed: counts.fetch(:removed, 0),
+          unchanged: counts.fetch(:unchanged, 0) }
+      end
+
+      def compute_annotated_blocks
+        # Queue per heading handles duplicate headings without silently
+        # dropping sections.
+        old_lookup = old_sections.each_with_object({}) do |sec, hash|
+          (hash[sec.heading] ||= []) << sec
+        end
+        new_headings = new_sections.map(&:heading).to_set
+
+        removed_before, trailing_removed =
+          group_removed_before(old_sections, new_headings, &:heading)
+
+        annotated = []
+
+        new_sections.each do |new_sec|
+          (removed_before[new_sec.heading] || []).each do |removed_sec|
+            removed_sec.blocks.each { |b| annotated << b.merge("_diff_status" => "removed") }
+          end
+
+          old_sec = old_lookup[new_sec.heading]&.shift
+          if old_sec.nil?
+            new_sec.blocks.each { |b| annotated << b.merge("_diff_status" => "added") }
+          elsif old_sec.fingerprint == new_sec.fingerprint
+            new_sec.blocks.each { |b| annotated << b.merge("_diff_status" => "unchanged") }
+          else
+            annotated.concat(annotate_modified_blocks(old_sec.blocks, new_sec.blocks))
+          end
+        end
+
+        # Extra occurrences of headings that exist in new but had more copies
+        # in old. Non-surviving headings are already covered by removed_before
+        # / trailing_removed.
+        old_lookup.each do |heading, remaining|
+          next unless new_headings.include?(heading)
+          remaining.each do |sec|
+            sec.blocks.each { |b| annotated << b.merge("_diff_status" => "removed") }
+          end
+        end
+
+        trailing_removed.each do |removed_sec|
+          removed_sec.blocks.each { |b| annotated << b.merge("_diff_status" => "removed") }
+        end
+
+        annotated
+      end
+
+      # Compares two block lists by block ID to produce fine-grained per-block
+      # annotations. Removed blocks are inserted inline at their original
+      # position in the old list. Modified blocks carry "_diff_spans" for
+      # word-level inline rendering.
+      def annotate_modified_blocks(old_blocks, new_blocks)
+        old_by_id = old_blocks.select { |b| present_id?(b) }.to_h { |b| [ b["id"], b ] }
+        new_ids   = new_blocks.filter_map { |b| b["id"] if present_id?(b) }.to_set
+
+        removed_before, trailing_removed =
+          group_removed_before(old_blocks, new_ids) { |b| b["id"] }
+
+        result = []
+
+        new_blocks.each do |block|
+          (removed_before[block["id"]] || []).each do |removed_block|
+            result << removed_block.merge("_diff_status" => "removed")
+          end
+
+          old_block = old_by_id[block["id"]]
+          if old_block.nil?
+            result << block.merge("_diff_status" => "added")
+          elsif block_content_equal?(old_block, block)
+            result << block.merge("_diff_status" => "unchanged")
+          else
+            result << block.merge(
+              "_diff_status" => "modified",
+              "_diff_spans"  => word_diff_spans(old_block, block)
+            )
+          end
+        end
+
+        trailing_removed.each { |b| result << b.merge("_diff_status" => "removed") }
+
+        result
+      end
+
+      def present_id?(block)
+        !block["id"].to_s.empty?
+      end
+
+      # Walks +items+ in order and groups removed items (those whose key is not
+      # in +surviving_keys+) immediately before the next surviving item.
+      # The block extracts the key from each item.
+      #
+      # Returns [removed_before_hash, trailing_array] where:
+      #   removed_before_hash[key] = items removed just before that surviving key
+      #   trailing_array           = items removed after the last surviving item
+      def group_removed_before(items, surviving_keys)
+        pending        = []
+        removed_before = {}
+
+        items.each do |item|
+          key = yield(item)
+          if surviving_keys.include?(key)
+            removed_before[key] = pending if pending.any?
+            pending = []
+          else
+            pending << item
+          end
+        end
+
+        [ removed_before, pending ]
+      end
+
+      def block_content_equal?(block_a, block_b)
+        block_a["type"]     == block_b["type"] &&
+          block_a["content"]  == block_b["content"] &&
+          block_a["props"]    == block_b["props"] &&
+          block_a["children"] == block_b["children"]
+      end
+
+      # Returns an array of diff spans for word-level inline rendering.
+      # Each span: { "type" => "unchanged"|"removed"|"added", "text" => "..." }
+      def word_diff_spans(old_block, new_block)
+        old_tokens = tokenize(plain_block_text(old_block))
+        new_tokens = tokenize(plain_block_text(new_block))
+
+        spans = []
+        ::Diff::LCS.sdiff(old_tokens, new_tokens).each do |change|
+          case change.action
+          when "=" then spans << { "type" => "unchanged", "text" => change.new_element }
+          when "+" then spans << { "type" => "added",     "text" => change.new_element }
+          when "-" then spans << { "type" => "removed",   "text" => change.old_element }
+          when "!"
+            spans << { "type" => "removed", "text" => change.old_element }
+            spans << { "type" => "added",   "text" => change.new_element }
+          end
+        end
+
+        merge_consecutive_spans(spans)
+      end
+
+      def plain_block_text(block)
+        Bali::BlockNote::Text.extract_text(block)
+      end
+
+      def tokenize(text)
+        text.scan(/\S+|\s+/)
+      end
+
+      def merge_consecutive_spans(spans)
+        spans.each_with_object([]) do |span, acc|
+          if acc.last&.dig("type") == span["type"]
+            acc.last["text"] += span["text"]
+          else
+            acc << span.dup
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/bali/block_note/text.rb
+++ b/app/lib/bali/block_note/text.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Bali
+  module BlockNote
+    # Shared BlockNote JSON text extraction. Single source of truth for
+    # converting BlockNote block structures into plain text.
+    #
+    # Pure Ruby on purpose: no ActiveSupport core extensions and no database,
+    # so hosts can lean on it from models, jobs, or scripts alike. Diffing
+    # (Bali::BlockNote::Diff) and chunking (Bali::BlockNote::Chunker) share
+    # this extractor — anything user-visible must contribute here, or the
+    # diff misses edits whose text survives (e.g. a plain word swapped for an
+    # entityReference chip of the same name).
+    module Text
+      module_function
+
+      # Extracts plain text from a single BlockNote block (heading, paragraph,
+      # etc.). Covers inline `text` and `entityReference` nodes, table blocks
+      # (both `tableRow` and `tableContent` shapes), and recursively descends
+      # into nested children.
+      def extract_text(block)
+        inline = inline_text(block["content"])
+        children = Array(block["children"])
+                     .map { |b| extract_text(b) }
+                     .join(" ")
+        cells = table_cell_text(block)
+        [ inline, children, *cells ].reject { |part| part.strip.empty? }.join(" ")
+      end
+
+      # Inline content can be an Array of inline nodes (paragraph, heading) or
+      # a Hash wrapper such as `{ "type" => "tableContent", "rows" => [...] }`
+      # for the `table` block shape. Hash wrappers are handled in
+      # `table_cell_text`, so this only walks Array shapes here.
+      def inline_text(inline)
+        return "" unless inline.is_a?(Array)
+
+        inline.filter_map { |node| inline_node_text(node) }.join
+      end
+
+      INLINE_TEXT_EXTRACTORS = {
+        "text"            => ->(node) { node["text"] },
+        "entityReference" => ->(node) { node.dig("props", "entityName") }
+      }.freeze
+
+      def inline_node_text(node)
+        return nil unless node.is_a?(Hash)
+
+        extractor = INLINE_TEXT_EXTRACTORS[node["type"]]
+        extractor&.call(node)
+      end
+
+      # Pulls plain text out of every cell in a table block, supporting both:
+      #   - Legacy `tableRow` shape: block["cells"] = [[ inline_node, ... ], ...]
+      #   - Current `table` block:   block["content"] = { type: "tableContent",
+      #       rows: [{ cells: [{ content: [...] }] }] }
+      def table_cell_text(block)
+        case block["type"]
+        when "tableRow"
+          Array(block["cells"]).flat_map { |row| Array(row).filter_map { |c| inline_node_text(c) } }
+        when "table"
+          table = block["content"]
+          return [] unless table.is_a?(Hash) && table["type"] == "tableContent"
+
+          Array(table["rows"]).flat_map { |row|
+            Array(row["cells"]).map { |cell|
+              cell_content = cell.is_a?(Hash) ? cell["content"] : cell
+              inline_text(cell_content)
+            }
+          }
+        else
+          []
+        end
+      end
+
+      # Converts an array of BlockNote blocks into a single plain text string.
+      def blocks_to_text(blocks)
+        Array(blocks).map { |b| extract_text(b) }
+                     .join(" ")
+                     .gsub(/[[:space:]]+/, " ")
+                     .strip
+      end
+
+      # Normalizes BlockNote content from various formats (Array, Hash, String)
+      # into an Array of blocks. Handles the legacy BlockNote v1 format
+      # (doc > blockGroup > blockContainer > block) by unwrapping container
+      # layers to produce a flat array of content blocks.
+      def normalize(content)
+        blocks = case content
+        when Array  then content
+        when Hash   then content.fetch("content", [])
+        when String then normalize(JSON.parse(content))
+        else []
+        end
+
+        unwrap_containers(blocks)
+      rescue JSON::ParserError => e
+        warn_malformed(e)
+        []
+      end
+
+      WRAPPER_TYPES = %w[blockGroup blockContainer].freeze
+
+      # Recursively unwraps blockGroup/blockContainer wrappers to extract
+      # content blocks.
+      def unwrap_containers(blocks)
+        blocks.flat_map do |block|
+          if WRAPPER_TYPES.include?(block["type"])
+            unwrap_containers(Array(block["content"]))
+          else
+            block
+          end
+        end
+      end
+
+      def warn_malformed(error)
+        return unless defined?(Rails) && Rails.respond_to?(:logger)
+
+        Rails.logger&.warn("[Bali::BlockNote::Text] Malformed JSON content: #{error.message}")
+      end
+      private_class_method :warn_malformed
+    end
+  end
+end

--- a/bali_view_component.gemspec
+++ b/bali_view_component.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "caxlsx"
+  # Word-level LCS diff for Bali::BlockNote::Diff (MIT, no transitive deps).
+  spec.add_dependency "diff-lcs", "~> 1.5"
   # Capped: icon resolution and several legacy spellings ride the alias SVGs
   # lucide-rails still ships, and an uncapped bump that drops them turns those
   # names into IconNotAvailable — a 500 — with no change on the host's side.

--- a/test/bali/block_note/chunker_test.rb
+++ b/test/bali/block_note/chunker_test.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliBlockNoteChunkerTest < ActiveSupport::TestCase
+  HEADING_BLOCK = ->(id, text, level: 2) {
+    {
+      "id" => id,
+      "type" => "heading",
+      "props" => { "textColor" => "default", "textAlignment" => "left",
+                   "backgroundColor" => "default", "level" => level },
+      "content" => [ { "type" => "text", "text" => text, "styles" => {} } ],
+      "children" => []
+    }
+  }
+
+  PARAGRAPH_BLOCK = ->(id, text) {
+    {
+      "id" => id,
+      "type" => "paragraph",
+      "props" => { "textColor" => "default", "textAlignment" => "left", "backgroundColor" => "default" },
+      "content" => [ { "type" => "text", "text" => text, "styles" => {} } ],
+      "children" => []
+    }
+  }
+
+  # Chunking respects document sections
+
+  test "splits document into chunks by heading sections" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Establecer los lineamientos para el proceso."),
+      HEADING_BLOCK.call("h2", "Alcance"),
+      PARAGRAPH_BLOCK.call("p2", "Aplica a todas las áreas de la organización."),
+      HEADING_BLOCK.call("h3", "Procedimiento"),
+      PARAGRAPH_BLOCK.call("p3", "Seguir los pasos indicados en este documento.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_equal 3, chunks.length
+  end
+
+  test "each chunk corresponds to a natural document section" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Establecer los lineamientos para el proceso."),
+      HEADING_BLOCK.call("h2", "Alcance"),
+      PARAGRAPH_BLOCK.call("p2", "Aplica a todas las áreas de la organización.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_includes chunks[0][:content], "Objetivo"
+    assert_includes chunks[1][:content], "Alcance"
+  end
+
+  test "preserves section title as metadata" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Texto del objetivo.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_equal "Objetivo", chunks[0][:section_title]
+  end
+
+  test "assigns sequential positions starting from zero" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Primero."),
+      HEADING_BLOCK.call("h2", "Alcance"),
+      PARAGRAPH_BLOCK.call("p2", "Segundo.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_equal 0, chunks[0][:position]
+    assert_equal 1, chunks[1][:position]
+  end
+
+  test "includes token_count for each chunk" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Texto breve.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert chunks[0][:token_count] > 0
+  end
+
+  # Optimal chunk sizes
+
+  test "long sections are subdivided with overlap" do
+    # Build a section with ~2400 chars to force subdivision (target ~1600 chars)
+    long_text = "Esta es una oración de prueba que se repite para generar contenido suficiente. " * 30
+    blocks = [
+      HEADING_BLOCK.call("h1", "Sección Larga"),
+      PARAGRAPH_BLOCK.call("p1", long_text)
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert chunks.length > 1, "Long section should be split into multiple chunks"
+  end
+
+  test "subdivided chunks share overlap content" do
+    long_text = "Esta es una oración de prueba que se repite para generar contenido suficiente. " * 30
+    blocks = [
+      HEADING_BLOCK.call("h1", "Sección Larga"),
+      PARAGRAPH_BLOCK.call("p1", long_text)
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert chunks.length >= 2
+    # The second chunk starts OVERLAP_CHARS before the end of the first chunk,
+    # so its opening must be a literal substring of the first chunk.
+    assert_includes chunks[0][:content], chunks[1][:content][0, 100],
+                    "second chunk must start with content from the end of the first chunk"
+  end
+
+  test "every subdivided chunk keeps the section title" do
+    long_text = "Contenido repetido para forzar la subdivisión del texto en partes. " * 40
+    blocks = [
+      HEADING_BLOCK.call("h1", "Sección Larga"),
+      PARAGRAPH_BLOCK.call("p1", long_text)
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert chunks.length >= 2
+    chunks.each { |chunk| assert_equal "Sección Larga", chunk[:section_title] }
+  end
+
+  test "chunk sizes stay near the target" do
+    long_text = "Palabras que suman contenido para el verificador de tamaños de chunk. " * 50
+    blocks = [ PARAGRAPH_BLOCK.call("p1", long_text) ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    chunks.each do |chunk|
+      assert chunk[:content].length <= Bali::BlockNote::Chunker::TARGET_CHARS + Bali::BlockNote::Chunker::OVERLAP_CHARS,
+             "chunk of #{chunk[:content].length} chars exceeds target + overlap"
+    end
+  end
+
+  # Edge cases
+
+  test "returns empty array for nil content" do
+    chunks = Bali::BlockNote::Chunker.new(nil).call
+    assert_equal [], chunks
+  end
+
+  test "returns empty array for empty blocks" do
+    chunks = Bali::BlockNote::Chunker.new([]).call
+    assert_equal [], chunks
+  end
+
+  test "returns empty array for invalid JSON string" do
+    chunks = Bali::BlockNote::Chunker.new("not json{{{").call
+    assert_equal [], chunks
+  end
+
+  test "accepts a JSON string of blocks" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Texto del objetivo.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks.to_json).call
+
+    assert_equal 1, chunks.length
+    assert_equal "Objetivo", chunks[0][:section_title]
+  end
+
+  test "accepts a Hash with a content key" do
+    blocks = [
+      HEADING_BLOCK.call("h1", "Objetivo"),
+      PARAGRAPH_BLOCK.call("p1", "Texto del objetivo.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new({ "content" => blocks }).call
+
+    assert_equal 1, chunks.length
+  end
+
+  test "skips sections whose text is empty" do
+    blocks = [
+      PARAGRAPH_BLOCK.call("p1", ""),
+      HEADING_BLOCK.call("h1", "Con texto"),
+      PARAGRAPH_BLOCK.call("p2", "Contenido real.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_equal 1, chunks.length
+    assert_equal "Con texto", chunks[0][:section_title]
+  end
+
+  test "handles content with no headings as single chunk" do
+    blocks = [
+      PARAGRAPH_BLOCK.call("p1", "Párrafo sin encabezado."),
+      PARAGRAPH_BLOCK.call("p2", "Otro párrafo.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_equal 1, chunks.length
+    assert_nil chunks[0][:section_title]
+  end
+
+  test "section_title is nil for chunk with no preceding heading" do
+    blocks = [
+      PARAGRAPH_BLOCK.call("p1", "Introducción sin encabezado.")
+    ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    assert_nil chunks[0][:section_title]
+  end
+
+  test "token_count approximates character count divided by 4" do
+    text = "a" * 400
+    blocks = [ PARAGRAPH_BLOCK.call("p1", text) ]
+
+    chunks = Bali::BlockNote::Chunker.new(blocks).call
+
+    # ~100 tokens for 400 chars (4 chars/token approximation for Spanish)
+    assert_in_delta 100, chunks[0][:token_count], 20
+  end
+end

--- a/test/bali/block_note/diff_test.rb
+++ b/test/bali/block_note/diff_test.rb
@@ -1,0 +1,557 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliBlockNoteDiffTest < ActiveSupport::TestCase
+  def build_block(type, text, level: nil)
+    props = { "textColor" => "default", "textAlignment" => "left", "backgroundColor" => "default" }
+    props["level"] = level if type == "heading"
+    {
+      "id" => SecureRandom.uuid,
+      "type" => type,
+      "props" => props,
+      "content" => [ { "type" => "text", "text" => text, "styles" => {} } ],
+      "children" => []
+    }
+  end
+
+  def sample_content
+    [
+      build_block("heading", "Objetivo", level: 2),
+      build_block("paragraph", "Establecer los lineamientos para compras."),
+      build_block("heading", "Alcance", level: 2),
+      build_block("paragraph", "Aplica a todas las areas.")
+    ]
+  end
+
+  test "detects no changes when content is identical" do
+    diff = Bali::BlockNote::Diff.new(sample_content, sample_content)
+
+    assert_not diff.changes?
+    assert_equal 0, diff.summary[:added]
+    assert_equal 0, diff.summary[:modified]
+    assert_equal 0, diff.summary[:removed]
+    assert_equal 2, diff.summary[:unchanged]
+  end
+
+  test "detects added sections" do
+    old_content = sample_content
+    new_content = sample_content + [
+      build_block("heading", "Responsables", level: 2),
+      build_block("paragraph", "El jefe de compras es responsable.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+
+    assert diff.changes?
+    assert_equal 1, diff.summary[:added]
+    assert_equal 2, diff.summary[:unchanged]
+
+    added = diff.changed_sections.find { |s| s[:status] == :added }
+    assert_equal "Responsables", added[:heading]
+  end
+
+  test "detects modified sections" do
+    old_content = sample_content
+    new_content = [
+      build_block("heading", "Objetivo", level: 2),
+      build_block("paragraph", "NUEVO texto del objetivo modificado."),
+      build_block("heading", "Alcance", level: 2),
+      build_block("paragraph", "Aplica a todas las areas.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+
+    assert diff.changes?
+    assert_equal 1, diff.summary[:modified]
+    assert_equal 1, diff.summary[:unchanged]
+
+    modified = diff.changed_sections.find { |s| s[:status] == :modified }
+    assert_equal "Objetivo", modified[:heading]
+  end
+
+  test "detects removed sections" do
+    old_content = sample_content
+    new_content = [
+      build_block("heading", "Objetivo", level: 2),
+      build_block("paragraph", "Establecer los lineamientos para compras.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+
+    assert diff.changes?
+    assert_equal 1, diff.summary[:removed]
+    assert_equal 1, diff.summary[:unchanged]
+
+    removed = diff.changed_sections.find { |s| s[:status] == :removed }
+    assert_equal "Alcance", removed[:heading]
+  end
+
+  test "reports section level from heading props" do
+    old_content = []
+    new_content = [
+      build_block("heading", "Detalle", level: 3),
+      build_block("paragraph", "Contenido.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    section = diff.changed_sections.find { |s| s[:heading] == "Detalle" }
+
+    assert_equal 3, section[:level]
+  end
+
+  test "handles nil content gracefully" do
+    diff = Bali::BlockNote::Diff.new(nil, nil)
+
+    assert_not diff.changes?
+    assert_equal({ added: 0, modified: 0, removed: 0, unchanged: 0 }, diff.summary)
+  end
+
+  test "handles empty arrays" do
+    diff = Bali::BlockNote::Diff.new([], [])
+
+    assert_not diff.changes?
+  end
+
+  test "treats all content as new when old is empty" do
+    diff = Bali::BlockNote::Diff.new([], sample_content)
+
+    assert diff.changes?
+    assert_equal 2, diff.summary[:added]
+  end
+
+  test "annotated_blocks includes diff status" do
+    base = sample_content
+    new_content = base + [
+      build_block("heading", "Nuevo", level: 2),
+      build_block("paragraph", "Contenido nuevo.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new(base, new_content)
+    blocks = diff.annotated_blocks
+
+    unchanged_blocks = blocks.select { |b| b["_diff_status"] == "unchanged" }
+    added_blocks = blocks.select { |b| b["_diff_status"] == "added" }
+
+    assert_equal 4, unchanged_blocks.size
+    assert_equal 2, added_blocks.size
+  end
+
+  test "handles legacy hash format content" do
+    legacy = { "content" => sample_content }
+    diff = Bali::BlockNote::Diff.new(legacy, sample_content)
+
+    assert_not diff.changes?
+  end
+
+  test "handles JSON string content" do
+    json_str = sample_content.to_json
+    diff = Bali::BlockNote::Diff.new(json_str, sample_content)
+
+    assert_not diff.changes?
+  end
+
+  test "exposes normalized old_content and new_content" do
+    diff = Bali::BlockNote::Diff.new(sample_content.to_json, nil)
+
+    assert_equal 4, diff.old_content.size
+    assert_equal [], diff.new_content
+  end
+
+  # --- Block-level diff ---
+
+  test "unchanged blocks within a modified section are not marked as modified" do
+    heading  = build_block("heading", "Objetivo", level: 2)
+    para_a   = build_block("paragraph", "Primer párrafo sin cambios.")
+    para_b   = build_block("paragraph", "Segundo párrafo que sí cambia.")
+    para_c   = build_block("paragraph", "Tercer párrafo sin cambios.")
+
+    old_content = [ heading, para_a, para_b, para_c ]
+
+    modified_b = para_b.merge("content" => [ { "type" => "text", "text" => "Segundo párrafo MODIFICADO.", "styles" => {} } ])
+    new_content = [ heading, para_a, modified_b, para_c ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    blocks = diff.annotated_blocks
+
+    statuses = blocks.each_with_object({}) { |b, h| h[b["id"]] = b["_diff_status"] }
+
+    assert_equal "unchanged", statuses[heading["id"]]
+    assert_equal "unchanged", statuses[para_a["id"]], "para_a should be unchanged"
+    assert_equal "modified",  statuses[modified_b["id"]], "para_b should be modified"
+    assert_equal "unchanged", statuses[para_c["id"]], "para_c should be unchanged"
+  end
+
+  test "new block inserted into existing section is annotated as added" do
+    heading = build_block("heading", "Alcance", level: 2)
+    para_a  = build_block("paragraph", "Aplica a todas las áreas.")
+    para_new = build_block("paragraph", "Párrafo nuevo agregado.")
+
+    old_content = [ heading, para_a ]
+    new_content = [ heading, para_a, para_new ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    blocks = diff.annotated_blocks
+
+    added = blocks.select { |b| b["_diff_status"] == "added" }
+    assert_equal 1, added.size
+    assert_equal para_new["id"], added.first["id"]
+  end
+
+  test "block removed from section is included as removed" do
+    heading = build_block("heading", "Alcance", level: 2)
+    para_a  = build_block("paragraph", "Primer párrafo.")
+    para_b  = build_block("paragraph", "Párrafo que se elimina.")
+
+    old_content = [ heading, para_a, para_b ]
+    new_content = [ heading, para_a ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    blocks = diff.annotated_blocks
+
+    removed = blocks.select { |b| b["_diff_status"] == "removed" }
+    assert_equal 1, removed.size
+    assert_equal para_b["id"], removed.first["id"]
+  end
+
+  test "block with same id and same content is unchanged even when section has other changes" do
+    heading  = build_block("heading", "Objetivo", level: 2)
+    stable   = build_block("paragraph", "Este párrafo no cambia nunca.")
+    changing = build_block("paragraph", "Este párrafo cambia.")
+
+    old_content = [ heading, stable, changing ]
+    modified_changing = changing.merge(
+      "content" => [ { "type" => "text", "text" => "Este párrafo ya cambió.", "styles" => {} } ]
+    )
+    new_content = [ heading, stable, modified_changing ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+
+    stable_block = diff.annotated_blocks.find { |b| b["id"] == stable["id"] }
+    assert_equal "unchanged", stable_block["_diff_status"], "stable block must remain unchanged"
+  end
+
+  test "section level summary is unaffected by block level changes" do
+    heading = build_block("heading", "Objetivo", level: 2)
+    para    = build_block("paragraph", "Texto original.")
+    modified_para = para.merge(
+      "content" => [ { "type" => "text", "text" => "Texto modificado.", "styles" => {} } ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, para ], [ heading, modified_para ])
+
+    assert_equal 1, diff.summary[:modified], "section-level summary should show 1 modified"
+    assert_equal 0, diff.summary[:added]
+    assert_equal 0, diff.summary[:removed]
+  end
+
+  test "removed section appears inline at its original position, not at the end" do
+    sec_a_heading = build_block("heading", "Sección A", level: 2)
+    sec_a_para    = build_block("paragraph", "Contenido A.")
+    sec_b_heading = build_block("heading", "Sección B", level: 2)
+    sec_b_para    = build_block("paragraph", "Contenido B — se elimina.")
+    sec_c_heading = build_block("heading", "Sección C", level: 2)
+    sec_c_para    = build_block("paragraph", "Contenido C.")
+
+    old_content = [ sec_a_heading, sec_a_para, sec_b_heading, sec_b_para, sec_c_heading, sec_c_para ]
+    new_content = [ sec_a_heading, sec_a_para, sec_c_heading, sec_c_para ]
+
+    diff   = Bali::BlockNote::Diff.new(old_content, new_content)
+    blocks = diff.annotated_blocks
+    ids    = blocks.map { |b| b["id"] }
+
+    # Removed section B must appear before section C, not at the end
+    idx_b_heading = ids.index(sec_b_heading["id"])
+    idx_c_heading = ids.index(sec_c_heading["id"])
+
+    assert_not_nil idx_b_heading, "Removed section B heading must be present"
+    assert idx_b_heading < idx_c_heading, "Removed section B must appear before section C"
+    assert_equal "removed", blocks[idx_b_heading]["_diff_status"]
+  end
+
+  test "removed block appears inline at its original position within a section" do
+    heading = build_block("heading", "Sección", level: 2)
+    para_a  = build_block("paragraph", "Párrafo A.")
+    para_b  = build_block("paragraph", "Párrafo B — se elimina.")
+    para_c  = build_block("paragraph", "Párrafo C.")
+
+    old_content = [ heading, para_a, para_b, para_c ]
+    new_content = [ heading, para_a, para_c ]
+
+    diff   = Bali::BlockNote::Diff.new(old_content, new_content)
+    blocks = diff.annotated_blocks
+    ids    = blocks.map { |b| b["id"] }
+
+    idx_b = ids.index(para_b["id"])
+    idx_c = ids.index(para_c["id"])
+
+    assert_not_nil idx_b, "Removed para_b must be present"
+    assert idx_b < idx_c, "Removed para_b must appear before para_c"
+    assert_equal "removed", blocks[idx_b]["_diff_status"]
+  end
+
+  test "modified block carries _diff_spans with word-level changes" do
+    heading  = build_block("heading", "Section", level: 2)
+    old_para = build_block("paragraph", "The quick brown fox.")
+    new_para = old_para.merge(
+      "content" => [ { "type" => "text", "text" => "The quick red fox.", "styles" => {} } ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, old_para ], [ heading, new_para ])
+    modified = diff.annotated_blocks.find { |b| b["_diff_status"] == "modified" }
+
+    assert_not_nil modified, "expected a modified block"
+    spans = modified["_diff_spans"]
+    assert_not_nil spans, "modified block must carry _diff_spans"
+
+    removed_texts = spans.select { |s| s["type"] == "removed" }.map { |s| s["text"] }.join
+    added_texts   = spans.select { |s| s["type"] == "added"   }.map { |s| s["text"] }.join
+
+    assert_includes removed_texts, "brown", "removed span should contain old word"
+    assert_includes added_texts,   "red",   "added span should contain new word"
+  end
+
+  test "consecutive spans of the same type are merged" do
+    heading  = build_block("heading", "Section", level: 2)
+    old_para = build_block("paragraph", "hola mundo")
+    new_para = old_para.merge(
+      "content" => [ { "type" => "text", "text" => "hola querido mundo", "styles" => {} } ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, old_para ], [ heading, new_para ])
+    modified = diff.annotated_blocks.find { |b| b["_diff_status"] == "modified" }
+    spans = modified["_diff_spans"]
+
+    # "querido" and the following space are two consecutive added tokens —
+    # they must collapse into a single span, and no two adjacent spans may
+    # share a type.
+    added = spans.select { |s| s["type"] == "added" }
+    assert_equal 1, added.size, "consecutive added tokens must collapse into one span"
+    assert_equal "querido", added.first["text"].strip
+    spans.each_cons(2) do |a, b|
+      assert_not_equal a["type"], b["type"], "adjacent spans must not share a type: #{spans.inspect}"
+    end
+
+    # Reconstruction invariants: unchanged+removed spans rebuild the old text,
+    # unchanged+added spans rebuild the new text.
+    old_text = spans.reject { |s| s["type"] == "added" }.map { |s| s["text"] }.join
+    new_text = spans.reject { |s| s["type"] == "removed" }.map { |s| s["text"] }.join
+    assert_equal "hola mundo", old_text
+    assert_equal "hola querido mundo", new_text
+  end
+
+  test "unchanged block within a modified section has no _diff_spans" do
+    heading  = build_block("heading", "Section", level: 2)
+    stable   = build_block("paragraph", "This does not change.")
+    changing = build_block("paragraph", "This changes.")
+    modified = changing.merge(
+      "content" => [ { "type" => "text", "text" => "This has changed.", "styles" => {} } ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, stable, changing ], [ heading, stable, modified ])
+    stable_block = diff.annotated_blocks.find { |b| b["id"] == stable["id"] }
+
+    assert_equal "unchanged", stable_block["_diff_status"]
+    assert_nil stable_block["_diff_spans"], "unchanged blocks must not carry _diff_spans"
+  end
+
+  test "handles duplicate section headings without silent data loss" do
+    heading_a   = build_block("heading", "Notas", level: 2)
+    para_a      = build_block("paragraph", "Primera sección de notas.")
+    heading_b   = build_block("heading", "Cuerpo", level: 2)
+    para_b      = build_block("paragraph", "Contenido del cuerpo.")
+    heading_a2  = build_block("heading", "Notas", level: 2)
+    para_a2     = build_block("paragraph", "Segunda sección de notas.")
+
+    old_content = [ heading_a, para_a, heading_b, para_b, heading_a2, para_a2 ]
+
+    # New content keeps only one "Notas" section
+    new_content = [ heading_a, para_a, heading_b, para_b ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+
+    assert_equal 1, diff.summary[:removed], "duplicate removed section must be counted"
+    assert_equal 2, diff.summary[:unchanged]
+
+    removed = diff.changed_sections.select { |s| s[:status] == :removed }
+    assert_equal 1, removed.size
+    assert_equal "Notas", removed.first[:heading]
+  end
+
+  test "extra duplicate section blocks are annotated as removed" do
+    heading_a   = build_block("heading", "Notas", level: 2)
+    para_a      = build_block("paragraph", "Primera sección de notas.")
+    heading_a2  = build_block("heading", "Notas", level: 2)
+    para_a2     = build_block("paragraph", "Segunda sección de notas.")
+
+    old_content = [ heading_a, para_a, heading_a2, para_a2 ]
+    new_content = [ heading_a, para_a ]
+
+    diff = Bali::BlockNote::Diff.new(old_content, new_content)
+    removed_ids = diff.annotated_blocks
+                      .select { |b| b["_diff_status"] == "removed" }
+                      .map { |b| b["id"] }
+
+    assert_includes removed_ids, heading_a2["id"]
+    assert_includes removed_ids, para_a2["id"]
+  end
+
+  # --- Structural granularity: entityReference and table cells ---
+
+  def text_node(text)
+    { "type" => "text", "text" => text, "styles" => {} }
+  end
+
+  def entity_reference_node(name, id: SecureRandom.hex(4), type: "GlossaryTerm")
+    { "type" => "entityReference",
+      "props" => { "entityType" => type, "entityId" => id, "entityName" => name } }
+  end
+
+  def paragraph_with(content)
+    { "id" => SecureRandom.uuid, "type" => "paragraph",
+      "props" => { "textColor" => "default", "textAlignment" => "left", "backgroundColor" => "default" },
+      "content" => content,
+      "children" => [] }
+  end
+
+  def table_block(rows)
+    { "id" => SecureRandom.uuid, "type" => "table",
+      "props" => { "textColor" => "default" },
+      "content" => {
+        "type" => "tableContent",
+        "rows" => rows.map { |cells|
+          { "cells" => cells.map { |c| { "content" => c } } }
+        }
+      },
+      "children" => [] }
+  end
+
+  test "section is :modified when an entityReference is inserted into a paragraph" do
+    heading = build_block("heading", "Glosario", level: 2)
+    para = paragraph_with([ text_node("Sin referencias.") ])
+    para_with_ref = para.merge(
+      "content" => [
+        text_node("Sin referencias. Ver "),
+        entity_reference_node("Cliente prospecto"),
+        text_node(".")
+      ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, para ], [ heading, para_with_ref ])
+
+    assert diff.changes?, "diff should detect the inserted entityReference"
+    assert_equal 1, diff.summary[:modified]
+  end
+
+  test "block is :modified when plain text is replaced by an entityReference of the same visible name" do
+    heading = build_block("heading", "Glosario", level: 2)
+    para_plain = paragraph_with([ text_node("Define el SLA aplicable.") ])
+    para_chip  = para_plain.merge(
+      "content" => [
+        text_node("Define el "),
+        entity_reference_node("SLA"),
+        text_node(" aplicable.")
+      ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, para_plain ], [ heading, para_chip ])
+    annotated = diff.annotated_blocks
+    modified = annotated.find { |b| b["id"] == para_plain["id"] }
+
+    assert_equal "modified", modified["_diff_status"],
+                 "replacing plain text by an entityReference must register as a modification"
+  end
+
+  test "_diff_spans include the entityReference name when a chip replaces plain text" do
+    heading = build_block("heading", "Glosario", level: 2)
+    para_plain = paragraph_with([ text_node("Aplica al cliente prospecto en el flujo.") ])
+    para_chip  = para_plain.merge(
+      "content" => [
+        text_node("Aplica al "),
+        entity_reference_node("cliente prospecto"),
+        text_node(" en el flujo.")
+      ]
+    )
+
+    diff = Bali::BlockNote::Diff.new([ heading, para_plain ], [ heading, para_chip ])
+    modified = diff.annotated_blocks.find { |b| b["_diff_status"] == "modified" }
+
+    assert_not_nil modified
+    spans = modified["_diff_spans"]
+    assert_not_nil spans
+    rendered = spans.map { |s| s["text"] }.join
+    assert_includes rendered, "cliente prospecto"
+  end
+
+  test "table block is :modified when a cell value changes" do
+    heading = build_block("heading", "Tabla", level: 2)
+    old_table = table_block([
+      [ [ text_node("Encabezado A") ], [ text_node("Encabezado B") ] ],
+      [ [ text_node("valor original") ], [ text_node("dato fijo") ] ]
+    ])
+    new_table = old_table.deep_dup
+    new_table["content"]["rows"][1]["cells"][0]["content"] = [ text_node("valor MODIFICADO") ]
+
+    diff = Bali::BlockNote::Diff.new([ heading, old_table ], [ heading, new_table ])
+    modified = diff.annotated_blocks.find { |b| b["id"] == old_table["id"] }
+
+    assert_equal "modified", modified["_diff_status"]
+    assert_equal 1, diff.summary[:modified]
+  end
+
+  test "table block is :modified when a cell text is replaced by an entityReference" do
+    heading = build_block("heading", "Tabla con chip", level: 2)
+    old_table = table_block([
+      [ [ text_node("Riesgo") ], [ text_node("Mitigación") ] ],
+      [ [ text_node("Falla del proveedor") ], [ text_node("activación de plan B") ] ]
+    ])
+    new_table = old_table.deep_dup
+    new_table["content"]["rows"][1]["cells"][1]["content"] = [
+      text_node("activación de "),
+      entity_reference_node("Plan de continuidad"),
+      text_node(".")
+    ]
+
+    diff = Bali::BlockNote::Diff.new([ heading, old_table ], [ heading, new_table ])
+    modified = diff.annotated_blocks.find { |b| b["id"] == old_table["id"] }
+
+    assert_equal "modified", modified["_diff_status"]
+  end
+
+  test "sections with regenerated block ids but identical shape are unchanged" do
+    old_heading = build_block("heading", "Objetivo", level: 2)
+    old_para    = build_block("paragraph", "Texto idéntico.")
+
+    # Same visible structure, new UUIDs (BlockNote regenerates ids on paste).
+    new_heading = old_heading.merge("id" => SecureRandom.uuid)
+    new_para    = old_para.merge("id" => SecureRandom.uuid)
+
+    diff = Bali::BlockNote::Diff.new([ old_heading, old_para ], [ new_heading, new_para ])
+
+    assert_not diff.changes?, "id-only differences must not register as changes"
+  end
+
+  test "handles content without leading heading" do
+    content_without_heading = [
+      build_block("paragraph", "Intro paragraph without a heading."),
+      build_block("paragraph", "Another paragraph."),
+      build_block("heading", "First Section", level: 2),
+      build_block("paragraph", "Section content.")
+    ]
+
+    diff = Bali::BlockNote::Diff.new([], content_without_heading)
+
+    assert diff.changes?
+
+    sections = diff.changed_sections
+    # Should have a section with empty heading for the leading paragraphs
+    untitled = sections.find { |s| s[:heading].empty? }
+    assert_not_nil untitled, "Expected a section with an empty heading for leading paragraphs"
+    assert_equal :added, untitled[:status]
+
+    # And the named section
+    named = sections.find { |s| s[:heading] == "First Section" }
+    assert_not_nil named
+    assert_equal :added, named[:status]
+  end
+end

--- a/test/bali/block_note/text_test.rb
+++ b/test/bali/block_note/text_test.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliBlockNoteTextTest < ActiveSupport::TestCase
+  HEADING = {
+    "id" => "h1", "type" => "heading",
+    "props" => { "textColor" => "default", "textAlignment" => "left",
+                 "backgroundColor" => "default", "level" => 2 },
+    "content" => [ { "type" => "text", "text" => "Objetivo", "styles" => {} } ],
+    "children" => []
+  }.freeze
+
+  PARAGRAPH = {
+    "id" => "p1", "type" => "paragraph",
+    "props" => { "textColor" => "default", "textAlignment" => "left", "backgroundColor" => "default" },
+    "content" => [ { "type" => "text", "text" => "Texto del párrafo.", "styles" => {} } ],
+    "children" => []
+  }.freeze
+
+  TABLE_ROW = {
+    "id" => "tr1", "type" => "tableRow",
+    "cells" => [ [ { "type" => "text", "text" => "Celda 1" }, { "type" => "text", "text" => "Celda 2" } ] ],
+    "content" => [],
+    "children" => []
+  }.freeze
+
+  ENTITY_REFERENCE_BLOCK = {
+    "id" => "p2", "type" => "paragraph",
+    "props" => { "textColor" => "default", "textAlignment" => "left", "backgroundColor" => "default" },
+    "content" => [
+      { "type" => "text", "text" => "Ver el ", "styles" => {} },
+      { "type" => "entityReference",
+        "props" => { "entityType" => "GlossaryTerm", "entityId" => "42", "entityName" => "Cliente prospecto" } },
+      { "type" => "text", "text" => " para más detalles.", "styles" => {} }
+    ],
+    "children" => []
+  }.freeze
+
+  TABLE_CONTENT_BLOCK = {
+    "id" => "tab1", "type" => "table",
+    "props" => { "textColor" => "default" },
+    "content" => {
+      "type" => "tableContent",
+      "rows" => [
+        { "cells" => [
+          { "content" => [ { "type" => "text", "text" => "Cabecera A", "styles" => {} } ] },
+          { "content" => [ { "type" => "text", "text" => "Cabecera B", "styles" => {} } ] }
+        ] },
+        { "cells" => [
+          { "content" => [ { "type" => "text", "text" => "Valor 1", "styles" => {} } ] },
+          { "content" => [ { "type" => "text", "text" => "Valor 2", "styles" => {} } ] }
+        ] }
+      ]
+    },
+    "children" => []
+  }.freeze
+
+  NESTED_BLOCK = {
+    "id" => "n1", "type" => "paragraph",
+    "content" => [ { "type" => "text", "text" => "Padre", "styles" => {} } ],
+    "children" => [
+      {
+        "id" => "n2", "type" => "paragraph",
+        "content" => [ { "type" => "text", "text" => "Hijo", "styles" => {} } ],
+        "children" => []
+      }
+    ]
+  }.freeze
+
+  # extract_text
+
+  test "extracts inline text from a block" do
+    assert_equal "Objetivo", Bali::BlockNote::Text.extract_text(HEADING)
+  end
+
+  test "extracts text from nested children" do
+    assert_equal "Padre Hijo", Bali::BlockNote::Text.extract_text(NESTED_BLOCK)
+  end
+
+  test "extracts text from deeply nested children" do
+    block = {
+      "id" => "n1", "type" => "paragraph",
+      "content" => [ { "type" => "text", "text" => "Nivel 1", "styles" => {} } ],
+      "children" => [
+        { "id" => "n2", "type" => "paragraph",
+          "content" => [ { "type" => "text", "text" => "Nivel 2", "styles" => {} } ],
+          "children" => [
+            { "id" => "n3", "type" => "paragraph",
+              "content" => [ { "type" => "text", "text" => "Nivel 3", "styles" => {} } ],
+              "children" => [] }
+          ] }
+      ]
+    }
+    assert_equal "Nivel 1 Nivel 2 Nivel 3", Bali::BlockNote::Text.extract_text(block)
+  end
+
+  test "extracts text from table row cells" do
+    result = Bali::BlockNote::Text.extract_text(TABLE_ROW)
+    assert_includes result, "Celda 1"
+    assert_includes result, "Celda 2"
+  end
+
+  test "returns empty string for block with no content" do
+    block = { "id" => "e1", "type" => "paragraph", "content" => [], "children" => [] }
+    assert_equal "", Bali::BlockNote::Text.extract_text(block)
+  end
+
+  test "ignores whitespace-only inline text when joining parts" do
+    block = {
+      "id" => "w1", "type" => "paragraph",
+      "content" => [ { "type" => "text", "text" => "   ", "styles" => {} } ],
+      "children" => [
+        { "id" => "w2", "type" => "paragraph",
+          "content" => [ { "type" => "text", "text" => "Solo el hijo", "styles" => {} } ],
+          "children" => [] }
+      ]
+    }
+    assert_equal "Solo el hijo", Bali::BlockNote::Text.extract_text(block)
+  end
+
+  # entityReference inline nodes
+
+  test "includes entityReference entityName when extracting inline text" do
+    result = Bali::BlockNote::Text.extract_text(ENTITY_REFERENCE_BLOCK)
+    assert_includes result, "Cliente prospecto"
+    assert_includes result, "Ver el"
+    assert_includes result, "para más detalles."
+  end
+
+  test "extracts text from a block that is solely an entityReference" do
+    block = {
+      "id" => "p3", "type" => "paragraph",
+      "content" => [
+        { "type" => "entityReference",
+          "props" => { "entityType" => "Document", "entityId" => "7", "entityName" => "POL-001" } }
+      ],
+      "children" => []
+    }
+    assert_equal "POL-001", Bali::BlockNote::Text.extract_text(block)
+  end
+
+  # inline_text / inline_node_text edge cases
+
+  test "inline_text returns empty string for non-array content" do
+    assert_equal "", Bali::BlockNote::Text.inline_text(nil)
+    assert_equal "", Bali::BlockNote::Text.inline_text({ "type" => "tableContent" })
+    assert_equal "", Bali::BlockNote::Text.inline_text("raw string")
+  end
+
+  test "inline_node_text ignores unknown node types and non-hash nodes" do
+    assert_nil Bali::BlockNote::Text.inline_node_text({ "type" => "unknownType", "text" => "x" })
+    assert_nil Bali::BlockNote::Text.inline_node_text("not a hash")
+    assert_nil Bali::BlockNote::Text.inline_node_text(nil)
+  end
+
+  # table blocks with tableContent shape
+
+  test "extracts cell text from a table block in tableContent shape" do
+    result = Bali::BlockNote::Text.extract_text(TABLE_CONTENT_BLOCK)
+    assert_includes result, "Cabecera A"
+    assert_includes result, "Cabecera B"
+    assert_includes result, "Valor 1"
+    assert_includes result, "Valor 2"
+  end
+
+  test "extracts entityReference inside a table cell" do
+    block = {
+      "id" => "tab2", "type" => "table",
+      "content" => {
+        "type" => "tableContent",
+        "rows" => [
+          { "cells" => [
+            { "content" => [
+              { "type" => "entityReference",
+                "props" => { "entityType" => "GlossaryTerm", "entityId" => "9", "entityName" => "SLA" } }
+            ] }
+          ] }
+        ]
+      },
+      "children" => []
+    }
+    assert_includes Bali::BlockNote::Text.extract_text(block), "SLA"
+  end
+
+  test "table block whose content is not tableContent yields no cell text" do
+    block = { "id" => "tab3", "type" => "table", "content" => { "type" => "other" }, "children" => [] }
+    assert_equal [], Bali::BlockNote::Text.table_cell_text(block)
+  end
+
+  test "table_cell_text returns empty array for non-table blocks" do
+    assert_equal [], Bali::BlockNote::Text.table_cell_text(PARAGRAPH)
+  end
+
+  # blocks_to_text
+
+  test "joins multiple blocks into single string" do
+    result = Bali::BlockNote::Text.blocks_to_text([ HEADING, PARAGRAPH ])
+    assert_equal "Objetivo Texto del párrafo.", result
+  end
+
+  test "collapses runs of whitespace into single spaces" do
+    block = {
+      "id" => "s1", "type" => "paragraph",
+      "content" => [ { "type" => "text", "text" => "  Espacios \n\t dobles  ", "styles" => {} } ],
+      "children" => []
+    }
+    assert_equal "Espacios dobles", Bali::BlockNote::Text.blocks_to_text([ block ])
+  end
+
+  test "returns empty string for empty array" do
+    assert_equal "", Bali::BlockNote::Text.blocks_to_text([])
+  end
+
+  test "handles nil input" do
+    assert_equal "", Bali::BlockNote::Text.blocks_to_text(nil)
+  end
+
+  # normalize
+
+  test "normalizes Array input as-is" do
+    blocks = [ HEADING ]
+    assert_equal blocks, Bali::BlockNote::Text.normalize(blocks)
+  end
+
+  test "normalizes Hash with content key" do
+    input = { "content" => [ HEADING ] }
+    assert_equal [ HEADING ], Bali::BlockNote::Text.normalize(input)
+  end
+
+  test "normalizes Hash without content key to empty array" do
+    assert_equal [], Bali::BlockNote::Text.normalize({ "type" => "doc" })
+  end
+
+  test "normalizes JSON string" do
+    json = [ HEADING ].to_json
+    result = Bali::BlockNote::Text.normalize(json)
+    assert_equal 1, result.length
+    assert_equal "heading", result.first["type"]
+  end
+
+  test "returns empty array for nil" do
+    assert_equal [], Bali::BlockNote::Text.normalize(nil)
+  end
+
+  test "returns empty array for invalid JSON string" do
+    assert_equal [], Bali::BlockNote::Text.normalize("not valid json{{{")
+  end
+
+  test "returns empty array for empty string" do
+    assert_equal [], Bali::BlockNote::Text.normalize("")
+  end
+
+  test "returns empty array for unexpected type" do
+    assert_equal [], Bali::BlockNote::Text.normalize(42)
+  end
+
+  # normalize: legacy BlockNote v1 wrappers
+
+  test "unwraps blockGroup and blockContainer wrappers" do
+    legacy = [
+      { "type" => "blockGroup",
+        "content" => [
+          { "type" => "blockContainer", "content" => [ HEADING ] },
+          { "type" => "blockContainer", "content" => [ PARAGRAPH ] }
+        ] }
+    ]
+    result = Bali::BlockNote::Text.normalize(legacy)
+    assert_equal %w[heading paragraph], result.map { |b| b["type"] }
+  end
+
+  test "unwraps nested wrappers recursively" do
+    legacy = [
+      { "type" => "blockGroup",
+        "content" => [
+          { "type" => "blockGroup",
+            "content" => [ { "type" => "blockContainer", "content" => [ PARAGRAPH ] } ] }
+        ] }
+    ]
+    result = Bali::BlockNote::Text.normalize(legacy)
+    assert_equal [ PARAGRAPH ], result
+  end
+
+  test "keeps regular blocks intact while unwrapping siblings" do
+    mixed = [
+      HEADING,
+      { "type" => "blockGroup", "content" => [ PARAGRAPH ] }
+    ]
+    result = Bali::BlockNote::Text.normalize(mixed)
+    assert_equal [ HEADING, PARAGRAPH ], result
+  end
+end


### PR DESCRIPTION
## Resumen

PR 1 de 2 del issue #708 (cluster documents-engine): las tres libs puras de contenido BlockNote, trasplantadas de gobierno-corporativo (`Document::BlockNoteText` / `Document::ContentDiff` / `Document::Chunker`) y generalizadas bajo el engine, más `diff-lcs` como dependencia del gemspec. Refs #708 — el PR2 (tabla `bali_entity_references` + concern + registry + controller) viene después y es el que completa el issue.

## Qué entra

- **`Bali::BlockNote::Text`** (`app/lib/bali/block_note/text.rb`): extracción de texto plano de estructuras BlockNote — nodos inline `text` y `entityReference`, tablas en las dos formas (`tableRow` legacy y `tableContent` actual), children anidados — y `normalize` que acepta Array/Hash/String JSON y desenvuelve los wrappers v1 (`blockGroup`/`blockContainer`). Queda como el walker ÚNICO que el concern del PR2 compartirá con el diff (hoy gc tiene dos walkers paralelos; el spec pide colapsarlos).
- **`Bali::BlockNote::Diff`** (`diff.rb`): diff a dos granularidades — secciones por heading (`changed_sections`/`summary`, fingerprint estructural SHA256 con los `id` de bloque quitados, para que los UUIDs regenerados no cuenten como cambio pero un chip `entityReference` con el mismo texto visible sí) y bloques por UUID (`annotated_blocks` con `_diff_status` y `_diff_spans` de palabra vía `Diff::LCS`). Los bloques/secciones eliminados aparecen inline en su posición original; headings duplicados se manejan con colas por heading sin pérdida de datos.
- **`Bali::BlockNote::Chunker`** (`chunker.rb`): chunks semánticos delimitados por headings para indexado/RAG — 1600 chars objetivo, 300 de overlap con snap a límite de palabra, ~4 chars/token. SIN pgvector: embeddings y vector storage quedan en el host, como marca el spec.
- **`diff-lcs` (~> 1.5)** como runtime dependency del gemspec (decisión recomendada del spec: MIT, minúscula y sin ella `Diff` no carga). Lockfile actualizado (1.6.2, la misma que corre gc en prod).
- **78 tests unitarios** en `test/bali/block_note/` — los de gc portados completos más casos nuevos: unwrap de wrappers v1 (no estaba cubierto en gc), merge de spans consecutivos con invariantes de reconstrucción, fingerprint estable ante ids regenerados, secciones duplicadas anotadas, Chunker con JSON string/Hash/JSON inválido, títulos preservados en subdivisiones y cota de tamaño de chunk.

## Decisiones de implementación

- **`app/lib/`, no `lib/`**: el spec lo fija ahí porque `app/lib` ya está en la ASIGNACIÓN de `eager_load_paths` (`lib/bali/engine.rb:20`) — cero directorios nuevos, cero riesgo del gotcha v2.17.0. Verificado con `Rails.application.eager_load!` además de la suite.
- **Puras de verdad**: sin core extensions de ActiveSupport (`blank?`/`squish`/`index_by` reemplazados por Ruby pelado) y con el log de JSON malformado tras un guard `defined?(Rails)`. Verificado cargándolas con `ruby -e` sin Rails.
- **`::Diff::LCS` calificado desde la raíz** dentro de `Bali::BlockNote::Diff`: el nombre corto resolvería contra la propia clase `Diff` y no contra la gema.
- Paridad de comportamiento con gc mantenida a propósito (mismos extractores inline, mismo fingerprint): el diff mínimo del concern del PR2 depende de que la extracción no cambie por debajo.

## Tests

- `bundle exec rails test test/bali/block_note/` → 78 runs, 166 assertions, 0 failures.
- Regresión rápida `test/bali/models` + `test/bali/concerns` → verde.
- RuboCop limpio en los 7 archivos tocados.
- Smoke test en Ruby sin Rails (Text/Diff/Chunker + JSON inválido) → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
