### PR TITLE
test(dynamic-fields): spec Cypress que congela el contrato JS del controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v3.0.0] - 2026-08-05
+### Added
+
+- **Cypress coverage for `dynamic-fields-controller`** (#715 PR1, closes the TODO from #155).
+  `cypress/e2e/dynamic-fields-controller.cy.js` freezes the controller's current JS contract
+  before the #715 feature work touches it: `addFields` clones the `<template>` replacing the
+  `new_record` placeholder with a numeric child index, `removeFields` hides the row (it stays
+  in the DOM), sets `.destroy-flag` to `true` and strips the non-hidden form elements while
+  keeping the hidden ones, `moveUp`/`moveDown` swap rows and renumber every `[data-position]`
+  input (and are no-ops at the edges), and the `remove-duplicates` mode drops already-selected
+  options from the cloned template and disables the add button at maximum size — on `connect()`
+  too — re-enabling it when a row is removed. Two new Lookbook previews back the parts the Ruby
+  helper does not emit yet (`sortable`, `remove_duplicates`), wired by hand the way host apps
+  do today; the add/remove specs run against the existing `default`/`empty` previews.
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to
 the stable channel: `3.0` merges into `main`, `main` becomes the v3 line, and the next

--- a/app/assets/javascripts/bali/controllers/dynamic-fields-controller.js
+++ b/app/assets/javascripts/bali/controllers/dynamic-fields-controller.js
@@ -7,7 +7,7 @@ import {
   nextSibling
 } from '../utils/domHelpers.js'
 
-// TODO: Add tests (Issue: #155)
+// Contract frozen by cypress/e2e/dynamic-fields-controller.cy.js (#155/#715).
 
 export class DynamicFieldsController extends Controller {
   static targets = ['template', 'container', 'button']

--- a/app/components/bali/form/dynamic_fields/preview.rb
+++ b/app/components/bali/form/dynamic_fields/preview.rb
@@ -10,11 +10,11 @@ module Bali
         # Uses the Movie model with has_many :characters association.
         def default
           movie = Movie.new
-          movie.characters.build(name: 'John Doe')
-          movie.characters.build(name: 'Jane Smith')
+          movie.characters.build(name: "John Doe")
+          movie.characters.build(name: "Jane Smith")
 
           render_with_template(
-            template: 'bali/form/dynamic_fields/previews/default',
+            template: "bali/form/dynamic_fields/previews/default",
             locals: { model: movie }
           )
         end
@@ -24,7 +24,7 @@ module Bali
         # Dynamic fields with no initial records
         def empty
           render_with_template(
-            template: 'bali/form/dynamic_fields/previews/empty',
+            template: "bali/form/dynamic_fields/previews/empty",
             locals: { model: Movie.new }
           )
         end
@@ -34,10 +34,10 @@ module Bali
         # Custom header layout using a block
         def with_custom_block
           movie = Movie.new
-          movie.characters.build(name: 'Example Character')
+          movie.characters.build(name: "Example Character")
 
           render_with_template(
-            template: 'bali/form/dynamic_fields/previews/with_custom_block',
+            template: "bali/form/dynamic_fields/previews/with_custom_block",
             locals: { model: movie }
           )
         end
@@ -47,9 +47,32 @@ module Bali
         # Dynamic fields with custom button classes
         def custom_button
           render_with_template(
-            template: 'bali/form/dynamic_fields/previews/custom_button',
+            template: "bali/form/dynamic_fields/previews/custom_button",
             locals: { model: Movie.new }
           )
+        end
+
+        # Sortable
+        # --------
+        # Rows carrying a hidden `[data-position]` input plus move up/down
+        # buttons, mirroring the markup host apps wire by hand today — the Ruby
+        # helper does not emit positions or move buttons yet. Exists to freeze
+        # the moveUp/moveDown/resetPositionValues contract of the
+        # dynamic-fields Stimulus controller (Cypress:
+        # dynamic-fields-controller.cy.js).
+        def sortable
+          render_with_template(template: "bali/form/dynamic_fields/previews/sortable")
+        end
+
+        # Remove Duplicates
+        # -----------------
+        # The controller's `remove-duplicates` mode: cloned templates drop
+        # options already selected in other rows, and the add button disables
+        # once every option is in use. The Ruby helper does not emit this mode
+        # yet, so the markup is wired by hand the way host apps do. Exists to
+        # freeze the JS contract (Cypress: dynamic-fields-controller.cy.js).
+        def remove_duplicates
+          render_with_template(template: "bali/form/dynamic_fields/previews/remove_duplicates")
         end
       end
     end

--- a/app/components/bali/form/dynamic_fields/previews/remove_duplicates.html.erb
+++ b/app/components/bali/form/dynamic_fields/previews/remove_duplicates.html.erb
@@ -1,0 +1,132 @@
+<%# Freezes the remove-duplicates contract of dynamic-fields-controller
+    (#715 PR1, covered by cypress/e2e/dynamic-fields-controller.cy.js).
+
+    `f.dynamic_fields_group` does not emit `remove-duplicates-value` — the
+    mode is JS-only today and host apps wire it by hand, so this preview
+    does too.
+
+    Two independent controller instances:
+    - #genre-picker starts below the maximum (1 of 3 options in use).
+    - #genre-picker-full starts AT the maximum, so connect() must disable
+      its add button on page load. %>
+<div class="p-4 max-w-2xl">
+  <h3 class="text-lg font-semibold mb-4">Genres (no duplicates)</h3>
+
+  <div id="genre-picker"
+       data-controller="dynamic-fields"
+       data-dynamic-fields-size-value="1"
+       data-dynamic-fields-remove-duplicates-value="true"
+       data-dynamic-fields-fields-selector-value=".genre-fields">
+    <div class="flex justify-between items-center">
+      <label class="label">Genres</label>
+      <div class="flex items-center">
+        <button type="button"
+                class="btn btn-primary"
+                data-dynamic-fields-target="button"
+                data-action="dynamic-fields#addFields">Add Genre</button>
+        <template data-dynamic-fields-target="template">
+          <div class="genre-fields card bg-base-200 p-4 mb-2">
+            <div class="flex items-center gap-4">
+              <div class="flex-1">
+                <select class="select w-full" name="movie[genres][new_record][name]">
+                  <option value="action">Action</option>
+                  <option value="comedy">Comedy</option>
+                  <option value="drama">Drama</option>
+                </select>
+              </div>
+              <div class="flex-none">
+                <button type="button" class="btn btn-error btn-sm"
+                        data-action="dynamic-fields#removeFields">Remove</button>
+                <input type="hidden"
+                       name="movie[genres][new_record][_destroy]"
+                       class="destroy-flag">
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div data-dynamic-fields-target="container">
+      <div class="genre-fields card bg-base-200 p-4 mb-2">
+        <div class="flex items-center gap-4">
+          <div class="flex-1">
+            <select class="select w-full" name="movie[genres][0][name]">
+              <option value="action" selected>Action</option>
+              <option value="comedy">Comedy</option>
+              <option value="drama">Drama</option>
+            </select>
+          </div>
+          <div class="flex-none">
+            <button type="button" class="btn btn-error btn-sm"
+                    data-action="dynamic-fields#removeFields">Remove</button>
+            <input type="hidden"
+                   name="movie[genres][0][_destroy]"
+                   class="destroy-flag">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3 class="text-lg font-semibold my-4">Already at maximum</h3>
+
+  <div id="genre-picker-full"
+       data-controller="dynamic-fields"
+       data-dynamic-fields-size-value="3"
+       data-dynamic-fields-remove-duplicates-value="true"
+       data-dynamic-fields-fields-selector-value=".genre-fields">
+    <div class="flex justify-between items-center">
+      <label class="label">Genres</label>
+      <div class="flex items-center">
+        <button type="button"
+                class="btn btn-primary"
+                data-dynamic-fields-target="button"
+                data-action="dynamic-fields#addFields">Add Genre</button>
+        <template data-dynamic-fields-target="template">
+          <div class="genre-fields card bg-base-200 p-4 mb-2">
+            <div class="flex items-center gap-4">
+              <div class="flex-1">
+                <select class="select w-full" name="movie[all_genres][new_record][name]">
+                  <option value="action">Action</option>
+                  <option value="comedy">Comedy</option>
+                  <option value="drama">Drama</option>
+                </select>
+              </div>
+              <div class="flex-none">
+                <button type="button" class="btn btn-error btn-sm"
+                        data-action="dynamic-fields#removeFields">Remove</button>
+                <input type="hidden"
+                       name="movie[all_genres][new_record][_destroy]"
+                       class="destroy-flag">
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div data-dynamic-fields-target="container">
+      <% %w[action comedy drama].each_with_index do |genre, index| %>
+        <div class="genre-fields card bg-base-200 p-4 mb-2">
+          <div class="flex items-center gap-4">
+            <div class="flex-1">
+              <select class="select w-full" name="movie[all_genres][<%= index %>][name]">
+                <option value="action" <%= 'selected' if genre == 'action' %>>Action</option>
+                <option value="comedy" <%= 'selected' if genre == 'comedy' %>>Comedy</option>
+                <option value="drama" <%= 'selected' if genre == 'drama' %>>Drama</option>
+              </select>
+            </div>
+            <div class="flex-none">
+              <button type="button" class="btn btn-error btn-sm"
+                      data-action="dynamic-fields#removeFields">Remove</button>
+              <input type="hidden"
+                     name="movie[all_genres][<%= index %>][_destroy]"
+                     class="destroy-flag">
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/bali/form/dynamic_fields/previews/sortable.html.erb
+++ b/app/components/bali/form/dynamic_fields/previews/sortable.html.erb
@@ -1,0 +1,82 @@
+<%# Freezes the positions/reordering contract of dynamic-fields-controller
+    (#715 PR1, covered by cypress/e2e/dynamic-fields-controller.cy.js).
+
+    The markup is wired by hand on purpose: `f.dynamic_fields_group` does not
+    emit `[data-position]` inputs nor moveUp/moveDown buttons yet — host apps
+    (costa-norte route stops, afal-apps monetary lines) build this markup
+    themselves, so the preview mirrors that usage instead of going through
+    the helper. %>
+<div class="p-4 max-w-2xl">
+  <h3 class="text-lg font-semibold mb-4">Sortable Characters</h3>
+
+  <div id="sortable-characters"
+       data-controller="dynamic-fields"
+       data-dynamic-fields-size-value="3"
+       data-dynamic-fields-fields-selector-value=".character-fields">
+    <div class="flex justify-between items-center">
+      <label class="label">Characters</label>
+      <div class="flex items-center">
+        <button type="button"
+                class="btn btn-primary"
+                data-dynamic-fields-target="button"
+                data-action="dynamic-fields#addFields">Add Character</button>
+        <template data-dynamic-fields-target="template">
+          <div class="character-fields card bg-base-200 p-4 mb-2">
+            <div class="flex items-center gap-4">
+              <input type="hidden"
+                     name="movie[characters_attributes][new_record][position]"
+                     data-position>
+              <div class="flex-1">
+                <input type="text"
+                       class="input w-full"
+                       name="movie[characters_attributes][new_record][name]"
+                       placeholder="Character name">
+              </div>
+              <div class="flex-none flex items-center gap-1">
+                <button type="button" class="btn btn-sm"
+                        data-action="dynamic-fields#moveUp">Up</button>
+                <button type="button" class="btn btn-sm"
+                        data-action="dynamic-fields#moveDown">Down</button>
+                <button type="button" class="btn btn-error btn-sm"
+                        data-action="dynamic-fields#removeFields">Remove</button>
+                <input type="hidden"
+                       name="movie[characters_attributes][new_record][_destroy]"
+                       class="destroy-flag">
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div data-dynamic-fields-target="container">
+      <% %w[Alpha Beta Gamma].each_with_index do |name, index| %>
+        <div class="character-fields card bg-base-200 p-4 mb-2">
+          <div class="flex items-center gap-4">
+            <input type="hidden"
+                   name="movie[characters_attributes][<%= index %>][position]"
+                   value="<%= index + 1 %>"
+                   data-position>
+            <div class="flex-1">
+              <input type="text"
+                     class="input w-full"
+                     name="movie[characters_attributes][<%= index %>][name]"
+                     value="<%= name %>">
+            </div>
+            <div class="flex-none flex items-center gap-1">
+              <button type="button" class="btn btn-sm"
+                      data-action="dynamic-fields#moveUp">Up</button>
+              <button type="button" class="btn btn-sm"
+                      data-action="dynamic-fields#moveDown">Down</button>
+              <button type="button" class="btn btn-error btn-sm"
+                      data-action="dynamic-fields#removeFields">Remove</button>
+              <input type="hidden"
+                     name="movie[characters_attributes][<%= index %>][_destroy]"
+                     class="destroy-flag">
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/cypress/e2e/dynamic-fields-controller.cy.js
+++ b/cypress/e2e/dynamic-fields-controller.cy.js
@@ -1,0 +1,173 @@
+// Freezes the current contract of dynamic-fields-controller (#715 PR1,
+// closes the TODO from #155) before any behavior change lands. Runs against
+// the Lookbook previews in app/components/bali/form/dynamic_fields/.
+
+describe('DynamicFieldsController', () => {
+  context('adding fields', () => {
+    beforeEach(() => {
+      cy.visit('/bali/form/dynamic_fields/default')
+    })
+
+    it('renders one row per existing record', () => {
+      cy.get('.character-fields').should('have.length', 2)
+    })
+
+    it('clones the template into the container', () => {
+      cy.contains('button', 'Add Character').click()
+      cy.get('.character-fields').should('have.length', 3)
+
+      cy.contains('button', 'Add Character').click()
+      cy.get('.character-fields').should('have.length', 4)
+    })
+
+    it('replaces the new_record placeholder with a numeric child index', () => {
+      cy.contains('button', 'Add Character').click()
+
+      cy.get('.character-fields')
+        .last()
+        .find('input[type="text"]')
+        .invoke('attr', 'name')
+        .should('match', /^movie\[characters_attributes\]\[\d+\]\[name\]$/)
+
+      cy.get('[data-dynamic-fields-target="container"] [name*="new_record"]')
+        .should('not.exist')
+    })
+
+    it('adds the first row to an empty container', () => {
+      cy.visit('/bali/form/dynamic_fields/empty')
+
+      cy.get('.character-fields').should('have.length', 0)
+      cy.contains('button', 'Add Your First Character').click()
+      cy.get('.character-fields').should('have.length', 1)
+    })
+  })
+
+  context('removing fields', () => {
+    beforeEach(() => {
+      cy.visit('/bali/form/dynamic_fields/default')
+    })
+
+    it('hides the row instead of deleting it from the DOM', () => {
+      cy.get('.character-fields').first().as('row')
+
+      cy.get('@row').contains('button', 'Remove').click()
+      cy.get('@row').should('exist').and('not.be.visible')
+      cy.get('.character-fields').should('have.length', 2)
+    })
+
+    it('flags the record for destruction', () => {
+      cy.get('.character-fields').first().within(() => {
+        cy.contains('button', 'Remove').click()
+        cy.get('.destroy-flag').should('have.value', 'true')
+      })
+    })
+
+    it('strips the non-hidden form elements but keeps the hidden ones', () => {
+      cy.get('.character-fields').first().within(() => {
+        cy.get('input[type="text"]').should('exist')
+
+        cy.contains('button', 'Remove').click()
+
+        cy.get('input[type="text"]').should('not.exist')
+        cy.get('input[type="hidden"]').should('exist')
+      })
+    })
+  })
+
+  context('reordering', () => {
+    beforeEach(() => {
+      cy.visit('/bali/form/dynamic_fields/sortable')
+    })
+
+    // [name, position] per row, in DOM order
+    const expectRows = expected => {
+      cy.get('#sortable-characters [data-dynamic-fields-target="container"] .character-fields')
+        .should($rows => {
+          const actual = [...$rows].map(row => [
+            row.querySelector('input[type="text"]').value,
+            row.querySelector('[data-position]').value
+          ])
+          expect(actual).to.deep.equal(expected)
+        })
+    }
+
+    const row = index => cy.get('.character-fields').eq(index)
+
+    it('renders the rows in order', () => {
+      expectRows([['Alpha', '1'], ['Beta', '2'], ['Gamma', '3']])
+    })
+
+    it('moveDown swaps the row with the next one and renumbers positions', () => {
+      row(0).contains('button', 'Down').click()
+      expectRows([['Beta', '1'], ['Alpha', '2'], ['Gamma', '3']])
+    })
+
+    it('moveUp swaps the row with the previous one and renumbers positions', () => {
+      row(2).contains('button', 'Up').click()
+      expectRows([['Alpha', '1'], ['Gamma', '2'], ['Beta', '3']])
+    })
+
+    it('moveUp on the first row is a no-op', () => {
+      row(0).contains('button', 'Up').click()
+      expectRows([['Alpha', '1'], ['Beta', '2'], ['Gamma', '3']])
+    })
+
+    it('moveDown on the last row is a no-op', () => {
+      row(2).contains('button', 'Down').click()
+      expectRows([['Alpha', '1'], ['Beta', '2'], ['Gamma', '3']])
+    })
+
+    it('stamps the new size on the added row position input', () => {
+      cy.contains('button', 'Add Character').click()
+
+      cy.get('.character-fields').should('have.length', 4)
+      cy.get('.character-fields').last().find('[data-position]')
+        .should('have.value', '4')
+    })
+  })
+
+  context('remove duplicates', () => {
+    beforeEach(() => {
+      cy.visit('/bali/form/dynamic_fields/remove_duplicates')
+    })
+
+    const addButton = () =>
+      cy.get('#genre-picker [data-dynamic-fields-target="button"]')
+
+    it('omits the options already selected in other rows from the cloned template', () => {
+      addButton().click()
+
+      cy.get('#genre-picker .genre-fields').should('have.length', 2)
+      cy.get('#genre-picker .genre-fields').eq(1).within(() => {
+        cy.get('select option').should('have.length', 2)
+        cy.get('option[value="action"]').should('not.exist')
+      })
+    })
+
+    it('disables the add button when every option is in use', () => {
+      addButton().click()
+      cy.get('#genre-picker .genre-fields').should('have.length', 2)
+      addButton().should('not.be.disabled').click()
+
+      cy.get('#genre-picker .genre-fields').should('have.length', 3)
+      addButton().should('be.disabled')
+    })
+
+    it('disables the add button on connect when already at maximum', () => {
+      cy.get('#genre-picker-full [data-dynamic-fields-target="button"]')
+        .should('be.disabled')
+    })
+
+    it('re-enables the add button when a row is removed', () => {
+      addButton().click()
+      cy.get('#genre-picker .genre-fields').should('have.length', 2)
+      addButton().click()
+      addButton().should('be.disabled')
+
+      cy.get('#genre-picker .genre-fields').last()
+        .contains('button', 'Remove').click()
+
+      addButton().should('not.be.disabled')
+    })
+  })
+})


### PR DESCRIPTION
## Resumen

PR1 de #715: tests primero, sin tocar comportamiento. `cypress/e2e/dynamic-fields-controller.cy.js` congela el contrato actual de `dynamic-fields-controller.js` contra los previews de Lookbook antes de que el trabajo de #715 lo extienda. Cierra de paso el TODO de tests que el controller arrastraba desde #155.

## Qué cubre (17 tests)

- **addFields**: clona el `<template>` al container reemplazando el placeholder `new_record` por un índice numérico (timestamp); funciona también partiendo de un container vacío. Contra los previews `default`/`empty` existentes.
- **removeFields**: oculta la fila (sigue en el DOM), pone `.destroy-flag` en `true` y quita los elementos de formulario no-hidden conservando los hidden (lo que viaja al submit).
- **moveUp/moveDown**: intercambian la fila con su vecina y renumeran TODOS los inputs `[data-position]` según el orden del DOM; no-op en los bordes. `addFields` estampa el tamaño nuevo en el `[data-position]` de la fila agregada.
- **remove-duplicates**: el template clonado excluye las opciones ya seleccionadas en otras filas; el botón de agregar se deshabilita al llegar al máximo — también en `connect()` cuando la página ya carga al máximo — y se rehabilita al quitar una fila.

## Previews nuevos

`sortable` y `remove_duplicates` en `app/components/bali/form/dynamic_fields/`: cablean a mano el markup que `f.dynamic_fields_group` todavía no emite (posiciones, botones de mover, modo remove-duplicates), igual que lo hacen hoy costa-norte y afal-apps — que es exactamente lo que PR2 va a absorber en el helper. Sin componente nuevo, según la decisión anotada en el issue.

## Verificación

- `cypress run --browser electron --spec cypress/e2e/dynamic-fields-controller.cy.js`: 17/17 en verde contra el dummy del worktree.
- Los 4 previews (`default`, `empty`, `sortable`, `remove_duplicates`) responden 200.
- Minitest de lo tocado (`dynamic_fields_test`, `stimulus_target_guards_test`): 22 runs, 0 failures.
- `yarn check:manifest` OK.

Refs #715. Refs #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)