### PR TITLE
refactor(filters): deuda de duplicaciones — PreservedParams compartido, Persistable y divider del combinator (#725 PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SimpleFilters lost the listing URL's own query params on every submit.** A GET submit replaces the action's query string with the form's fields, so a host passing `url:` with params of its own (a scope such as `status=historico`) saw them silently dropped each time the simple form was applied — the "Clear" link preserved them (beta.6), the submit did not. The form now re-emits the non-filter query params of its `url:` as hidden fields with the exact semantics `Bali::Filters::Component` always had: `q`, `clear_filters`, `clear_search` and `saved_view` stay out, and on a key collision the explicit `preserved_params:` hash wins, so a host already passing the param by hand does not emit it twice. (Refs #725)
+
+### Changed
+
+- **Filters/SimpleFilters internal dedup — no rendered-output change for the full panel.** The preserved-params semantics above now live in one shared `Bali::Filters::PreservedParams` module; the `storage_id`/`persist_enabled?`/`persistence_toggle?` persistence trio both components copied is now the `Bali::Filters::Persistable` concern; and the AND/OR combinator divider the panel template carried twice (popover and inline branches) is the `Bali::Filters::CombinatorDivider::Component` subcomponent. (Refs #725)
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/app/components/bali/data_table/simple_filters/component.html.erb
+++ b/app/components/bali/data_table/simple_filters/component.html.erb
@@ -1,8 +1,9 @@
 <%= form_with url: @url, method: :get, builder: Bali::FormBuilder, data: { turbo_frame: "_top" } do |f| %>
-  <%# Preserve top-level params (e.g. an active group_by) across the GET submit %>
-  <% preserved_params.each do |name, value| %>
-    <%= tag.input(type: "hidden", name: name, value: value) %>
-  <% end %>
+  <%# Preserve top-level params across the GET submit: el browser descarta el query de la
+      action en un submit GET, así que tanto los params propios de la `url:` del host (un
+      scope como `status=historico`) como los explícitos (`preserved_params`, p. ej. un
+      `group_by` activo) se re-emiten como hidden fields — misma semántica que Filters. %>
+  <%= preserved_params_hidden_fields %>
   <%# El scroll horizontal es del teléfono: arriba de `sm` la fila envuelve
       (`sm:flex-wrap`) y no scrollea nunca. Pero `overflow-x-auto` seguía puesto en todos
       los anchos, y eso hace de la fila un contenedor de scroll, que RECORTA en su caja de

--- a/app/components/bali/data_table/simple_filters/component.rb
+++ b/app/components/bali/data_table/simple_filters/component.rb
@@ -18,6 +18,8 @@ module Bali
       #
       class Component < ApplicationViewComponent
         include Utils::Url
+        include Bali::Filters::PreservedParams
+        include Bali::Filters::Persistable
 
         # Min-width for slim_select dropdowns. Triggers in SimpleFilters are narrow
         # (~13rem), so we let the dropdown grow past the trigger to fit long labels
@@ -40,7 +42,10 @@ module Bali
         # @param persistence_toggle [Boolean] Render the bookmark toggle inline (default: true).
         #   DataTable turns it off and paints it as its own toolbar control.
         # @param preserved_params [Hash] Extra top-level params (e.g. an active
-        #   `group_by`) rendered as hidden fields so the GET submit keeps them
+        #   `group_by`) rendered as hidden fields so the GET submit keeps them.
+        #   Non-filter params already in the `url:` query string travel too
+        #   (same semantics as Filters::Component); on a key collision the
+        #   explicit hash wins.
         # rubocop:disable Metrics/ParameterLists
         def initialize(url:, filters: [], show_clear: false, search: nil, storage_id: nil,
                        persist_enabled: false, persistence_toggle: true, preserved_params: {})
@@ -55,32 +60,12 @@ module Bali
           @preserved_params = preserved_params || {}
         end
 
-        attr_reader :storage_id
-
-        # Top-level params to carry through the GET submit as hidden fields.
-        # Blank values are dropped so no empty inputs are emitted.
-        def preserved_params
-          @preserved_params.reject { |_, value| value.to_s.blank? }
-        end
-
         def render?
           @filters.any? || search_enabled?
         end
 
         def show_clear?
           @show_clear
-        end
-
-        # Returns true if user has enabled persistence
-        def persist_enabled?
-          @persist_enabled
-        end
-
-        # El DataTable pinta el marcador como control propio de la toolbar y apaga este: dos
-        # controladores `filter-persistence` sobre el mismo storage_id se pisan el
-        # localStorage y la cookie.
-        def persistence_toggle?
-          @persistence_toggle
         end
 
         def search_enabled?

--- a/app/components/bali/filters/combinator_divider/component.html.erb
+++ b/app/components/bali/filters/combinator_divider/component.html.erb
@@ -1,0 +1,19 @@
+<div class="flex items-center justify-center gap-2 my-2">
+  <div class="flex-1 border-t border-base-300"></div>
+  <input type="hidden" name="q[m]" value="<%= combinator %>" data-filters-target="groupCombinator">
+  <div class="join" data-filters-target="groupCombinatorToggle">
+    <button type="button"
+            class="join-item btn btn-xs w-10 <%= combinator == 'and' ? 'btn-primary' : 'btn-outline' %>"
+            data-action="filters#setGroupCombinator"
+            data-combinator="and">
+      <%= t('bali_view.filters.combinators.and') %>
+    </button>
+    <button type="button"
+            class="join-item btn btn-xs w-10 <%= combinator == 'or' ? 'btn-primary' : 'btn-outline' %>"
+            data-action="filters#setGroupCombinator"
+            data-combinator="or">
+      <%= t('bali_view.filters.combinators.or') %>
+    </button>
+  </div>
+  <div class="flex-1 border-t border-base-300"></div>
+</div>

--- a/app/components/bali/filters/combinator_divider/component.rb
+++ b/app/components/bali/filters/combinator_divider/component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bali
+  module Filters
+    module CombinatorDivider
+      # Divider with the AND/OR toggle rendered between filter groups. Extracted
+      # because the popover and inline branches of `Filters::Component` carried
+      # the same markup twice.
+      #
+      # The markup mirrors `createCombinatorDivider` in
+      # `filters/controllers/filters_controller.js` (the copy for groups added
+      # client-side); the root keeps the `flex` class because `removeGroup`
+      # identifies dividers by it when deleting adjacent siblings.
+      class Component < ApplicationViewComponent
+        attr_reader :combinator
+
+        # @param combinator [String] "and" or "or" - the currently-applied group combinator
+        def initialize(combinator:)
+          @combinator = combinator
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/filters/component.html.erb
+++ b/app/components/bali/filters/component.html.erb
@@ -105,25 +105,7 @@
                   <% filter_groups.each_with_index do |group, group_idx| %>
                     <% if group_idx > 0 %>
                       <%# Group combinator divider (AND/OR toggle between groups) %>
-                      <div class="flex items-center justify-center gap-2 my-2">
-                        <div class="flex-1 border-t border-base-300"></div>
-                        <input type="hidden" name="q[m]" value="<%= combinator %>" data-filters-target="groupCombinator">
-                        <div class="join" data-filters-target="groupCombinatorToggle">
-                          <button type="button"
-                                class="join-item btn btn-xs w-10 <%= combinator == 'and' ? 'btn-primary' : 'btn-outline' %>"
-                                data-action="filters#setGroupCombinator"
-                                data-combinator="and">
-                            <%= t('bali_view.filters.combinators.and') %>
-                          </button>
-                          <button type="button"
-                                class="join-item btn btn-xs w-10 <%= combinator == 'or' ? 'btn-primary' : 'btn-outline' %>"
-                                data-action="filters#setGroupCombinator"
-                                data-combinator="or">
-                            <%= t('bali_view.filters.combinators.or') %>
-                          </button>
-                        </div>
-                        <div class="flex-1 border-t border-base-300"></div>
-                      </div>
+                      <%= render Bali::Filters::CombinatorDivider::Component.new(combinator: combinator) %>
                     <% end %>
 
                     <%= render Bali::Filters::FilterGroup::Component.new(
@@ -237,25 +219,7 @@
           <% filter_groups.each_with_index do |group, group_idx| %>
             <% if group_idx > 0 %>
               <%# Group combinator divider (AND/OR toggle between groups) %>
-              <div class="flex items-center justify-center gap-2 my-2">
-                <div class="flex-1 border-t border-base-300"></div>
-                <input type="hidden" name="q[m]" value="<%= combinator %>" data-filters-target="groupCombinator">
-                <div class="join" data-filters-target="groupCombinatorToggle">
-                  <button type="button"
-                                class="join-item btn btn-xs w-10 <%= combinator == 'and' ? 'btn-primary' : 'btn-outline' %>"
-                                data-action="filters#setGroupCombinator"
-                                data-combinator="and">
-                    <%= t('bali_view.filters.combinators.and') %>
-                  </button>
-                  <button type="button"
-                                class="join-item btn btn-xs w-10 <%= combinator == 'or' ? 'btn-primary' : 'btn-outline' %>"
-                                data-action="filters#setGroupCombinator"
-                                data-combinator="or">
-                    <%= t('bali_view.filters.combinators.or') %>
-                  </button>
-                </div>
-                <div class="flex-1 border-t border-base-300"></div>
-              </div>
+              <%= render Bali::Filters::CombinatorDivider::Component.new(combinator: combinator) %>
             <% end %>
 
             <%= render Bali::Filters::FilterGroup::Component.new(

--- a/app/components/bali/filters/component.rb
+++ b/app/components/bali/filters/component.rb
@@ -3,13 +3,11 @@
 module Bali
   module Filters
     class Component < ApplicationViewComponent
-      # `saved_view` NO se preserva: re-enviarlo hace que el server re-aplique el payload de
-      # la vista, pisando en silencio los filtros o la búsqueda que el usuario acaba de
-      # escribir. (`page` sí viaja: preservarlo es comportamiento deliberado de Bali.)
-      EXCLUDED_PARAMS = %w[q clear_filters clear_search saved_view].freeze
+      include Bali::Filters::PreservedParams
+      include Bali::Filters::Persistable
 
       attr_reader :url, :available_attributes, :apply_mode, :id, :popover, :combinator,
-                  :filter_groups, :max_groups, :storage_id, :persist_enabled, :turbo_stream
+                  :filter_groups, :max_groups, :turbo_stream
 
       # Renders the applied filter pills above the filter builder
       renders_one :applied_tags, ->(**options) do
@@ -84,24 +82,6 @@ module Bali
         @id = options[:id] || "filters-#{SecureRandom.hex(4)}"
       end
       # rubocop:enable Metrics/ParameterLists
-
-      # Returns true if persistence is available (storage_id is configured)
-      def persistence_available?
-        @storage_id.present?
-      end
-
-      # Returns true if user has enabled persistence
-      def persist_enabled?
-        @persist_enabled
-      end
-
-      # El DataTable pinta el marcador como control propio de la toolbar y apaga este: dos
-      # controladores `filter-persistence` sobre el mismo storage_id se pisan el localStorage
-      # y la cookie. Apaga SOLO el toggle — el panel sigue necesitando storage_id y
-      # persist_enabled para su leyenda "Auto-guardado".
-      def persistence_toggle?
-        @persistence_toggle
-      end
 
       def button_text
         @button_text || I18n.t("bali_view.filters.filters_button")
@@ -179,34 +159,6 @@ module Bali
         }.to_json
       end
 
-      # Extract non-filter query params to preserve them when submitting.
-      # Combines params parsed from the URL with any explicitly-passed
-      # `preserved_params` (e.g. an active `group_by`), which win on key
-      # collisions. Returns an array of [name, value] pairs for hidden_field_tag.
-      def preserved_query_params
-        query_string = URI.parse(url).query
-        from_url = if query_string.blank?
-                     []
-        else
-                     params = Rack::Utils.parse_nested_query(query_string)
-                     flatten_params(params.except(*EXCLUDED_PARAMS))
-        end
-
-        explicit = flatten_params(@preserved_params.stringify_keys).reject { |_, value| value.to_s.blank? }
-        explicit_keys = explicit.map(&:first)
-        from_url.reject { |name, _| explicit_keys.include?(name) } + explicit
-      end
-
-      # Render hidden fields for preserved params (call from template).
-      # `id: nil` como en active_filter_hidden_fields: en modo popover estos campos se pintan
-      # en los DOS forms (búsqueda rápida y panel), y con id derivado del name quedaban ids
-      # duplicados en el documento.
-      def preserved_params_hidden_fields
-        safe_join(
-          preserved_query_params.map { |name, value| helpers.hidden_field_tag(name, value, id: nil) }
-        )
-      end
-
       # Hidden fields carrying the APPLIED filter state (q[g][...]/q[m]), so the quick-search
       # form preserves active filters instead of clearing them. Serializes `filter_groups`
       # back into the same Ransack param shape the filter form submits; the consolidated
@@ -251,20 +203,6 @@ module Bali
           condition[:value].map { |v| [ "#{base}_#{condition[:operator]}][]", v ] }
         else
           [ [ "#{base}_#{condition[:operator]}]", condition[:value] ] ]
-        end
-      end
-
-      # Recursively flatten nested params hash into [name, value] pairs.
-      # e.g., {"sort" => {"column" => "name"}} becomes [["sort[column]", "name"]]
-      def flatten_params(params, prefix = nil)
-        params.flat_map do |key, value|
-          field_name = prefix ? "#{prefix}[#{key}]" : key.to_s
-
-          case value
-          when Hash  then flatten_params(value, field_name)
-          when Array then value.map { |v| [ "#{field_name}[]", v ] }
-          else            [ [ field_name, value ] ]
-          end
         end
       end
 

--- a/app/components/bali/filters/persistable.rb
+++ b/app/components/bali/filters/persistable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Bali
+  module Filters
+    # The persistence trio shared by `Filters::Component` and
+    # `DataTable::SimpleFilters::Component`. `DataTable#capture_persistence`
+    # coordinates both: it lifts the bookmark toggle out of whichever form is in
+    # use and paints it once as a toolbar control.
+    #
+    # Includers must set `@storage_id`, `@persist_enabled` and
+    # `@persistence_toggle` in their initializer.
+    module Persistable
+      attr_reader :storage_id, :persist_enabled
+
+      # Returns true if persistence is available (storage_id is configured)
+      def persistence_available?
+        @storage_id.present?
+      end
+
+      # Returns true if user has enabled persistence
+      def persist_enabled?
+        @persist_enabled
+      end
+
+      # El DataTable pinta el marcador como control propio de la toolbar y apaga este: dos
+      # controladores `filter-persistence` sobre el mismo storage_id se pisan el localStorage
+      # y la cookie. Apaga SOLO el toggle — el form sigue necesitando storage_id y
+      # persist_enabled (la leyenda "Auto-guardado" del panel sale de ahí).
+      def persistence_toggle?
+        @persistence_toggle
+      end
+    end
+  end
+end

--- a/app/components/bali/filters/preserved_params.rb
+++ b/app/components/bali/filters/preserved_params.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Bali
+  module Filters
+    # Shared semantics for what a filter form carries through its GET submit.
+    #
+    # A GET submit replaces the action's query string with the form's fields, so
+    # anything living in the listing URL (a host scope, `page`, `sort`) is lost
+    # unless it is re-emitted as hidden fields. Both `Filters::Component` and
+    # `DataTable::SimpleFilters::Component` include this module so the two forms
+    # preserve params with ONE semantic: query params parsed from `url:` plus the
+    # explicit `preserved_params:` hash, deduplicated with explicit winning.
+    #
+    # Includers must set `@url` and `@preserved_params` in their initializer.
+    module PreservedParams
+      # `saved_view` NO se preserva: re-enviarlo hace que el server re-aplique el payload de
+      # la vista, pisando en silencio los filtros o la búsqueda que el usuario acaba de
+      # escribir. (`page` sí viaja: preservarlo es comportamiento deliberado de Bali.)
+      EXCLUDED_PARAMS = %w[q clear_filters clear_search saved_view].freeze
+
+      # Extract non-filter query params to preserve them when submitting.
+      # Combines params parsed from the URL with any explicitly-passed
+      # `preserved_params` (e.g. an active `group_by`), which win on key
+      # collisions. Returns an array of [name, value] pairs for hidden_field_tag.
+      def preserved_query_params
+        query_string = URI.parse(@url).query
+        from_url = if query_string.blank?
+                     []
+        else
+                     params = Rack::Utils.parse_nested_query(query_string)
+                     flatten_params(params.except(*EXCLUDED_PARAMS))
+        end
+
+        explicit = flatten_params(@preserved_params.stringify_keys).reject { |_, value| value.to_s.blank? }
+        explicit_keys = explicit.map(&:first)
+        from_url.reject { |name, _| explicit_keys.include?(name) } + explicit
+      end
+
+      # Render hidden fields for preserved params (call from template).
+      # `id: nil` porque estos campos pueden pintarse en más de un form del mismo documento
+      # (en modo popover van en el de búsqueda rápida Y en el del panel), y con id derivado
+      # del name quedaban ids duplicados.
+      def preserved_params_hidden_fields
+        safe_join(
+          preserved_query_params.map { |name, value| helpers.hidden_field_tag(name, value, id: nil) }
+        )
+      end
+
+      private
+
+      # Recursively flatten nested params hash into [name, value] pairs.
+      # e.g., {"sort" => {"column" => "name"}} becomes [["sort[column]", "name"]]
+      def flatten_params(params, prefix = nil)
+        params.flat_map do |key, value|
+          field_name = prefix ? "#{prefix}[#{key}]" : key.to_s
+
+          case value
+          when Hash  then flatten_params(value, field_name)
+          when Array then value.map { |v| [ "#{field_name}[]", v ] }
+          else            [ [ field_name, value ] ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/bali/components/data_table/simple_filters_test.rb
+++ b/test/bali/components/data_table/simple_filters_test.rb
@@ -47,6 +47,41 @@ class BaliDataTableSimpleFiltersComponentTest < ComponentTestCase
     assert_no_selector("input[type=hidden][name=group_by]", visible: :all)
   end
 
+  # Misma semántica que Filters::Component (módulo compartido PreservedParams): el browser
+  # descarta el query de la action en un submit GET, así que un host que pasa `url:` con
+  # params propios (un scope como `status=historico`) los perdía en cada submit del form
+  # simple. El link Limpiar ya los conservaba (clear_href); el submit no.
+  def test_reemits_non_filter_query_params_from_url_as_hidden_fields
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(
+      url: "/test?status=historico&page=2", filters: @filters
+    ))
+    assert_selector("form input[type=hidden][name=status][value=historico]", visible: :all)
+    assert_selector("form input[type=hidden][name=page][value='2']", visible: :all)
+  end
+
+  def test_does_not_reemit_filter_or_clearing_params_from_url
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(
+      url: "/test?q%5Bstatus_eq%5D=active&clear_filters=true&clear_search=true&saved_view=5&page=2",
+      filters: @filters
+    ))
+    assert_no_selector("input[type=hidden][name='q[status_eq]']", visible: :all)
+    assert_no_selector("input[type=hidden][name=clear_filters]", visible: :all)
+    assert_no_selector("input[type=hidden][name=clear_search]", visible: :all)
+    assert_no_selector("input[type=hidden][name=saved_view]", visible: :all)
+    assert_selector("form input[type=hidden][name=page][value='2']", visible: :all)
+  end
+
+  # Regla de deduplicación heredada de Filters: en colisión de key, el hash explícito gana
+  # sobre el query de la URL — sin esto un host que ya pasaba el param a mano por
+  # `preserved_params:` lo emitiría dos veces.
+  def test_explicit_preserved_params_win_over_url_query_params
+    render_inline(Bali::DataTable::SimpleFilters::Component.new(
+      url: "/test?group_by=status", filters: @filters, preserved_params: { "group_by" => "genre" }
+    ))
+    assert_selector("form input[type=hidden][name=group_by][value=genre]", visible: :all)
+    assert_no_selector("input[type=hidden][name=group_by][value=status]", visible: :all)
+  end
+
   def test_renders_visible_filter_label
     render_inline(Bali::DataTable::SimpleFilters::Component.new(url: "/test", filters: @filters))
     assert_selector("label", text: "Status")


### PR DESCRIPTION
PR3 de deuda del cluster filters-data: cierra las tres duplicaciones de la beta.1 que quedaban entre `Bali::Filters::Component` y `Bali::DataTable::SimpleFilters::Component`. Va temprano a propósito, por las colisiones del programa v3.1 en Filters/SimpleFilters.

Refs #725

## Qué cambia

**1. Semántica única de `preserved_params` — módulo compartido `Bali::Filters::PreservedParams`.**
`Filters::Component` parseaba el query de su `url:` y lo re-emitía como hidden fields; SimpleFilters solo re-emitía el hash explícito. Consecuencia (el gap real, memoria `filter-form-param-round-trip`): un host que pasa `url:` con query propio (un scope como `status=historico` en afal-apps) lo perdía en cada submit GET del form simple — el browser descarta el query de la action en GET. El link "Limpiar" de beta.6 ya los conservaba; el submit no.

Ahora ambos forms preservan con la MISMA regla, extraída sin cambios de `Filters::Component`: query de la `url:` menos `EXCLUDED_PARAMS` (`q`, `clear_filters`, `clear_search`, `saved_view`) + hash explícito, que gana en colisión de key — así un host que ya pasaba el param a mano por `preserved_params:` no lo emite dos veces (el riesgo que nombra el spec).

**2. Divider del combinator unificado — subcomponente `Bali::Filters::CombinatorDivider::Component`.**
El markup del toggle AND/OR entre grupos estaba dos veces en el template del panel (ramas popover e inline). El subcomponente rinde markup byte-idéntico (verificado contra el render previo); la raíz conserva la clase `flex` porque `removeGroup` del controller identifica los dividers por ella.

**3. Concern `Bali::Filters::Persistable`.**
El trío `storage_id` / `persist_enabled?` / `persistence_toggle?` estaba copiado en los dos components (con `capture_persistence` del DataTable coordinándolos — eso no se toca). SimpleFilters gana de paso `persistence_available?`, que solo existía en el panel.

Ninguna firma de constructor cambia; no hay cambios de docs porque la guía no documentaba `preserved_params`.

## Comportamiento

- `Filters::Component`: idéntico (métodos movidos tal cual a los módulos; divider byte-idéntico).
- `SimpleFilters`: un solo cambio deliberado, el fix del punto 1 — registrado en CHANGELOG bajo *Fixed*.

## Verificación

- Minitest antes (base `origin/3.1`): 210 runs verdes en los archivos de filters/data_table; después: 213 (3 tests nuevos de la semántica unificada), 0 fallos. Suite completa: **3771 runs, 0 fallos**. Rubocop limpio.
- Browser (dummy en :3041): previews de `filters` y `data_table/simple_filters` en 200; `/admin/studios?view=grid` re-emite `<input type="hidden" name="view" value="grid">` en el form simple (ruta DataTable → preserved_params end-to-end); divider renderizado idéntico al anterior (targets `groupCombinator`/`groupCombinatorToggle`, estado activo correcto).
- Cypress (electron, contra :3041): `filters-controller`, `filters-condition-controller`, `filter-persistence-simple-filters` — **19/19 verdes** (cubre agregar/quitar grupos y el toggle del combinator sobre el divider extraído).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
