### PR TITLE
feat(avatar): name:/initials: con color determinístico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Avatar derives initials and a deterministic color from `name:`.** `Bali::Avatar::Component.new(name: 'Ana García López')` now renders an initials placeholder — first letter of the first and the last word ("AL", unicode-aware upcase; one word yields one letter) — over a background hashed from the name into the fixed `Bali::Status` palette minus `slate`/`gray`, rendered as an inline style: the same person gets the same color on every render, process and DaisyUI theme. The hash is the new `Bali::Utils::ColorCalculator#deterministic_color(seed)` (`Zlib.crc32`, not the per-process-randomized `String#hash`); collisions between names are expected and fine. `initials:` overrides the derivation, and images keep winning: picture slot > `src:` > manual `placeholder` slot (which keeps its static neutral background) > `name:`/`initials:`. With `name:` present the avatar also stops being invisible to assistive tech: initials avatars get `role="img"`, `aria-label` and `title` with the full name, and image avatars use it as the `alt` (an explicit `alt:` wins). Groundwork for `Topbar::UserMenu` (#713). (#712)
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/app/components/bali/avatar/component.html.erb
+++ b/app/components/bali/avatar/component.html.erb
@@ -1,11 +1,13 @@
-<%= tag.div class: container_classes, **@options.except(:class) do %>
-  <%= tag.div class: [inner_classes, (placeholder_classes if placeholder?)].compact do %>
-    <% if placeholder? %>
-      <%= placeholder %>
-    <% elsif picture? %>
+<%= tag.div class: container_classes, **container_attributes do %>
+  <%= tag.div(**inner_attributes) do %>
+    <% if picture? %>
       <%= picture %>
     <% elsif @src.present? %>
-      <%= image_tag @src, alt: @options[:alt] || '', class: 'w-full h-full object-cover', loading: 'lazy', decoding: 'async' %>
+      <%= image_tag @src, alt: image_alt, class: 'w-full h-full object-cover', loading: 'lazy', decoding: 'async' %>
+    <% elsif placeholder? %>
+      <%= placeholder %>
+    <% elsif initials? %>
+      <span aria-hidden="true"><%= initials %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/bali/avatar/component.rb
+++ b/app/components/bali/avatar/component.rb
@@ -3,6 +3,8 @@
 module Bali
   module Avatar
     class Component < ApplicationViewComponent
+      include Utils::ColorCalculator
+
       renders_one :picture, ->(image_url:, **options) {
         Picture::Component.new(image_url: image_url, **options)
       }
@@ -57,10 +59,12 @@ module Bali
       }.freeze
 
       # rubocop:disable Metrics/ParameterLists
-      def initialize(src: nil, size: :md, shape: :circle, mask: nil,
-                     status: nil, ring: nil, **options)
+      def initialize(src: nil, name: nil, initials: nil, size: :md, shape: :circle,
+                     mask: nil, status: nil, ring: nil, **options)
         # rubocop:enable Metrics/ParameterLists
         @src = src
+        @name = name.presence
+        @initials = initials.presence
         @size = size&.to_sym
         @shape = shape&.to_sym
         @mask = mask&.to_sym
@@ -73,9 +77,33 @@ module Bali
         class_names(
           "avatar",
           STATUSES[@status],
-          placeholder? && "avatar-placeholder",
+          (placeholder? || initials?) && "avatar-placeholder",
           @options[:class]
         )
+      end
+
+      def container_attributes
+        attrs = @options.except(:class)
+        return attrs if @name.blank?
+
+        attrs[:title] = @name unless attrs.key?(:title)
+        return attrs if image? || attrs.key?(:role)
+
+        attrs[:role] = "img"
+        attrs[:"aria-label"] = @name unless labelled?(attrs)
+        attrs
+      end
+
+      def inner_attributes
+        attrs = {
+          class: class_names(
+            inner_classes,
+            (placeholder_classes if placeholder?),
+            (placeholder_text_size if initials?)
+          )
+        }
+        attrs[:style] = initials_style if initials?
+        attrs
       end
 
       def inner_classes
@@ -95,6 +123,17 @@ module Bali
         )
       end
 
+      # Two initials: first letter of the first and the last word ("Ana García
+      # López" → "AL"), unicode-aware upcase; a single word yields one letter.
+      # An explicit `initials:` always wins over the derivation.
+      def initials
+        @derived_initials ||= @initials || derive_initials
+      end
+
+      def image_alt
+        @options[:alt] || @name || ""
+      end
+
       private
 
       def shape_classes
@@ -110,8 +149,35 @@ module Bali
         )
       end
 
+      def image?
+        picture? || @src.present?
+      end
+
       def placeholder?
-        placeholder.present? && !picture? && @src.blank?
+        placeholder.present? && !image?
+      end
+
+      def initials?
+        initials.present? && !image? && placeholder.blank?
+      end
+
+      def derive_initials
+        return if @name.blank?
+
+        words = @name.split
+        letters = words.size >= 2 ? [ words.first[0], words.last[0] ] : [ words.first[0] ]
+        letters.join.upcase
+      end
+
+      # Inline style, like Status: the same person gets the same colour on
+      # every theme and render, with no Tailwind safelist.
+      def initials_style
+        pair = deterministic_color(@name || @initials)
+        "background-color: #{pair[:bg]}; color: #{pair[:fg]};"
+      end
+
+      def labelled?(attrs)
+        attrs.key?(:"aria-label") || attrs.key?(:aria_label) || attrs.dig(:aria, :label).present?
       end
 
       def placeholder_text_size

--- a/app/components/bali/avatar/preview.rb
+++ b/app/components/bali/avatar/preview.rb
@@ -50,9 +50,41 @@ module Bali
         )
       end
 
+      # With Name (Derived Initials)
+      # ----------------
+      # `name:` derives two initials — the first letter of the FIRST and the LAST
+      # word ("Ana García López" → AL, "María de la Luz" → ML; a single word
+      # yields one letter) — and paints a deterministic background: the name is
+      # hashed into the fixed Status palette (minus slate/gray), so the same
+      # person gets the same color on every render and DaisyUI theme.
+      # `initials:` overrides the derivation; an image (`src:` or the picture
+      # slot) always wins over initials. The container gets `role="img"`,
+      # `aria-label` and `title` with the full name.
+      # @param name text
+      # @param initials text
+      # @param size select [xs, sm, md, lg, xl]
+      def with_name(name: 'Ana García López', initials: '', size: :md)
+        render Bali::Avatar::Component.new(
+          name: name.presence, initials: initials.presence, size: size.to_sym
+        )
+      end
+
+      # Deterministic Colors
+      # ----------------
+      # A grid of names showing the stable name→color mapping. Collisions are
+      # expected and fine: two people can share a color.
+      def deterministic_colors
+        render_with_template(
+          template: 'bali/avatar/previews/deterministic_colors'
+        )
+      end
+
       # With Placeholder
       # ----------------
-      # Avatar with text initials instead of image
+      # Avatar with custom placeholder content via the manual slot. Prefer
+      # `name:` (see "With Name") — it derives initials and a color for you;
+      # the slot remains for fully custom content and keeps the static
+      # neutral background.
       # @param initials text
       # @param size select [xs, sm, md, lg, xl]
       def with_placeholder(initials: 'JD', size: :md)

--- a/app/components/bali/avatar/previews/deterministic_colors.html.erb
+++ b/app/components/bali/avatar/previews/deterministic_colors.html.erb
@@ -1,0 +1,13 @@
+<% names = [
+     'Ana García', 'Juan Pérez', 'Ana García López', 'María de la Luz',
+     'Cher', 'álvaro núñez', 'Luisa Fernández', 'Carlos Mendoza',
+     'Sofía Ramírez', 'Pedro Alcántara', 'Lucía Ortega', 'Miguel Ángel Ríos'
+   ] %>
+<div class="flex flex-wrap gap-6">
+  <% names.each do |name| %>
+    <div class="flex w-24 flex-col items-center gap-2">
+      <%= render Bali::Avatar::Component.new(name: name, size: :md) %>
+      <span class="text-center text-xs text-base-content/70"><%= name %></span>
+    </div>
+  <% end %>
+</div>

--- a/app/components/bali/utils/color_calculator.rb
+++ b/app/components/bali/utils/color_calculator.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
+require "zlib"
+
 module Bali
   module Utils
     module ColorCalculator
+      # Colours from Bali::Status::Component::PALETTE that deterministic_color
+      # never picks: `slate` and `gray` read as "disabled"/"empty" states, and
+      # no user should look switched-off just because of how their name hashes.
+      DETERMINISTIC_EXCLUDED = %i[slate gray].freeze
+
       def convert_to_brightness_value(background_hex_color)
         background_hex_color.scan(/../).map(&:hex).sum
       end
@@ -11,6 +18,19 @@ module Bali
         return if background_hex_color.blank?
 
         convert_to_brightness_value(background_hex_color.gsub("#", "")) > 382.5 ? "#000" : "#fff"
+      end
+
+      # Hashes a string to a stable { bg:, fg: } pair from the fixed Status
+      # palette (contrast already resolved, theme-independent): the same seed
+      # maps to the same colour on every render, process and DaisyUI theme.
+      # Collisions (two seeds, one colour) are expected and fine.
+      #
+      # Zlib.crc32 and not String#hash on purpose — the latter is randomized
+      # per process, which would reshuffle every avatar on each deploy.
+      def deterministic_color(seed)
+        palette = Bali::Status::Component::PALETTE.except(*DETERMINISTIC_EXCLUDED)
+        keys = palette.keys
+        palette.fetch(keys[Zlib.crc32(seed.to_s) % keys.size])
       end
     end
   end

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -1023,16 +1023,47 @@ Constraints:
 
 #### Avatar
 
-User avatar display.
+User avatar display: an image when there is one, derived initials when there is not.
 
 ```erb
+<%# Image avatar %>
 <%= render Bali::Avatar::Component.new(
   src: user.avatar_url,
-  alt: user.name,
+  name: user.name,
   size: :md,
   shape: :circle
 ) %>
+
+<%# No image: `name:` derives the initials and a stable background color %>
+<%= render Bali::Avatar::Component.new(name: 'Ana García López') %>
+
+<%# Explicit initials override the derivation %>
+<%= render Bali::Avatar::Component.new(initials: 'AG') %>
 ```
+
+**Options:**
+- `src` - Image URL (default: nil)
+- `name` - Full name; derives two initials and a deterministic background when no image renders (default: nil)
+- `initials` - Explicit initials, overriding the `name:` derivation (default: nil)
+- `size` - `:xs`, `:sm`, `:md`, `:lg`, `:xl` (default: `:md`)
+- `shape` - `:square`, `:rounded`, `:circle` (default: `:circle`)
+- `mask` - `:heart`, `:squircle`, `:hexagon`, `:triangle`, `:diamond`, `:pentagon`, `:star` (default: nil)
+- `status` - `:online`, `:offline` presence indicator (default: nil)
+- `ring` - Ring color: `:primary`, `:secondary`, `:accent`, `:neutral`, `:success`, `:warning`, `:error`, `:info` (default: nil)
+
+**Initials rule:** first letter of the *first* and the *last* word — "Ana García López" → AL,
+"María de la Luz" → ML; a single word yields one letter. Unicode-aware upcase.
+
+**Deterministic color:** the name is hashed (`Bali::Utils::ColorCalculator#deterministic_color`)
+into the fixed `Bali::Status` palette minus `slate`/`gray`, rendered as an inline style — the same
+person gets the same color on every render, process and DaisyUI theme. Collisions (two people, one
+color) are expected. The manual `placeholder` slot still exists for fully custom content and keeps
+the static neutral background.
+
+**Precedence:** picture slot > `src:` > `placeholder` slot > `name:`/`initials:`.
+
+**Accessibility:** with `name:`, an initials avatar gets `role="img"`, `aria-label` and `title`
+with the full name; an image avatar uses the name as `alt` (explicit `alt:` wins) plus `title`.
 
 #### Tag (Badge)
 

--- a/test/bali/components/avatar_test.rb
+++ b/test/bali/components/avatar_test.rb
@@ -119,6 +119,118 @@ class BaliAvatarComponentTest < ComponentTestCase
     assert_selector('img[src*="avatar.png"]')
   end
 
+  def test_initials_derives_first_and_last_word_initials_from_name
+    render_inline(Bali::Avatar::Component.new(name: "Ana García"))
+    assert_selector(".avatar.avatar-placeholder")
+    assert_text("AG")
+  end
+
+  def test_initials_derives_from_first_and_last_word_on_compound_names
+    render_inline(Bali::Avatar::Component.new(name: "Ana García López"))
+    assert_text("AL")
+    render_inline(Bali::Avatar::Component.new(name: "María de la Luz"))
+    assert_text("ML")
+  end
+
+  def test_initials_derives_a_single_letter_from_a_single_word_name
+    render_inline(Bali::Avatar::Component.new(name: "Cher"))
+    assert_text("C")
+  end
+
+  def test_initials_upcases_unicode_letters
+    render_inline(Bali::Avatar::Component.new(name: "álvaro núñez"))
+    assert_text("ÁN")
+  end
+
+  def test_initials_explicit_initials_override_the_derivation
+    render_inline(Bali::Avatar::Component.new(name: "Ana García", initials: "ZZ"))
+    assert_text("ZZ")
+    assert_no_text("AG")
+  end
+
+  def test_initials_renders_with_explicit_initials_and_no_name
+    render_inline(Bali::Avatar::Component.new(initials: "AG"))
+    assert_selector(".avatar.avatar-placeholder")
+    assert_text("AG")
+  end
+
+  def test_initials_applies_a_deterministic_background_from_the_status_palette
+    render_inline(Bali::Avatar::Component.new(name: "Ana García"))
+    pair = Bali::Status::Component::PALETTE[:red] # crc32("Ana García") % 10 → :red
+    assert_selector("[style='background-color: #{pair[:bg]}; color: #{pair[:fg]};']")
+  end
+
+  def test_initials_same_name_renders_the_same_style_on_every_render
+    first = render_inline(Bali::Avatar::Component.new(name: "Juan Pérez")).css("[style]").first["style"]
+    second = render_inline(Bali::Avatar::Component.new(name: "Juan Pérez")).css("[style]").first["style"]
+    assert_equal(first, second)
+  end
+
+  def test_initials_color_seed_is_the_name_when_both_name_and_initials_are_given
+    with_both = render_inline(
+      Bali::Avatar::Component.new(name: "Ana García", initials: "ZZ")
+    ).css("[style]").first["style"]
+    with_name = render_inline(Bali::Avatar::Component.new(name: "Ana García")).css("[style]").first["style"]
+    assert_equal(with_name, with_both)
+  end
+
+  def test_initials_does_not_use_the_static_neutral_placeholder_colors
+    render_inline(Bali::Avatar::Component.new(name: "Ana García"))
+    assert_no_selector(".bg-neutral")
+  end
+
+  def test_initials_applies_the_placeholder_text_size_for_the_avatar_size
+    render_inline(Bali::Avatar::Component.new(name: "Ana García", size: :xl))
+    assert_selector(".text-3xl")
+  end
+
+  def test_initials_src_wins_over_name
+    render_inline(Bali::Avatar::Component.new(src: "/avatar.png", name: "Ana García"))
+    assert_selector('img[src*="avatar.png"]')
+    assert_no_selector(".avatar-placeholder")
+    assert_no_text("AG")
+  end
+
+  def test_initials_picture_slot_wins_over_name
+    render_inline(Bali::Avatar::Component.new(name: "Ana García")) do |c|
+      c.with_picture(image_url: "/custom-avatar.png")
+    end
+    assert_selector('img[src*="custom-avatar.png"]')
+    assert_no_text("AG")
+  end
+
+  def test_initials_manual_placeholder_slot_wins_over_derived_initials
+    render_inline(Bali::Avatar::Component.new(name: "Ana García")) do |c|
+      c.with_placeholder { "XY" }
+    end
+    assert_text("XY")
+    assert_no_text("AG")
+  end
+
+  def test_accessibility_name_adds_role_img_aria_label_and_title_on_initials_avatars
+    render_inline(Bali::Avatar::Component.new(name: "Ana García"))
+    assert_selector('.avatar[role="img"][aria-label="Ana García"][title="Ana García"]')
+  end
+
+  def test_accessibility_name_becomes_the_image_alt_when_src_is_present
+    render_inline(Bali::Avatar::Component.new(src: "/avatar.png", name: "Ana García"))
+    assert_selector('img[alt="Ana García"]')
+    assert_selector('.avatar[title="Ana García"]')
+    assert_no_selector('.avatar[role="img"]')
+  end
+
+  def test_accessibility_explicit_alt_wins_over_name_for_the_image
+    render_inline(Bali::Avatar::Component.new(src: "/avatar.png", name: "Ana García", alt: "Profile"))
+    assert_selector('img[alt="Profile"]')
+  end
+
+  def test_accessibility_without_name_no_role_aria_label_or_title_is_added
+    render_inline(Bali::Avatar::Component.new(initials: "AG"))
+    assert_no_selector(".avatar[role]")
+    assert_no_selector(".avatar[aria-label]")
+    assert_no_selector(".avatar[title]")
+  end
+
   def test_presence_indicator_renders_online_status
     render_inline(Bali::Avatar::Component.new(src: "/default.png", status: :online))
     assert_selector(".avatar.avatar-online")

--- a/test/bali/utils_test.rb
+++ b/test/bali/utils_test.rb
@@ -86,3 +86,47 @@ class BaliUtilsTest < ActiveSupport::TestCase
     assert_nil(@helper.test_id_attr(nil))
   end
 end
+
+class ColorCalculatorContext
+  include Bali::Utils::ColorCalculator
+end
+
+class BaliUtilsColorCalculatorTest < ActiveSupport::TestCase
+  def setup
+    @helper = ColorCalculatorContext.new
+  end
+
+  def test_deterministic_color_returns_a_bg_fg_pair_from_the_status_palette
+    pair = @helper.deterministic_color("Ana García")
+
+    assert_includes(Bali::Status::Component::PALETTE.values, pair)
+    assert(pair.key?(:bg))
+    assert(pair.key?(:fg))
+  end
+
+  def test_deterministic_color_is_stable_for_the_same_seed
+    assert_equal(@helper.deterministic_color("Ana García"),
+                 @helper.deterministic_color("Ana García"))
+  end
+
+  # String#hash is randomized per process; the mapping must survive restarts,
+  # so it is pinned to Zlib.crc32 and these seeds assert the exact colour.
+  def test_deterministic_color_mapping_is_stable_across_processes
+    palette = Bali::Status::Component::PALETTE
+
+    assert_equal(palette[:red], @helper.deterministic_color("Ana García"))
+    assert_equal(palette[:green], @helper.deterministic_color("Juan Pérez"))
+  end
+
+  def test_deterministic_color_never_picks_slate_or_gray
+    excluded = Bali::Status::Component::PALETTE.values_at(:slate, :gray)
+
+    1_000.times do |i|
+      refute_includes(excluded, @helper.deterministic_color("seed-#{i}"))
+    end
+  end
+
+  def test_deterministic_color_accepts_a_nil_seed
+    assert_includes(Bali::Status::Component::PALETTE.values, @helper.deterministic_color(nil))
+  end
+end


### PR DESCRIPTION
## Resumen

Implementa la API `name:`/`initials:` del Avatar (spec §#712 de `docs/plans/v3.1/tier1-components.md`):

- **`name:`** deriva dos iniciales — primera letra de la **primera** y la **última** palabra ("Ana García López" → AL, "María de la Luz" → ML; una sola palabra da una letra), upcase unicode-aware (712-D2).
- **Color determinístico**: nuevo `Bali::Utils::ColorCalculator#deterministic_color(seed)` que hashea el string con `Zlib.crc32` (estable entre procesos, a diferencia de `String#hash`) a la paleta fija de Status **sin `slate`/`gray`** (10 colores útiles, 712-D1), y se renderiza como inline style igual que Status — mismo color en todo tema y deploy, sin safelist. Colisiones entre nombres: esperables y documentadas.
- **`initials:`** explícito pisa la derivación; la precedencia queda picture slot > `src:` > slot `placeholder` manual (conserva su fondo neutral estático) > `name:`/`initials:`.
- **Accesibilidad (712-D3)**: con `name:`, el avatar de iniciales lleva `role="img"` + `aria-label` + `title` con el nombre completo (y las iniciales `aria-hidden`); el de imagen usa el nombre como `alt` (un `alt:` explícito gana) + `title`.
- `Avatar::Group`/`Avatar::Upload` intactos; `with_avatar(name:)` funciona vía el passthrough existente.

Deja la API lista para que la consuma `Topbar::UserMenu` (#713). Refs #712

## Verificación

- Minitest: `avatar_test.rb` + `utils_test.rb` — 94 runs, 0 failures (derivación simple/compuesta/una palabra/unicode, override, determinismo entre renders y procesos, exclusión de slate/gray en 1000 seeds, precedencias, a11y).
- Rubocop: 0 ofensas en los archivos tocados.
- Lookbook verificado en browser (puerto 3011): previews nuevos `with_name` (con params name/initials/size) y `deterministic_colors` (grid de 12 nombres, 8 colores distintos, contraste legible) renderizan 200 con el markup esperado; screenshot inspeccionado.
- Sin JS tocado → sin Cypress (según el spec).

## Docs

- `docs/guides/components.md`: sección Avatar reescrita (opciones, regla de iniciales, color determinístico, precedencia, a11y).
- CHANGELOG bajo `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)