### PR TITLE
feat(description_list): grid responsive de pares label/valor (#727)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::DescriptionList::Component` — a set of label/value pairs in the component's own responsive grid** (#727). The middle ground between `Bali::LabelValue` (one pair the caller places) and `Bali::PropertiesTable` (one set read top to bottom as a table): `columns:` 1/2/3 with responsive collapse, `layout:` `:stacked` (default) or `:horizontal` (term and value side by side inside each cell), and `with_item(label:, value:)` accepting block content for rich values such as a `Bali::Tag`. Markup is one `<dl>` of `<div><dt/><dd/></div>` cells, and `dt`/`dd` reuse LabelValue's typography so the three options read as one family; the guide now carries the three-way comparison under DescriptionList.
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/app/components/bali/description_list/component.html.erb
+++ b/app/components/bali/description_list/component.html.erb
@@ -1,0 +1,5 @@
+<%= tag.dl(**component_attributes) do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/bali/description_list/component.rb
+++ b/app/components/bali/description_list/component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Bali
+  module DescriptionList
+    # A set of read-only label/value pairs laid out in the component's own
+    # responsive grid — one `<dl>` whose items are `<div><dt/><dd/></div>`
+    # cells (a `<div>` wrapping `<dt>`/`<dd>` inside a `<dl>` is valid HTML).
+    #
+    # This is the middle ground between `Bali::LabelValue::Component` (ONE
+    # pair, placed by the caller) and `Bali::PropertiesTable::Component` (one
+    # set read straight through with table navigation). Reach for
+    # DescriptionList when the pairs belong together as a set but want a grid
+    # rather than table rows. `<dt>`/`<dd>` reuse LabelValue's typography so
+    # the three options read as one family.
+    class Component < ApplicationViewComponent
+      BASE_CLASSES = "description-list-component grid gap-x-6 gap-y-3"
+
+      # Frozen hash so Tailwind sees the responsive classes as literal strings
+      # in a scanned file — same pattern as
+      # `Bali::DashboardPage::Component::STATS_COLUMNS`.
+      COLUMNS = {
+        1 => "grid-cols-1",
+        2 => "grid-cols-1 sm:grid-cols-2",
+        3 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+      }.freeze
+
+      DEFAULT_COLUMNS = 2
+
+      renders_many :items, lambda { |label:, value: nil, **options|
+        Bali::DescriptionList::Item::Component.new(
+          label: label, value: value, layout: @layout, **options
+        )
+      }
+
+      def initialize(columns: DEFAULT_COLUMNS, layout: :stacked, **options)
+        @columns = columns
+        @layout = layout
+        @options = options
+      end
+
+      private
+
+      attr_reader :options
+
+      def component_classes
+        class_names(BASE_CLASSES, COLUMNS.fetch(@columns, COLUMNS[DEFAULT_COLUMNS]), options[:class])
+      end
+
+      def component_attributes
+        options.except(:class).merge(class: component_classes)
+      end
+    end
+  end
+end

--- a/app/components/bali/description_list/item/component.html.erb
+++ b/app/components/bali/description_list/item/component.html.erb
@@ -1,0 +1,4 @@
+<%= tag.div(**item_attributes) do %>
+  <dt class="<%= label_classes %>"><%= label %></dt>
+  <dd class="<%= value_classes %>"><%= value || content %></dd>
+<% end %>

--- a/app/components/bali/description_list/item/component.rb
+++ b/app/components/bali/description_list/item/component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Bali
+  module DescriptionList
+    module Item
+      # One label/value cell inside a `Bali::DescriptionList::Component` grid.
+      # Emits `<div><dt/><dd/></div>` — the wrapping `<div>` is what lets a
+      # `<dl>` be a grid without the term and its value landing in different
+      # cells.
+      class Component < ApplicationViewComponent
+        BASE_CLASSES = "description-list-item-component"
+
+        # `:horizontal` puts the term and its value side by side inside the
+        # cell: `<dt>` on the first track, `<dd>` across the remaining two.
+        LAYOUT_CLASSES = {
+          stacked: nil,
+          horizontal: "grid grid-cols-3 gap-x-2"
+        }.freeze
+
+        def initialize(label:, value: nil, layout: :stacked, **options)
+          @label = label
+          @value = value
+          @layout = LAYOUT_CLASSES.key?(layout) ? layout : :stacked
+          @options = options
+        end
+
+        private
+
+        attr_reader :label, :value, :layout, :options
+
+        def item_classes
+          class_names(BASE_CLASSES, LAYOUT_CLASSES[layout], options[:class])
+        end
+
+        def item_attributes
+          options.except(:class).merge(class: item_classes)
+        end
+
+        # LabelValue's typography, so a DescriptionList and a standalone
+        # LabelValue on the same page read as one family.
+        def label_classes
+          Bali::LabelValue::Component::LABEL_CLASSES
+        end
+
+        def value_classes
+          class_names(
+            Bali::LabelValue::Component::VALUE_CLASSES,
+            layout == :horizontal && "col-span-2"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/description_list/preview.rb
+++ b/app/components/bali/description_list/preview.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Bali
+  module DescriptionList
+    class Preview < ApplicationViewComponentPreview
+      # DescriptionList lays out a SET of label/value pairs in its own responsive
+      # grid. For a single pair you place yourself use `Bali::LabelValue`; when
+      # the set reads top to bottom like a table, use `Bali::PropertiesTable`.
+      #
+      # `layout: :horizontal` puts each term and its value side by side inside
+      # the cell instead of stacking them.
+      #
+      # @param columns select { choices: [1, 2, 3] }
+      # @param layout select { choices: [stacked, horizontal] }
+      def default(columns: 2, layout: :stacked)
+        render Bali::DescriptionList::Component.new(columns: columns.to_i, layout: layout.to_sym) do |c|
+          c.with_item(label: 'Full name', value: 'Juan Pérez')
+          c.with_item(label: 'Email', value: 'juan.perez@example.com')
+          c.with_item(label: 'Phone', value: '+52 664 123 4567')
+          c.with_item(label: 'Company', value: 'Grupo AFAL')
+          c.with_item(label: 'City', value: 'Tijuana, B.C.')
+          c.with_item(label: 'Member since', value: 'January 2024')
+        end
+      end
+
+      # Items accept block content instead of `value:` for rich values —
+      # a `Bali::Tag`, a link, or any HTML.
+      def with_rich_values
+        render_with_template
+      end
+    end
+  end
+end

--- a/app/components/bali/description_list/previews/with_rich_values.html.erb
+++ b/app/components/bali/description_list/previews/with_rich_values.html.erb
@@ -1,0 +1,12 @@
+<%= render Bali::DescriptionList::Component.new(columns: 2) do |c| %>
+  <% c.with_item(label: 'Status') do %>
+    <%= render Bali::Tag::Component.new(text: 'Active', color: :success) %>
+  <% end %>
+  <% c.with_item(label: 'Priority') do %>
+    <%= render Bali::Tag::Component.new(text: 'High', color: :warning) %>
+  <% end %>
+  <% c.with_item(label: 'Website') do %>
+    <a href="#" class="link link-primary">grupoafal.com</a>
+  <% end %>
+  <% c.with_item(label: 'Owner', value: 'Juan Pérez') %>
+<% end %>

--- a/app/components/bali/label_value/component.rb
+++ b/app/components/bali/label_value/component.rb
@@ -13,9 +13,13 @@ module Bali
     # one set read top to bottom: it renders a single `<table>` of `<th
     # scope="row">`/`<td>` rows, which gives a screen reader table navigation
     # over the whole set and one announcement of how many rows there are.
+    # Reach for `Bali::DescriptionList::Component` when the pairs form one set
+    # that wants a grid rather than table rows: ONE `<dl>` with a cell per
+    # pair, so the whole set stays a single list announced once.
     # LabelValue is the right call for a pair that stands on its own, or when
-    # each pair needs its own placement in a grid — every instance is its own
-    # one-pair list, so a run of them is a run of lists, not one set.
+    # each pair needs its own placement in a layout neither of those can
+    # express — every instance is its own one-pair list, so a run of them is
+    # a run of lists, not one set.
     class Component < ApplicationViewComponent
       LABEL_CLASSES = "font-bold text-xs text-base-content/70"
       VALUE_CLASSES = "min-h-6"

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -1433,6 +1433,41 @@ Slots: `with_filters_panel`, `with_simple_filters`, `with_content` (`with_table`
 Export is not one of them: `page.with_export` on the surrounding page component puts it in
 the page's `⋯` — see [Secondary page actions](#secondary-page-actions-and-export).
 
+#### DescriptionList
+
+A set of label/value pairs laid out in the component's own responsive grid — the middle ground between `LabelValue` (one pair you place yourself) and `PropertiesTable` (one set read as a table). Renders one `<dl>` whose items are `<div><dt/><dd/></div>` cells, with `dt`/`dd` reusing LabelValue's typography.
+
+```erb
+<%= render Bali::DescriptionList::Component.new(columns: 2) do |c| %>
+  <% c.with_item(label: 'Name', value: 'Juan Perez') %>
+  <% c.with_item(label: 'Email', value: 'juan@example.com') %>
+  <% c.with_item(label: 'Status') do %>
+    <%= render Bali::Tag::Component.new(text: 'Active', color: :success) %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `columns` - Grid columns: `1`, `2`, or `3`; `2` and `3` collapse to one column on small screens (default: 2)
+- `layout` - `:stacked` (label above value) or `:horizontal` (label and value side by side inside each cell) (default: :stacked)
+- `**options` - Additional HTML attributes for the `<dl>`
+
+**Slots:** `with_item(label:, value:)` — items accept block content instead of `value:` for rich values (a `Tag`, a link, any HTML), and pass extra HTML attributes through to the item's `<div>`.
+
+**LabelValue, DescriptionList, or PropertiesTable?** They render the same information and read differently.
+
+| | LabelValue | DescriptionList | PropertiesTable |
+|---|---|---|---|
+| Markup | one `<dl>` per pair | one `<dl>`, a grid cell per pair | one `<table>`, `<th scope="row">` per row |
+| Layout | you place each pair — a grid cell, a card, a column | its own responsive grid | rows, stacked, zebra-striped |
+| Screen reader | a run of them is a run of separate one-pair lists | one list announced once | one set, with table navigation and a row count |
+
+Use `PropertiesTable` when the pairs form **one set read top to bottom**, which is most detail
+pages. Use `DescriptionList` when the pairs form one set but want **a grid, not table rows** —
+the dense header block of a show page, a two-column details card. Use `LabelValue` for a pair
+that stands on its own, or when each pair needs its own placement in a layout neither grid can
+express.
+
 #### Heatmap
 
 Grid visualization that shows magnitude as color intensity across two dimensions, e.g. activity by day and hour.
@@ -1526,17 +1561,11 @@ Displays a small bold label above its value — a common pattern on show pages. 
 - `value` - Value to display; when nil, block content is rendered instead (default: nil)
 - `**options` - Additional HTML attributes
 
-**LabelValue or PropertiesTable?** They render the same information and read differently.
-
-| | LabelValue | PropertiesTable |
-|---|---|---|
-| Markup | one `<dl>` per pair | one `<table>`, `<th scope="row">` per row |
-| Layout | you place each pair — a grid cell, a card, a column | rows, stacked, zebra-striped |
-| Screen reader | a run of them is a run of separate one-pair lists | one set, with table navigation and a row count |
-
-Use `PropertiesTable` when the pairs form **one set read top to bottom**, which is most detail
-pages. Use `LabelValue` for a pair that stands on its own, or when each pair needs its own
-placement in a layout the table cannot express.
+**LabelValue, DescriptionList, or PropertiesTable?** LabelValue is the right call for a pair
+that stands on its own, or when each pair needs its own placement in a layout — every instance
+is its own one-pair list, so a run of them is a run of lists, not one set. When the pairs form
+one set, reach for `DescriptionList` (its own grid) or `PropertiesTable` (table rows) — the
+full comparison lives under [DescriptionList](#descriptionlist).
 
 It was a `<div>` holding a `<label>` through v2. A `<label>` with no control to point at
 labels nothing: the text and the value beside it were two unrelated nodes in the
@@ -1604,6 +1633,8 @@ Displays key-value pairs in a zebra-striped table — useful for showing object 
 - `**options` - Additional HTML attributes for the table (e.g. `class`)
 
 **Slots:** `with_property(label:, value:)` — properties also accept block content for rich values like tags or links.
+
+Prefer this over `LabelValue` or `DescriptionList` when the pairs form one set read top to bottom — the comparison of the three lives under [DescriptionList](#descriptionlist).
 
 #### Rate
 

--- a/test/bali/components/description_list_test.rb
+++ b/test/bali/components/description_list_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliDescriptionListComponentTest < ComponentTestCase
+  def render_list(**options)
+    render_inline(Bali::DescriptionList::Component.new(**options)) do |c|
+      c.with_item(label: "Name", value: "Juan Perez")
+      c.with_item(label: "Email", value: "juan@example.com")
+    end
+  end
+
+  def test_renders_a_dl_grid_of_div_wrapped_dt_dd_pairs
+    render_list
+    assert_selector("dl.grid.description-list-component")
+    assert_selector("dl > div.description-list-item-component", count: 2)
+    assert_selector("dl > div > dt", text: "Name")
+    assert_selector("dl > div > dd", text: "Juan Perez")
+  end
+
+  def test_defaults_to_two_responsive_columns
+    render_list
+    assert_selector("dl[class*='grid-cols-1'][class*='sm:grid-cols-2']")
+  end
+
+  def test_renders_a_single_column
+    render_list(columns: 1)
+    assert_selector("dl[class*='grid-cols-1']")
+    assert_no_selector("dl[class*='sm:grid-cols-2']")
+  end
+
+  def test_renders_three_responsive_columns
+    render_list(columns: 3)
+    assert_selector("dl[class*='sm:grid-cols-2'][class*='lg:grid-cols-3']")
+  end
+
+  def test_falls_back_to_two_columns_for_an_unknown_count
+    render_list(columns: 7)
+    assert_selector("dl[class*='grid-cols-1'][class*='sm:grid-cols-2']")
+  end
+
+  def test_stacked_layout_does_not_turn_the_item_into_a_grid
+    render_list
+    assert_no_selector("dl > div.grid")
+  end
+
+  def test_horizontal_layout_puts_term_and_value_side_by_side
+    render_list(layout: :horizontal)
+    assert_selector("dl > div.grid[class*='grid-cols-3']", count: 2)
+    assert_selector("dl > div > dd[class*='col-span-2']", text: "Juan Perez")
+  end
+
+  def test_falls_back_to_stacked_for_an_unknown_layout
+    render_list(layout: :sideways)
+    assert_no_selector("dl > div.grid")
+  end
+
+  def test_renders_block_content_when_value_is_nil
+    render_inline(Bali::DescriptionList::Component.new) do |c|
+      c.with_item(label: "Status") { "Rich content" }
+    end
+    assert_selector("dd", text: "Rich content")
+  end
+
+  def test_prefers_value_over_block_content_when_both_provided
+    render_inline(Bali::DescriptionList::Component.new) do |c|
+      c.with_item(label: "Name", value: "From value") { "From block" }
+    end
+    assert_selector("dd", text: "From value")
+    assert_no_text("From block")
+  end
+
+  def test_reuses_label_value_typography_on_dt_and_dd
+    render_list
+    assert_selector("dt.font-bold.text-xs", text: "Name")
+    assert_selector("dd.min-h-6", text: "Juan Perez")
+  end
+
+  def test_merges_custom_classes_and_passes_attributes_through_on_the_dl
+    render_inline(Bali::DescriptionList::Component.new(class: "custom-class", data: { testid: "dl" })) do |c|
+      c.with_item(label: "Name", value: "Test")
+    end
+    assert_selector("dl.grid.custom-class[data-testid='dl']")
+  end
+
+  def test_merges_custom_classes_and_passes_attributes_through_on_items
+    render_inline(Bali::DescriptionList::Component.new) do |c|
+      c.with_item(label: "Name", value: "Test", class: "item-class", data: { testid: "item" })
+    end
+    assert_selector("dl > div.description-list-item-component.item-class[data-testid='item']")
+  end
+end


### PR DESCRIPTION
Nuevo `Bali::DescriptionList::Component`: el hueco entre `LabelValue` (un par suelto que coloca el caller) y `PropertiesTable` (un set leído de corrido como tabla). Refs #727

## Qué hace

- **Un solo `<dl>`** con una celda `<div><dt/><dd/></div>` por par (div envolviendo dt/dd dentro de dl es HTML válido) — el set entero es UNA lista para el screen reader, no una corrida de listas de un par.
- **`columns:`** 1/2/3 con colapso responsive (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`), safelist en hash congelado — mismo patrón que `STATS_COLUMNS` de DashboardPage para que el purger de Tailwind vea las clases literales. Valor desconocido cae al default (2).
- **`layout:`** `:stacked` (default, la forma de costa-norte) | `:horizontal` (dt/dd lado a lado dentro de la celda: `grid-cols-3` con `dd` en `col-span-2`, calcando la forma de centinela en operations_board) — la decisión 1 del análisis, resuelta por la recomendación.
- **`with_item(label:, value:)`** con bloque para valores ricos (Tag, links, HTML) — el nombre que pedía el issue (decisión 2). Los atributos extra pasan al `<div>` del item.
- **Tipografía compartida:** `dt`/`dd` reutilizan `LABEL_CLASSES`/`VALUE_CLASSES` de `Bali::LabelValue` para que las tres opciones se vean familia.
- **Docs:** la guía gana la sección DescriptionList con la tabla comparativa de las tres opciones; LabelValue y PropertiesTable apuntan a ella (la tabla de dos vías que vivía en LabelValue se extiende y se muda, no se duplica). El comment de `LabelValue::Component` extiende su criterio. CHANGELOG bajo `[Unreleased]`.

Sin CSS propio ni JS: puro Tailwind por utilidades, cero Cypress.

## Verificación

- Minitest: `test/bali/components/description_list_test.rb` — 13 tests (markup dl/div/dt/dd, columnas y fallback, layouts y fallback, bloque vs `value:`, tipografía, passthrough en dl e items) + los de LabelValue: 21 runs, 0 failures.
- Rubocop: 4 files inspected, no offenses.
- Lookbook contra el dummy del worktree: `default` (params columns/layout), `default?layout=horizontal` y `with_rich_values` responden **200** y el markup rendereado trae `sm:grid-cols-2`/`grid-cols-3 gap-x-2`/`badge-success` (el Tag del bloque renderea, no imprime HTML escapado).
- CSS compilado verificado: `sm:grid-cols-2`, `lg:grid-cols-3`, `col-span-2`, `gap-x-6` presentes en `builds/tailwind.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
