### PR TITLE
Bali::Gantt fase 1: contrato de datos + modo :static server-rendered (#704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::Gantt` — phase 1: the shared data contract and the server-rendered `:static` mode** (#704). One component, two renderers; this phase ships the foundation the React island (phases 2-3, #705/#719) will plug into:
+  - `Bali::Gantt::Data` parses and validates the frozen contract — `{ window, groups[], items[], dependencies[], critical_ids[] }` with two-level group/item nesting (`parent_id`), ISO8601 dates, and the optional fields the real island already consumes: `assignee`, `percent_complete`, `slack_days`, `priority`, plus `milestone:` (rendered as a diamond) and `href`. Single-date items draw as minimum-width bars, inverted ranges clamp to their start, and structural errors raise instead of silently dropping bars. A frozen sample of `TDFlow::GanttSerializer` output validates the rename mapping (`test/fixtures/gantt/`).
+  - `Bali::Gantt::TimeScale` — one day-based coordinate system shared with the future island (`px_per_day` 24/8/2 for day/week/month, exactly `ZoomControls.jsx`), `:auto` density picked from the window span, minimum bar width, inclusive ends, clipped calendar ticks/bands and the today marker.
+  - `Bali::Gantt::Colors` — the exact `color-mix`/oklch formulas of the island's `ganttColors.js` (verbatim-asserted in tests) so both renderers are visually identical; default status map plus support for host status catalogs.
+  - `Bali::Gantt::Component` `mode: :static` — sticky two-tier header, collapsible `<details>` groups (with their own rollup bars), today line, grid, `color_by: :status/:none`, zoom by links on a namespaced `gantt_zoom` param, `group_label:`, an announced `limit:` cap (never silent) and a "No dates" section. This closes the `color_by:` promise made to #667. `mode: :interactive` is part of the signature already and raises with a clear message until phase 3.
+  - Structural `--gantt-*` tokens in `@layer components`, `bali_view.gantt.*` locales (en/es), Lookbook previews, and a full dummy reference: `/admin/projects/:id?view=timeline` renders the timeline from seeded schedule data through `ProjectGantt`, a host-side reference implementation of the contract.
+
 ## [v3.0.0] - 2026-08-05
 
 **v3 goes stable.** Same code as `v3.0.0.beta.6` — this release promotes the beta line to

--- a/app/assets/stylesheets/bali/components.css
+++ b/app/assets/stylesheets/bali/components.css
@@ -16,6 +16,7 @@
 
 /* Data Display Components */
 @import "../../../components/bali/calendar/index.css" layer(components);
+@import "../../../components/bali/gantt/index.css" layer(components);
 @import "../../../components/bali/carousel/index.css" layer(components);
 @import "../../../components/bali/timeline/index.css" layer(components);
 @import "../../../components/bali/tooltip/index.css" layer(components);

--- a/app/components/bali/gantt/colors.rb
+++ b/app/components/bali/gantt/colors.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Bali
+  module Gantt
+    # Color system of the Gantt (#704) — the EXACT formulas of the React
+    # island's ganttColors.js, so the server-rendered `:static` mode and the
+    # phase-2 island are visually identical bar for bar. Every color is a hash
+    # { solid:, fill:, border:, text: }: bar body (fill+border), progress
+    # overlay (solid) and legend/badges (solid/text) share one treatment.
+    #
+    # Values are CSS strings over daisyUI 5 theme variables
+    # (`color-mix(in oklch, var(--color-*) N%, transparent)`), meant for INLINE
+    # styles — computed colors never go into interpolated Tailwind classes,
+    # which v4 purges.
+    module Colors
+      # Default status → daisyUI color variable map (ganttColors.js STATUS_VAR).
+      # nil = neutral (gray) treatment. Hosts with other status vocabularies
+      # pass their own catalog to the component instead of patching this.
+      DEFAULT_STATUS_VARS = {
+        "backlog" => nil,
+        "in_progress" => "--color-info",
+        "ready_for_review" => "--color-warning",
+        "complete" => "--color-success",
+        "cancelled" => nil
+      }.freeze
+
+      module_function
+
+      # ganttColors.js neutralColor().
+      def neutral
+        {
+          solid: "color-mix(in oklch, var(--color-base-content) 42%, transparent)",
+          fill: "color-mix(in oklch, var(--color-base-content) 10%, transparent)",
+          border: "color-mix(in oklch, var(--color-base-content) 30%, transparent)",
+          text: "color-mix(in oklch, var(--color-base-content) 62%, transparent)"
+        }
+      end
+
+      # ganttColors.js varColor(): color from a daisyUI variable (e.g.
+      # "--color-info"). fill/border derive by color-mix so no opaque token the
+      # theme might not define is needed.
+      def var_color(css_var)
+        color = "var(#{css_var})"
+        {
+          solid: color,
+          fill: "color-mix(in oklch, #{color} 16%, transparent)",
+          border: "color-mix(in oklch, #{color} 50%, transparent)",
+          text: color
+        }
+      end
+
+      # ganttColors.js statusColor(): daisyUI variable when the status maps to
+      # one, neutral otherwise.
+      def status_color(status, vars: DEFAULT_STATUS_VARS)
+        var = vars[status.to_s]
+        var ? var_color(var) : neutral
+      end
+
+      # ganttColors.js hueColor(): free-hue color (assignee/phase/priority
+      # modes land in phase 2; the formula is ported now for parity).
+      def hue_color(hue)
+        return neutral if hue.nil?
+
+        {
+          solid: "oklch(0.62 0.15 #{hue})",
+          fill: "oklch(0.62 0.15 #{hue} / 0.15)",
+          border: "oklch(0.6 0.15 #{hue} / 0.5)",
+          text: "oklch(0.46 0.16 #{hue})"
+        }
+      end
+
+      # ganttColors.js hashHue(): stable 0..359 hue from a string (same
+      # algorithm, so Ruby and JS color the same assignee identically).
+      def hash_hue(value)
+        value.to_s.each_char.reduce(0) { |hash, char| (hash * 31 + char.ord) % 360 }
+      end
+    end
+  end
+end

--- a/app/components/bali/gantt/component.html.erb
+++ b/app/components/bali/gantt/component.html.erb
@@ -1,0 +1,176 @@
+<%# Static Gantt (#704): generalized port of afal-apps' portfolio board. One scroll
+    container gives the sticky two-tier header (sticky top) and the sticky name
+    column (sticky left) without JavaScript; groups collapse with `<details>`.
+    Grid lines and the today marker are absolute divs spanning the full content
+    height — one node per tick, exact at true month widths (the gradient trick the
+    portfolio used assumes a fixed period, which day-based month columns don't have).
+    Computed geometry/colors ride inline styles; every class here is literal. %>
+<%= tag.div(**wrapper_attributes) do %>
+  <% if renderable? && (legend_entries.any? || zoom_links?) %>
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <% legend_entries.each do |entry| %>
+          <span class="flex items-center gap-1.5 text-xs text-base-content/70">
+            <span class="bali-gantt-swatch" style="background-color: <%= entry[:color] %>"></span>
+            <%= entry[:label] %>
+          </span>
+        <% end %>
+      </div>
+      <% if zoom_links? %>
+        <div class="join" role="group" aria-label="<%= t('.zoom.label') %>">
+          <% zoom_link_options.each do |option| %>
+            <%= render Bali::Link::Component.new(
+                  name: option[:label],
+                  href: option[:href],
+                  variant: :ghost,
+                  size: :xs,
+                  class: class_names("join-item", "btn-active" => option[:active])) %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if data.truncated? %>
+    <div class="alert alert-warning py-2 text-sm" role="status">
+      <%= t(".truncated", shown: data.dated_items.size, total: data.dated_total) %>
+    </div>
+  <% end %>
+
+  <% if renderable? %>
+    <div class="bali-gantt-canvas relative max-h-[70vh] overflow-auto rounded-lg border border-base-300 bg-base-100"
+         role="region" aria-label="<%= t('.label') %>" tabindex="0">
+      <div class="relative" style="<%= canvas_width_css %>">
+        <% time_scale.ticks.each do |tick| %>
+          <div class="bali-gantt-gridline" style="left: calc(var(--gantt-name-col) + <%= tick[:x] %>px)"></div>
+        <% end %>
+        <% if time_scale.today_x %>
+          <div class="bali-gantt-today" style="left: calc(var(--gantt-name-col) + <%= time_scale.today_x %>px)"
+               title="<%= t('.today') %>"></div>
+        <% end %>
+
+        <div class="sticky top-0 z-30 flex border-b border-base-300 bg-base-100" style="<%= canvas_width_css %>">
+          <div class="bali-gantt-name-cell sticky left-0 z-10 flex shrink-0 items-end border-r border-base-300 bg-base-100 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-base-content/50">
+            <%= group_label %>
+          </div>
+          <div class="relative shrink-0" style="<%= lane_width_css %>">
+            <div class="relative h-5">
+              <% time_scale.bands.each do |band| %>
+                <div class="absolute top-0 h-5 overflow-hidden border-l border-base-300 px-1 text-xs font-semibold whitespace-nowrap text-base-content/70"
+                     style="left: <%= band[:x] %>px; width: <%= band[:width] %>px"><%= band[:label] %></div>
+              <% end %>
+            </div>
+            <div class="relative h-5">
+              <% time_scale.ticks.each do |tick| %>
+                <div class="absolute top-0 h-5 overflow-hidden border-l border-base-200 px-1 text-[10px] leading-5 text-base-content/50"
+                     style="left: <%= tick[:x] %>px; width: <%= tick[:width] %>px"><%= tick[:label] %></div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <% sections.each do |section| %>
+          <% group = section[:group] %>
+          <% if group %>
+            <details class="bali-gantt-group group" open>
+              <summary class="flex cursor-pointer list-none items-center border-b border-base-200 bg-base-200/40 hover:bg-base-200"
+                       style="<%= canvas_width_css %>">
+                <span class="<%= class_names('bali-gantt-name-cell sticky left-0 z-10 flex shrink-0 items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-base-content/80', 'pl-6' => section[:depth].positive?) %>">
+                  <%= render Bali::Icon::Component.new("chevron-right", size: :small,
+                        class: "transition-transform group-open:rotate-90") %>
+                  <span class="truncate"><%= group.name %></span>
+                  <span class="font-normal text-base-content/50">(<%= section[:items].size %>)</span>
+                </span>
+                <span class="relative shrink-0 self-stretch" style="<%= lane_width_css %>">
+                  <% if group.dated? %>
+                    <span class="bali-gantt-group-bar absolute top-1/2 block -translate-y-1/2 rounded-full"
+                          style="<%= bar_style(group) %>"
+                          title="<%= bar_title(group) %>"></span>
+                  <% end %>
+                </span>
+              </summary>
+          <% end %>
+
+          <% section[:items].each do |item| %>
+            <div class="bali-gantt-row flex items-center border-b border-base-200 last:border-b-0 hover:bg-base-200/40"
+                 style="<%= canvas_width_css %>">
+              <div class="bali-gantt-name-cell sticky left-0 z-10 flex shrink-0 items-center gap-2 border-r border-base-300 bg-base-100 px-3 py-1">
+                <span class="<%= class_names('flex min-w-0 flex-1 items-center gap-2', 'pl-4' => item.sub_item?) %>">
+                  <% if item.href.present? %>
+                    <%= link_to item.name, item.href, class: "link link-hover truncate text-sm", title: item.name %>
+                  <% else %>
+                    <span class="truncate text-sm" title="<%= item.name %>"><%= item.name %></span>
+                  <% end %>
+                </span>
+                <% if item.assignee %>
+                  <span class="bali-gantt-assignee" style="<%= avatar_style(item.assignee) %>"
+                        title="<%= item.assignee.name %>"><%= item.assignee.initials %></span>
+                <% end %>
+              </div>
+              <div class="relative h-full shrink-0" style="<%= lane_width_css %>">
+                <% if item.milestone? %>
+                  <span class="bali-gantt-milestone absolute top-1/2 block"
+                        style="<%= milestone_style(item) %>"
+                        title="<%= bar_title(item) %>"
+                        data-critical="<%= data.critical?(item) %>"></span>
+                <% elsif item.href.present? %>
+                  <%= link_to item.href,
+                        class: "bali-gantt-bar absolute top-1/2 block -translate-y-1/2 rounded-sm border hover:brightness-110",
+                        style: bar_style(item),
+                        title: bar_title(item),
+                        "aria-label": item.name,
+                        data: { critical: data.critical?(item) } do %>
+                    <% if item.percent_complete.present? %>
+                      <span class="bali-gantt-progress block h-full rounded-sm" style="<%= progress_style(item) %>"></span>
+                    <% end %>
+                  <% end %>
+                <% else %>
+                  <span class="bali-gantt-bar absolute top-1/2 block -translate-y-1/2 rounded-sm border"
+                        style="<%= bar_style(item) %>"
+                        title="<%= bar_title(item) %>"
+                        data-critical="<%= data.critical?(item) %>">
+                    <% if item.percent_complete.present? %>
+                      <span class="bali-gantt-progress block h-full rounded-sm" style="<%= progress_style(item) %>"></span>
+                    <% end %>
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <% if group %>
+            </details>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <%= render Bali::EmptyState::Component.new(title: t(".empty"), icon: "chart-gantt") %>
+  <% end %>
+
+  <% if data.undated_total.positive? %>
+    <%= render Bali::Card::Component.new(style: :bordered, class: "bali-gantt-undated") do %>
+      <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-base-content/50">
+        <%= t(".undated_title") %>
+        <span class="font-normal normal-case text-base-content/50">(<%= data.undated_total %>)</span>
+      </div>
+      <p class="mb-3 text-sm text-base-content/60"><%= t(".undated_hint") %></p>
+      <ul class="grid grid-cols-1 gap-x-6 gap-y-1 md:grid-cols-2 lg:grid-cols-3">
+        <% data.undated_items.each do |item| %>
+          <li class="flex items-center gap-2 truncate text-sm">
+            <% if item.href.present? %>
+              <%= link_to item.name, item.href, class: "link link-hover truncate" %>
+            <% else %>
+              <span class="truncate"><%= item.name %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+      <% if data.undated_items.size < data.undated_total %>
+        <p class="mt-3 text-sm text-warning">
+          <%= t(".undated_truncated", shown: data.undated_items.size, total: data.undated_total) %>
+        </p>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bali/gantt/component.rb
+++ b/app/components/bali/gantt/component.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+module Bali
+  module Gantt
+    # Gantt chart (#704 — phase 1). One component, two renderers: this phase
+    # ships the shared data contract (Bali::Gantt::Data) and the server-rendered
+    # `:static` mode — a generalized port of TDFlow::PortfolioGantt's board:
+    # sticky two-tier header, collapsible `<details>` groups, today marker,
+    # month/week/day grid, an announced cap (never a silent one) and a "no
+    # dates" section for items that do not fit on the axis. `mode: :interactive`
+    # (the React Flow island) arrives with phases 2-3 (#705/#719); the option is
+    # signed now (D8) so host call sites never rewrite.
+    #
+    # All computed geometry and colors go in inline `style=` attributes — never
+    # interpolated Tailwind classes, which v4 purges. Structural sizes are
+    # `--gantt-*` tokens in index.css (@layer components) so hosts can retheme.
+    #
+    #   render Bali::Gantt::Component.new(
+    #     data: serializer.as_json,     # the contract — see Bali::Gantt::Data
+    #     color_by: :status,            # or :none (D9)
+    #     zoom: params[:gantt_zoom],    # :auto/:day/:week/:month, via links
+    #     statuses: [                   # status catalog: legend + colors
+    #       { value: 'in_progress', label: t('...'), color: '--color-info' }
+    #     ],
+    #     group_label: 'Stage', limit: 300, id: dom_id(project, :gantt)
+    #   )
+    class Component < ApplicationViewComponent
+      MODES = %i[static interactive].freeze
+      COLOR_BYS = %i[status none].freeze
+      DEFAULT_LIMIT = 300
+      DEFAULT_ZOOM_PARAM = "gantt_zoom"
+
+      attr_reader :data, :mode, :color_by, :zoom_param, :limit
+
+      # @param data [Hash, Bali::Gantt::Data] the Gantt document (contract in Bali::Gantt::Data)
+      # @param mode [Symbol] :static (server-rendered). :interactive raises until phase 3.
+      # @param color_by [Symbol] :status paints bars from the status catalog; :none is all-neutral.
+      # @param zoom [Symbol, String] :auto (default), :day, :week or :month — usually params[zoom_param].
+      # @param zoom_param [String] query param the zoom links write (namespaced, like gantt_group_by).
+      # @param zoom_links [Boolean] render the zoom switcher links.
+      # @param group_label [String] header of the sticky name column.
+      # @param statuses [Array<Hash>] status catalog [{ value:, label:, color: }] — color is a
+      #   daisyUI variable name ("--color-info") or nil for the neutral treatment.
+      # @param limit [Integer] announced cap on rendered items (nil = no cap).
+      def initialize(data:, mode: :static, color_by: :status, zoom: nil,
+                     zoom_param: DEFAULT_ZOOM_PARAM, zoom_links: true,
+                     group_label: nil, statuses: nil, limit: DEFAULT_LIMIT,
+                     id: nil, **options)
+        @mode = validate_mode!(mode)
+        @color_by = validate_color_by!(color_by)
+        @data = data.is_a?(Data) ? data : Data.new(data, limit: limit)
+        @zoom = zoom
+        @zoom_param = zoom_param.to_s
+        @zoom_links = zoom_links
+        @group_label = group_label
+        @statuses = statuses
+        @limit = limit
+        @id = id
+        @options = options
+      end
+
+      def time_scale
+        @time_scale ||= TimeScale.new(starts_on: data.window_starts_on,
+                                      ends_on: data.window_ends_on,
+                                      zoom: @zoom)
+      end
+
+      # Status catalog: [{ value:, label:, color: }]. Defaults to the island's
+      # STATUS_VAR map with humanized labels; hosts pass their own vocabulary.
+      def statuses
+        @statuses ||= Colors::DEFAULT_STATUS_VARS.map do |value, var|
+          { value: value, label: value.humanize, color: var }
+        end
+      end
+
+      def group_label
+        @group_label.presence || t(".name_column")
+      end
+
+      def renderable? = time_scale.valid? && (data.dated_items.any? || dated_groups.any?)
+
+      def dated_groups
+        @dated_groups ||= data.ordered_groups.select(&:dated?)
+      end
+
+      # Legend: only the statuses actually on screen, in catalog order —
+      # offering states nobody is seeing would invent information. Statuses
+      # outside the catalog close the list with the neutral treatment.
+      def legend_entries
+        return [] unless color_by == :status
+
+        present = (data.dated_items.map(&:status) + dated_groups.map(&:status)).compact.uniq
+        catalog = statuses.select { |entry| present.include?(entry[:value].to_s) }
+        extras = (present - statuses.map { |entry| entry[:value].to_s })
+                 .map { |value| { value: value, label: value.humanize, color: nil } }
+        (catalog + extras).map do |entry|
+          { label: entry[:label], color: color_set(entry[:value])[:solid] }
+        end
+      end
+
+      # Render order: the implicit ungrouped section first, then every group in
+      # document order (sub-groups indented). Groups render flat — each
+      # `<details>` collapses its own rows; a parent does not swallow its
+      # sub-groups, which matches how the portfolio board reads.
+      def sections
+        @sections ||= begin
+          list = []
+          list << { group: nil, depth: 0, items: data.ungrouped_items } if data.ungrouped_items.any?
+          data.ordered_groups.each do |group|
+            list << { group: group, depth: group.parent_id ? 1 : 0, items: data.items_for(group.id) }
+          end
+          list
+        end
+      end
+
+      def zoom_links? = @zoom_links
+
+      def zoom_link_options
+        TimeScale::ZOOMS.map do |key|
+          { zoom: key, label: t(".zoom.#{key}"), href: zoom_href(key),
+            active: time_scale.resolved_zoom == key }
+        end
+      end
+
+      # { solid:, fill:, border:, text: } for a status value under the current
+      # color_by mode.
+      def color_set(status)
+        return Colors.neutral if color_by == :none || status.nil?
+
+        Colors.status_color(status, vars: status_vars)
+      end
+
+      def bar_style(record)
+        geometry = time_scale.bar_geometry(record.starts_on, record.ends_on)
+        colors = color_set(record.status)
+        "left: #{geometry[:left]}px; width: #{geometry[:width]}px; " \
+          "background-color: #{colors[:fill]}; border-color: #{colors[:border]};"
+      end
+
+      def milestone_style(item)
+        colors = color_set(item.status)
+        "left: #{time_scale.x_for(item.starts_on)}px; background-color: #{colors[:solid]};"
+      end
+
+      def progress_style(item)
+        colors = color_set(item.status)
+        "width: #{item.percent_complete}%; background-color: #{colors[:solid]};"
+      end
+
+      def bar_title(record)
+        [ record.name, "#{helpers.l(record.starts_on)} – #{helpers.l(record.ends_on)}" ].join(" · ")
+      end
+
+      def avatar_style(assignee)
+        "background-color: oklch(0.6 0.14 #{Colors.hash_hue(assignee.id || assignee.name)});"
+      end
+
+      def canvas_width_css = "width: calc(var(--gantt-name-col) + #{time_scale.total_width}px)"
+      def lane_width_css = "width: #{time_scale.total_width}px"
+
+      def wrapper_attributes
+        @options.except(:class).merge(
+          id: @id,
+          class: class_names("bali-gantt space-y-3", @options[:class]),
+          data: (@options[:data] || {}).merge(
+            gantt_mode: mode, gantt_color_by: color_by, gantt_zoom: time_scale.resolved_zoom
+          )
+        ).compact
+      end
+
+      private
+
+      def validate_mode!(mode)
+        mode = mode&.to_sym
+        unless MODES.include?(mode)
+          raise ArgumentError, "mode must be one of #{MODES.inspect}, got #{mode.inspect}"
+        end
+        if mode == :interactive
+          raise ArgumentError,
+                "Bali::Gantt mode: :interactive is not available yet — it ships with the React " \
+                "island in phases 2-3 (#705/#719). Render mode: :static for now."
+        end
+
+        mode
+      end
+
+      def validate_color_by!(color_by)
+        color_by = color_by&.to_sym
+        return color_by if COLOR_BYS.include?(color_by)
+
+        raise ArgumentError, "color_by must be one of #{COLOR_BYS.inspect}, got #{color_by.inspect}"
+      end
+
+      def status_vars
+        @status_vars ||= statuses.to_h { |entry| [ entry[:value].to_s, entry[:color] ] }
+      end
+
+      # Zoom by links (read-only mode): plain GET links that rewrite only the
+      # namespaced zoom param and keep every other filter on the URL.
+      def zoom_href(key)
+        params = helpers.request.query_parameters.merge(zoom_param => key.to_s)
+        "#{helpers.request.path}?#{params.to_query}"
+      end
+    end
+  end
+end

--- a/app/components/bali/gantt/data.rb
+++ b/app/components/bali/gantt/data.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+module Bali
+  module Gantt
+    # Parses and validates the Gantt data contract (#704, decisions D5/D6).
+    #
+    # The contract is a plain Hash (symbol or string keys) shaped like:
+    #
+    #   {
+    #     window: { starts_on: "2026-01-01", ends_on: "2026-12-31" },  # optional
+    #     groups: [
+    #       { id: 1, name: "Discovery",                                 # required
+    #         parent_id: nil,          # one level of nesting (sub-groups), like the
+    #                                  # real stages tree — a sub-group cannot have
+    #                                  # children of its own
+    #         position: 0, status: "in_progress",                       # optional
+    #         starts_on: "...", ends_on: "...",  # group's own bar (rollup dates)
+    #         href: "/projects/1" }                                     # optional
+    #     ],
+    #     items: [
+    #       { id: 10, group_id: 1, name: "Wireframes",                  # id/name required
+    #         starts_on: "2026-01-02", ends_on: "2026-01-15",           # ISO8601 dates
+    #         parent_id: nil,          # sub-item (subtask); one level, like row_kind
+    #         status: "in_progress", priority: "high",                  # optional
+    #         milestone: false,        # D6: boolean, rendered as a diamond in :static
+    #         percent_complete: 40,    # 0..100
+    #         assignee: { id: 7, name: "Ana Luz", initials: "AL" },
+    #         slack_days: 3,
+    #         href: "/tasks/10" }                                       # optional
+    #     ],
+    #     dependencies: [
+    #       { id: 1, predecessor_id: 10, successor_id: 11,              # ids required
+    #         dependency_type: "finish_to_start", lag_days: 0 }
+    #     ],
+    #     critical_ids: [10, 11]
+    #   }
+    #
+    # Renames against the TDFlow::GanttSerializer this contract generalizes:
+    # stages→groups, tasks→items, title→name, stage_id→group_id,
+    # parent_stage_id/parent_task_id→parent_id, critical_task_ids→critical_ids.
+    # `is_critical` and `row_kind` are derived (critical_ids / parent_id), not fields.
+    # `test/bali/components/gantt/serializer_contract_test.rb` keeps the mapping
+    # honest against a frozen sample of the real serializer output.
+    #
+    # Dates follow the portfolio rules: an item with a single date is drawn as a
+    # minimum-width bar instead of vanishing into "no dates", and an inverted range
+    # is clamped to its start so a negative-width bar cannot render out of place.
+    # Structural problems (missing ids, unknown references, bad ISO dates, nesting
+    # deeper than one level) raise InvalidError: a typo that silently drops bars
+    # would lie about the schedule.
+    class Data
+      class InvalidError < ArgumentError; end
+
+      ISO_DATE = /\A\d{4}-\d{2}-\d{2}\z/
+
+      Group = Struct.new(:id, :name, :parent_id, :position, :status,
+                         :starts_on, :ends_on, :href, keyword_init: true) do
+        def dated? = starts_on.present?
+      end
+
+      Item = Struct.new(:id, :group_id, :parent_id, :name, :starts_on, :ends_on,
+                        :status, :priority, :milestone, :percent_complete,
+                        :assignee, :slack_days, :href, keyword_init: true) do
+        def milestone? = !!milestone
+        def dated? = starts_on.present?
+        def sub_item? = parent_id.present?
+      end
+
+      Assignee = Struct.new(:id, :name, :initials, keyword_init: true)
+
+      Dependency = Struct.new(:id, :predecessor_id, :successor_id,
+                              :dependency_type, :lag_days, keyword_init: true)
+
+      attr_reader :dependencies, :critical_ids, :limit, :dated_total, :undated_total
+
+      # `limit` caps the DATED items (in document order) BEFORE the window is
+      # derived, so the time axis is fixed by the bars that actually render —
+      # same rule as TDFlow::PortfolioGantt. nil = no cap.
+      def initialize(payload, limit: nil)
+        raise InvalidError, "Gantt data must be a Hash, got #{payload.class}" unless payload.is_a?(Hash)
+
+        @payload = payload.deep_symbolize_keys
+        @limit = limit
+        parse!
+      end
+
+      # Top-level groups in document order, each followed by its sub-groups —
+      # the same nesting rule as the serializer's `ordered_stages`. The host
+      # controls the order; `position` is carried through, not sorted on.
+      def ordered_groups
+        @ordered_groups ||= @groups.reject(&:parent_id).flat_map do |group|
+          [ group, *@groups.select { |g| g.parent_id == group.id } ]
+        end
+      end
+
+      # Dated items of a group: top-level items in document order, each followed
+      # by its sub-items. Only items that survived the cap.
+      def items_for(group_id)
+        rows = @dated_items.select { |item| item.group_id == group_id }
+        rows.reject(&:parent_id).flat_map do |item|
+          [ item, *rows.select { |i| i.parent_id == item.id } ]
+        end
+      end
+
+      # Dated items with no group, rendered as an implicit unnamed section.
+      def ungrouped_items
+        @ungrouped_items ||= items_for(nil)
+      end
+
+      def dated_items = @dated_items
+      def undated_items = @undated_items
+
+      def critical?(item_or_id)
+        id = item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id
+        critical_ids.include?(id)
+      end
+
+      def truncated? = @limit.present? && dated_total > @limit
+      def any? = (dated_total + undated_total).positive?
+
+      # Window bounds as Dates. Explicit `window:` wins; otherwise derived from
+      # the rendered items plus the groups' own dates (like `build_window`).
+      def window_starts_on = window_bounds.first
+      def window_ends_on = window_bounds.last
+
+      private
+
+      def parse!
+        @groups = Array(@payload[:groups]).map { |raw| build_group(raw) }
+        validate_group_tree!
+
+        items = Array(@payload[:items]).map { |raw| build_item(raw) }
+        validate_item_tree!(items)
+
+        dated, undated = items.partition(&:dated?)
+        @dated_total = dated.size
+        @undated_total = undated.size
+        @dated_items = @limit ? cap_preserving_parents(dated) : dated
+        @undated_items = @limit ? undated.first(@limit) : undated
+
+        @dependencies = Array(@payload[:dependencies]).map { |raw| build_dependency(raw) }
+        @critical_ids = Array(@payload[:critical_ids])
+      end
+
+      def build_group(raw)
+        raise InvalidError, "group requires id and name: #{raw.inspect}" unless raw[:id] && raw[:name]
+
+        starts_on, ends_on = normalize_range(raw[:starts_on], raw[:ends_on], "group #{raw[:id]}")
+        Group.new(id: raw[:id], name: raw[:name].to_s, parent_id: raw[:parent_id],
+                  position: raw[:position], status: raw[:status]&.to_s,
+                  starts_on: starts_on, ends_on: ends_on, href: raw[:href])
+      end
+
+      def build_item(raw)
+        raise InvalidError, "item requires id and name: #{raw.inspect}" unless raw[:id] && raw[:name]
+
+        if raw[:group_id] && group_ids.exclude?(raw[:group_id])
+          raise InvalidError, "item #{raw[:id]} references unknown group #{raw[:group_id]}"
+        end
+
+        starts_on, ends_on = normalize_range(raw[:starts_on], raw[:ends_on], "item #{raw[:id]}")
+        Item.new(id: raw[:id], group_id: raw[:group_id], parent_id: raw[:parent_id],
+                 name: raw[:name].to_s, starts_on: starts_on, ends_on: ends_on,
+                 status: raw[:status]&.to_s, priority: raw[:priority]&.to_s,
+                 milestone: !!raw[:milestone],
+                 percent_complete: normalize_percent(raw[:percent_complete], raw[:id]),
+                 assignee: build_assignee(raw[:assignee]),
+                 slack_days: raw[:slack_days], href: raw[:href])
+      end
+
+      def build_assignee(raw)
+        return nil if raw.blank?
+
+        Assignee.new(id: raw[:id], name: raw[:name].to_s, initials: raw[:initials].to_s)
+      end
+
+      def build_dependency(raw)
+        unless raw[:predecessor_id] && raw[:successor_id]
+          raise InvalidError, "dependency requires predecessor_id and successor_id: #{raw.inspect}"
+        end
+
+        Dependency.new(id: raw[:id], predecessor_id: raw[:predecessor_id],
+                       successor_id: raw[:successor_id],
+                       dependency_type: raw[:dependency_type]&.to_s,
+                       lag_days: raw[:lag_days] || 0)
+      end
+
+      # Portfolio date rules (derive_dates): each end falls back on the other
+      # before giving up, and an inverted range clamps to its start.
+      def normalize_range(starts_on, ends_on, context)
+        starts = parse_date(starts_on, context)
+        ends = parse_date(ends_on, context)
+        starts ||= ends
+        return [ nil, nil ] if starts.nil?
+
+        [ starts, [ ends || starts, starts ].max ]
+      end
+
+      def parse_date(value, context)
+        return nil if value.blank?
+        return value if value.is_a?(Date)
+
+        raise InvalidError, "#{context}: date must be ISO8601 (YYYY-MM-DD), got #{value.inspect}" unless
+          value.is_a?(String) && value.match?(ISO_DATE)
+
+        Date.iso8601(value)
+      rescue Date::Error
+        raise InvalidError, "#{context}: invalid date #{value.inspect}"
+      end
+
+      def normalize_percent(value, id)
+        return nil if value.blank?
+
+        Integer(value).clamp(0, 100)
+      rescue ArgumentError, TypeError
+        raise InvalidError, "item #{id}: percent_complete must be a number, got #{value.inspect}"
+      end
+
+      def validate_group_tree!
+        @groups.each do |group|
+          next if group.parent_id.nil?
+
+          parent = @groups.find { |g| g.id == group.parent_id }
+          raise InvalidError, "group #{group.id} references unknown parent #{group.parent_id}" if parent.nil?
+          raise InvalidError, "group #{group.id}: sub-groups cannot nest further (max 2 levels)" if parent.parent_id
+        end
+      end
+
+      def validate_item_tree!(items)
+        by_id = items.index_by(&:id)
+        items.each do |item|
+          next if item.parent_id.nil?
+
+          parent = by_id[item.parent_id]
+          raise InvalidError, "item #{item.id} references unknown parent #{item.parent_id}" if parent.nil?
+          raise InvalidError, "item #{item.id}: sub-items cannot nest further (max 2 levels)" if parent.parent_id
+          if parent.group_id != item.group_id
+            raise InvalidError, "item #{item.id} must live in its parent's group"
+          end
+        end
+      end
+
+      # Caps dated items in document order. A surviving sub-item whose parent
+      # fell over the cap would render orphaned, so parents count first.
+      def cap_preserving_parents(dated)
+        kept = dated.first(@limit)
+        kept_ids = kept.map(&:id).to_set
+        kept.select { |item| item.parent_id.nil? || kept_ids.include?(item.parent_id) }
+      end
+
+      def group_ids
+        @group_ids ||= @groups.map(&:id).to_set
+      end
+
+      def window_bounds
+        @window_bounds ||= begin
+          explicit = @payload[:window] || {}
+          starts = parse_date(explicit[:starts_on], "window")
+          ends = parse_date(explicit[:ends_on], "window")
+          derived_starts, derived_ends = derived_bounds
+          [ starts || derived_starts, ends || derived_ends ]
+        end
+      end
+
+      def derived_bounds
+        dates = @dated_items.flat_map { |i| [ i.starts_on, i.ends_on ] } +
+                @groups.select(&:dated?).flat_map { |g| [ g.starts_on, g.ends_on ] }
+        dates.compact!
+        return [ nil, nil ] if dates.empty?
+
+        [ dates.min, dates.max ]
+      end
+    end
+  end
+end

--- a/app/components/bali/gantt/index.css
+++ b/app/components/bali/gantt/index.css
@@ -1,0 +1,93 @@
+/* Bali::Gantt (#704) — structural tokens and the pieces of the static board
+ * whose geometry is fixed (not computed): row/bar heights, the name column
+ * width, grid lines, the today marker, milestones and the assignee chip.
+ * Computed geometry (left/width of every bar and tick) rides inline styles.
+ *
+ * Imported from bali/components.css with layer(components) on purpose (D7):
+ * the gantt's markup is its own — nothing here fights daisyUI, and host
+ * utility classes must keep winning. */
+.bali-gantt {
+  --gantt-name-col: 256px;
+  --gantt-row-h: 32px;
+  --gantt-bar-h: 14px;
+  --gantt-group-bar-h: 6px;
+  --gantt-milestone: 12px;
+}
+
+.bali-gantt-name-cell {
+  width: var(--gantt-name-col);
+}
+
+.bali-gantt-row {
+  height: var(--gantt-row-h);
+}
+
+.bali-gantt-row .bali-gantt-name-cell {
+  height: var(--gantt-row-h);
+}
+
+.bali-gantt-gridline {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  width: 1px;
+  pointer-events: none;
+  background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
+}
+
+.bali-gantt-today {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  width: 1px;
+  pointer-events: none;
+  background: color-mix(in oklch, var(--color-error) 60%, transparent);
+}
+
+.bali-gantt-bar {
+  height: var(--gantt-bar-h);
+  border-width: 1px;
+}
+
+.bali-gantt-group-bar {
+  height: var(--gantt-group-bar-h);
+  border-width: 1px;
+  border-style: solid;
+}
+
+/* CPM criticality marker: information the data already carries; one ring. */
+.bali-gantt-bar[data-critical="true"],
+.bali-gantt-milestone[data-critical="true"] {
+  box-shadow: 0 0 0 1px var(--color-error);
+}
+
+/* Diamond on the item's date (D6): a rotated square centered on its x. */
+.bali-gantt-milestone {
+  width: var(--gantt-milestone);
+  height: var(--gantt-milestone);
+  margin-left: calc(var(--gantt-milestone) / -2);
+  transform: translateY(-50%) rotate(45deg);
+  border-radius: 2px;
+}
+
+.bali-gantt-swatch {
+  display: inline-block;
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 0.125rem;
+}
+
+.bali-gantt-assignee {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  font-size: 0.5625rem;
+  font-weight: 600;
+  color: white;
+}

--- a/app/components/bali/gantt/preview.rb
+++ b/app/components/bali/gantt/preview.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Bali
+  module Gantt
+    class Preview < ApplicationViewComponentPreview
+      # The data contract is documented in Bali::Gantt::Data: `window` is optional,
+      # `groups` nest one level via `parent_id` (like stages/sub-stages), `items`
+      # nest one level via `parent_id` (subtasks), `milestone: true` renders a
+      # diamond on the item's date, and items without dates land in the "No dates"
+      # section instead of disappearing. `critical_ids` marks CPM-critical items.
+      #
+      # `mode: :interactive` (the React Flow island) raises until phases 2-3
+      # (#705/#719) — the option is already part of the signature so host call
+      # sites will not need rewriting.
+      #
+      # The zoom links rewrite only the `gantt_zoom` query param (namespaced, so it
+      # can coexist with other controls); inside Lookbook they reload the preview.
+      # @param color_by select { choices: [status, none] }
+      # @param zoom select { choices: [auto, day, week, month] }
+      def default(color_by: :status, zoom: :auto)
+        render Bali::Gantt::Component.new(
+          data: sample_data,
+          color_by: color_by.to_sym,
+          zoom: zoom,
+          group_label: "Stage"
+        )
+      end
+
+      # Hosts with their own status vocabulary pass a catalog:
+      # `statuses: [{ value:, label:, color: }]` where `color` is a daisyUI
+      # variable name ("--color-info") or nil for the neutral gray. The legend
+      # shows only the statuses present on screen, in catalog order.
+      def custom_status_catalog
+        render Bali::Gantt::Component.new(
+          data: sample_data,
+          statuses: [
+            { value: "backlog", label: "Pending", color: nil },
+            { value: "in_progress", label: "Cooking", color: "--color-secondary" },
+            { value: "complete", label: "Served", color: "--color-success" }
+          ]
+        )
+      end
+
+      # `limit:` caps how many dated items render (default 300) and the cut is
+      # ALWAYS announced with the real total — silent caps lie about the plan.
+      def truncated
+        render Bali::Gantt::Component.new(data: sample_data, limit: 3)
+      end
+
+      # No dated items at all: the component renders the shared empty state.
+      def empty
+        render Bali::Gantt::Component.new(data: { items: [] })
+      end
+
+      private
+
+      def sample_data
+        today = Date.current
+        {
+          groups: [
+            { id: 1, name: "Discovery", status: "complete",
+              starts_on: (today - 21).iso8601, ends_on: (today - 8).iso8601 },
+            { id: 2, name: "Build", status: "in_progress",
+              starts_on: (today - 7).iso8601, ends_on: (today + 21).iso8601 },
+            { id: 3, name: "Backend", parent_id: 2 },
+            { id: 4, name: "Launch" }
+          ],
+          items: [
+            { id: 10, group_id: 1, name: "Stakeholder interviews", status: "complete",
+              starts_on: (today - 21).iso8601, ends_on: (today - 15).iso8601,
+              percent_complete: 100,
+              assignee: { id: 1, name: "Ana Luz Durán", initials: "AD" } },
+            { id: 11, group_id: 1, name: "Findings summary", parent_id: 10,
+              status: "complete", starts_on: (today - 16).iso8601,
+              ends_on: (today - 15).iso8601, percent_complete: 100 },
+            { id: 12, group_id: 1, name: "Scope sign-off", status: "complete",
+              starts_on: (today - 14).iso8601, ends_on: (today - 8).iso8601,
+              percent_complete: 100 },
+            { id: 20, group_id: 2, name: "Component API", status: "in_progress",
+              starts_on: (today - 7).iso8601, ends_on: (today + 4).iso8601,
+              percent_complete: 60,
+              assignee: { id: 2, name: "Bruno Ortega", initials: "BO" } },
+            { id: 21, group_id: 2, name: "Static renderer", status: "in_progress",
+              starts_on: (today - 2).iso8601, ends_on: (today + 10).iso8601,
+              percent_complete: 30, slack_days: 0,
+              assignee: { id: 1, name: "Ana Luz Durán", initials: "AD" } },
+            { id: 30, group_id: 3, name: "Contract validation", status: "ready_for_review",
+              starts_on: (today + 2).iso8601, ends_on: (today + 12).iso8601 },
+            { id: 31, group_id: 3, name: "Fixtures", status: "backlog",
+              starts_on: (today + 8).iso8601, ends_on: (today + 14).iso8601 },
+            { id: 40, group_id: 4, name: "Beta release", milestone: true,
+              status: "backlog", starts_on: (today + 21).iso8601 },
+            { id: 41, group_id: 4, name: "Docs", status: "backlog" },
+            { id: 42, group_id: 4, name: "Announcement", status: "cancelled" }
+          ],
+          dependencies: [
+            { id: 1, predecessor_id: 20, successor_id: 30, dependency_type: "finish_to_start" },
+            { id: 2, predecessor_id: 21, successor_id: 40, dependency_type: "finish_to_start" }
+          ],
+          critical_ids: [20, 21, 40]
+        }
+      end
+    end
+  end
+end

--- a/app/components/bali/gantt/time_scale.rb
+++ b/app/components/bali/gantt/time_scale.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module Bali
+  module Gantt
+    # Date ↔ pixel geometry for the Gantt (#704). One coordinate system: DAYS.
+    #
+    # x(date) = days from the window start × px_per_day — the same conversion the
+    # React island's timeScale.js uses (dateToX / daysBetween), so phase 2 shares
+    # these numbers instead of reimplementing them. The zoom levels carry the
+    # island's exact densities (ZoomControls.jsx: day 24, week 8, month 2 px/day).
+    #
+    # This is also the port of TDFlow::PortfolioGantt's geometry rules, translated
+    # into day units: fixed zoom picked by window span (`:auto`), minimum bar
+    # width, inclusive end dates, fractional positioning (free with day units —
+    # the portfolio's fractional-month formula approximated exactly this) and the
+    # today marker. Month columns get their true calendar width (28–31 days), so
+    # the grid never drifts.
+    #
+    # Everything returns plain numbers/hashes for the template to inline in
+    # `style=` attributes — computed geometry never goes into interpolated
+    # Tailwind classes (v4 purges them; rule inherited from the portfolio view).
+    class TimeScale
+      # Island parity: ZoomControls.jsx ZOOM_LEVELS.
+      PX_PER_DAY = { day: 24, week: 8, month: 2 }.freeze
+      ZOOMS = PX_PER_DAY.keys.freeze
+      DEFAULT_ZOOM = :auto
+
+      # `:auto` picks a fixed density from the window span — the portfolio's
+      # "zoom by range" rule (a read-only board should not need a zoom control).
+      AUTO_DAY_MAX_DAYS = 45
+      AUTO_WEEK_MAX_DAYS = 400
+
+      MIN_BAR_PX = 6 # a one-day task is still visible (portfolio parity)
+
+      attr_reader :starts_on, :ends_on, :zoom
+
+      # `zoom` usually arrives from a query param, so unknown values normalize to
+      # `:auto` instead of raising — user input is not a programmer error.
+      def initialize(starts_on:, ends_on:, zoom: DEFAULT_ZOOM)
+        @starts_on = starts_on
+        @ends_on = ends_on && starts_on ? [ ends_on, starts_on ].max : ends_on
+        @zoom = normalize_zoom(zoom)
+      end
+
+      def valid? = starts_on.present? && ends_on.present?
+
+      # The zoom actually in effect (`:auto` resolved to a concrete unit).
+      def resolved_zoom
+        @resolved_zoom ||= if zoom == :auto
+                             auto_zoom
+        else
+                             zoom
+        end
+      end
+
+      def px_per_day = PX_PER_DAY.fetch(resolved_zoom)
+
+      # X in px of a date, measured from the window start. Same formula as the
+      # island's dateToX.
+      def x_for(date)
+        ((date - starts_on) * px_per_day).to_i
+      end
+
+      # Canvas width: the end date is INCLUSIVE, so the axis runs through the
+      # last day, not up to its midnight.
+      def total_width
+        @total_width ||= valid? ? x_for(ends_on + 1) : 0
+      end
+
+      # { left:, width: } for a bar, clamped to the canvas so an explicit window
+      # narrower than the data cannot paint outside it. End inclusive; minimum
+      # width so a one-day bar stays visible.
+      def bar_geometry(bar_starts_on, bar_ends_on)
+        left = x_for(bar_starts_on).clamp(0, total_width)
+        right = x_for(bar_ends_on + 1).clamp(0, total_width)
+        { left: left, width: [ right - left, MIN_BAR_PX ].max }
+      end
+
+      # Lower header tier: one tick per resolved unit, clipped to the canvas.
+      # [{ key:, label:, x:, width: }]
+      def ticks
+        @ticks ||= case resolved_zoom
+        when :day then day_segments
+        when :week then week_segments
+        else month_segments(with_year: false)
+        end
+      end
+
+      # Upper header tier for context: months over day/week zoom, years over
+      # month zoom — the island's timeBands and the portfolio's year band.
+      def bands
+        @bands ||= resolved_zoom == :month ? year_segments : month_segments(with_year: true)
+      end
+
+      # X of the "today" marker, or nil when today falls outside the window.
+      def today_x
+        return nil unless valid?
+        return nil unless Date.current.between?(starts_on, ends_on)
+
+        x_for(Date.current)
+      end
+
+      private
+
+      def normalize_zoom(value)
+        candidate = value.presence&.to_sym
+        ZOOMS.include?(candidate) ? candidate : :auto
+      end
+
+      def auto_zoom
+        return :week unless valid?
+
+        span = (ends_on - starts_on).to_i + 1
+        if span <= AUTO_DAY_MAX_DAYS then :day
+        elsif span <= AUTO_WEEK_MAX_DAYS then :week
+        else :month
+        end
+      end
+
+      def day_segments
+        return [] unless valid?
+
+        (starts_on..ends_on).map do |date|
+          { key: date.iso8601, label: date.day.to_s, x: x_for(date), width: px_per_day }
+        end
+      end
+
+      def week_segments
+        segments(step: :week) do |date|
+          "#{date.day} #{abbr_month(date)}"
+        end
+      end
+
+      def month_segments(with_year:)
+        segments(step: :month) do |date|
+          with_year ? "#{month_name(date)} #{date.year}" : abbr_month(date)
+        end
+      end
+
+      def year_segments
+        segments(step: :year) { |date| date.year.to_s }
+      end
+
+      # Walks calendar boundaries from the unit containing the window start,
+      # clipping the first and last segments to the canvas — the island's
+      # timeTicks/timeBands segStart rule.
+      def segments(step:)
+        return [] unless valid?
+
+        axis_end = ends_on + 1
+        cursor = unit_start(starts_on, step)
+        list = []
+        while cursor < axis_end
+          seg_start = [ cursor, starts_on ].max
+          seg_end = [ advance(cursor, step), axis_end ].min
+          list << { key: seg_start.iso8601, label: yield(cursor),
+                    x: x_for(seg_start), width: (seg_end - seg_start).to_i * px_per_day }
+          cursor = advance(cursor, step)
+        end
+        list
+      end
+
+      def unit_start(date, step)
+        case step
+        when :week then date.beginning_of_week(:monday)
+        when :month then date.beginning_of_month
+        else date.beginning_of_year
+        end
+      end
+
+      def advance(date, step)
+        case step
+        when :week then date + 7
+        when :month then date.next_month
+        else date.next_year
+        end
+      end
+
+      def abbr_month(date)
+        I18n.t("date.abbr_month_names")[date.month]
+      end
+
+      def month_name(date)
+        I18n.t("date.month_names")[date.month]
+      end
+    end
+  end
+end

--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -349,6 +349,20 @@ en:
         month: Month
         previous: Previous
         next: Next
+    gantt:
+      label: Gantt chart
+      name_column: Name
+      today: Today
+      empty: Nothing to plot yet
+      truncated: "Showing %{shown} of %{total} scheduled items"
+      undated_title: No dates
+      undated_hint: "These items have no dates yet, so they can't be placed on the timeline."
+      undated_truncated: "Showing %{shown} of %{total}"
+      zoom:
+        label: Zoom
+        day: Day
+        week: Week
+        month: Month
     navbar:
       main_navigation: Main navigation
       toggle_menu: Toggle menu

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -348,6 +348,20 @@ es:
         month: Mes
         previous: Anterior
         next: Siguiente
+    gantt:
+      label: Diagrama de Gantt
+      name_column: Nombre
+      today: Hoy
+      empty: Aún no hay nada que graficar
+      truncated: "Mostrando %{shown} de %{total} elementos con fechas"
+      undated_title: Sin fechas
+      undated_hint: "Estos elementos aún no tienen fechas, así que no pueden colocarse en la línea de tiempo."
+      undated_truncated: "Mostrando %{shown} de %{total}"
+      zoom:
+        label: Zoom
+        day: Día
+        week: Semana
+        month: Mes
     navbar:
       main_navigation: Navegación principal
       toggle_menu: Alternar menú

--- a/spec/dummy/app/controllers/admin/projects_controller.rb
+++ b/spec/dummy/app/controllers/admin/projects_controller.rb
@@ -8,7 +8,9 @@ module Admin
 
     def show
       @project = Project.find(params[:id])
+      @view = params[:view] == 'timeline' ? 'timeline' : 'board'
       @tasks_by_status = @project.tasks_by_status
+      @gantt = ProjectGantt.new(@project) if @view == 'timeline'
     end
   end
 end

--- a/spec/dummy/app/models/project_gantt.rb
+++ b/spec/dummy/app/models/project_gantt.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Reference implementation of the Bali::Gantt data contract for a host app
+# (#704): turns a Project's tasks into the document the component consumes.
+# Groups come from each task's phase (rolled-up dates give the group its own
+# bar), items carry status/milestone/percent_complete, and tasks without dates
+# are passed through so the component's "No dates" section stays honest.
+class ProjectGantt
+  # Task status → daisyUI color variable for the gantt catalog (nil = neutral).
+  # Mirrors Task::STATUS_COLORS, which paints the same states on the Kanban.
+  STATUS_VARS = {
+    "backlog" => nil,
+    "todo" => "--color-info",
+    "in_progress" => "--color-warning",
+    "done" => "--color-success"
+  }.freeze
+
+  def initialize(project)
+    @project = project
+  end
+
+  def to_h
+    { groups: groups, items: items }
+  end
+
+  # Status catalog for Bali::Gantt::Component (legend labels + colors).
+  def statuses
+    Task.statuses.keys.map do |status|
+      { value: status, label: status.humanize, color: STATUS_VARS[status] }
+    end
+  end
+
+  private
+
+  def tasks
+    @tasks ||= @project.tasks.positioned.to_a
+  end
+
+  # Phases in order of first appearance, each with its rolled-up date range.
+  def groups
+    tasks.map(&:phase).compact.uniq.map do |phase|
+      phase_tasks = tasks.select { |t| t.phase == phase && t.start_date }
+      { id: phase.parameterize, name: phase,
+        starts_on: phase_tasks.filter_map(&:start_date).min&.iso8601,
+        ends_on: phase_tasks.filter_map(&:due_date).max&.iso8601 }
+    end
+  end
+
+  def items
+    tasks.map do |task|
+      { id: task.id, group_id: task.phase&.parameterize, name: task.title,
+        starts_on: task.start_date&.iso8601, ends_on: task.due_date&.iso8601,
+        status: task.status, milestone: task.milestone?,
+        percent_complete: task.percent_complete }
+    end
+  end
+end

--- a/spec/dummy/app/views/admin/projects/index.html.erb
+++ b/spec/dummy/app/views/admin/projects/index.html.erb
@@ -24,7 +24,14 @@
             <% end %>
           </div>
 
-          <div class="mt-4 flex justify-end">
+          <div class="mt-4 flex justify-end gap-2">
+            <%= render Bali::Link::Component.new(
+              name: 'View Timeline',
+              href: admin_project_path(project, view: 'timeline'),
+              variant: :ghost,
+              size: :sm,
+              icon: 'chart-gantt'
+            ) %>
             <%= render Bali::Link::Component.new(
               name: 'View Board',
               href: admin_project_path(project),

--- a/spec/dummy/app/views/admin/projects/show.html.erb
+++ b/spec/dummy/app/views/admin/projects/show.html.erb
@@ -1,4 +1,7 @@
-<%# Admin Project Show - Showcases: PageHeader, Kanban with real drag-and-drop, Tag %>
+<%# Admin Project Show - Showcases: PageHeader, Kanban with real drag-and-drop,
+    Tag, and the Bali::Gantt :static timeline (?view=timeline). The Board |
+    Timeline switch is plain GET links; the gantt's own zoom links preserve the
+    `view` param because they rewrite only `gantt_zoom`. %>
 
 <%= render Bali::PageHeader::Component.new(
   title: @project.name,
@@ -6,33 +9,66 @@
   back: { href: admin_projects_path }
 ) %>
 
-<%= render Bali::Kanban::Component.new(
-  resource_name: 'task',
-  group_name: 'project-board',
-  list_param_name: 'status',
-  response_kind: :html
-) do |kanban| %>
-  <% Task::STATUSES.each do |status| %>
-    <% tasks = @tasks_by_status.fetch(status, []) %>
+<div class="mb-4 flex justify-end">
+  <div class="join">
+    <%= render Bali::Link::Component.new(
+      name: 'Board',
+      href: admin_project_path(@project),
+      icon: 'kanban',
+      variant: :ghost,
+      size: :sm,
+      active: @view == 'board',
+      class: class_names('join-item', 'btn-active' => @view == 'board')
+    ) %>
+    <%= render Bali::Link::Component.new(
+      name: 'Timeline',
+      href: admin_project_path(@project, view: 'timeline'),
+      icon: 'chart-gantt',
+      variant: :ghost,
+      size: :sm,
+      active: @view == 'timeline',
+      class: class_names('join-item', 'btn-active' => @view == 'timeline')
+    ) %>
+  </div>
+</div>
 
-    <% kanban.with_column(
-      title: status.humanize,
-      status: status,
-      color: Task::STATUS_COLORS[status]
-    ) do |col| %>
-      <% tasks.each do |task| %>
-        <% col.with_card(update_url: admin_project_task_path(@project, task)) do %>
-          <p class="font-medium text-sm"><%= task.title %></p>
-          <% if task.description.present? %>
-            <p class="text-xs text-base-content/60 mt-1"><%= truncate(task.description, length: 60) %></p>
+<% if @view == 'timeline' %>
+  <%= render Bali::Gantt::Component.new(
+    data: @gantt.to_h,
+    statuses: @gantt.statuses,
+    zoom: params[:gantt_zoom],
+    group_label: 'Phase',
+    id: "project-#{@project.id}-gantt"
+  ) %>
+<% else %>
+  <%= render Bali::Kanban::Component.new(
+    resource_name: 'task',
+    group_name: 'project-board',
+    list_param_name: 'status',
+    response_kind: :html
+  ) do |kanban| %>
+    <% Task::STATUSES.each do |status| %>
+      <% tasks = @tasks_by_status.fetch(status, []) %>
+
+      <% kanban.with_column(
+        title: status.humanize,
+        status: status,
+        color: Task::STATUS_COLORS[status]
+      ) do |col| %>
+        <% tasks.each do |task| %>
+          <% col.with_card(update_url: admin_project_task_path(@project, task)) do %>
+            <p class="font-medium text-sm"><%= task.title %></p>
+            <% if task.description.present? %>
+              <p class="text-xs text-base-content/60 mt-1"><%= truncate(task.description, length: 60) %></p>
+            <% end %>
+            <div class="mt-2">
+              <%= render Bali::Tag::Component.new(
+                text: task.priority.humanize,
+                color: Task::PRIORITY_COLORS[task.priority],
+                size: :sm
+              ) %>
+            </div>
           <% end %>
-          <div class="mt-2">
-            <%= render Bali::Tag::Component.new(
-              text: task.priority.humanize,
-              color: Task::PRIORITY_COLORS[task.priority],
-              size: :sm
-            ) %>
-          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/dummy/db/migrate/20260805000001_add_schedule_to_tasks.rb
+++ b/spec/dummy/db/migrate/20260805000001_add_schedule_to_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Cronograma real para las tareas del dummy (#704): el Gantt de admin/projects
+# necesita fechas, fases (los grupos del contrato), hitos y avance de verdad —
+# inventarlos en la vista mentiría sobre lo que el componente recibe.
+class AddScheduleToTasks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tasks, :start_date, :date
+    add_column :tasks, :due_date, :date
+    add_column :tasks, :phase, :string
+    add_column :tasks, :milestone, :boolean, default: false, null: false
+    add_column :tasks, :percent_complete, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_30_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -172,9 +172,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_000001) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
+    t.date "due_date"
+    t.boolean "milestone", default: false, null: false
+    t.integer "percent_complete"
+    t.string "phase"
     t.integer "position", default: 0, null: false
     t.integer "priority", default: 0, null: false
     t.integer "project_id", null: false
+    t.date "start_date"
     t.integer "status", default: 0, null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -182,27 +182,41 @@ project = Project.find_or_create_by!(name: "Bali Component Library") do |p|
   p.description = "Open-source ViewComponent library for Rails applications"
 end
 
+# Schedule fields (phase/dates/milestone/percent_complete) feed the Bali::Gantt
+# timeline at /admin/projects/:id?view=timeline (#704). Dates are relative to
+# Date.current so the today marker always lands inside the window; tasks without
+# dates exercise the "No dates" section on purpose.
+today = Date.current
 tasks_data = [
-  { title: "Audit existing icon usage", description: "Map all icon names used across AFAL apps", status: :done, priority: :low, position: 0 },
-  { title: "Migrate to Lucide icons", description: "Replace custom SVGs with Lucide equivalents", status: :done, priority: :medium, position: 1 },
-  { title: "Upgrade to daisyUI 5", description: "Update class names and verify all component previews", status: :in_progress, priority: :high, position: 0 },
-  { title: "Add DataTable filter persistence", description: "Save active filters to cookies for page reload", status: :in_progress, priority: :medium, position: 1 },
-  { title: "Build Kanban component", description: "Drag-and-drop board composing SortableList", status: :in_progress, priority: :high, position: 2 },
-  { title: "Create FeedbackWidget", description: "Floating button with iframe drawer for Opina", status: :todo, priority: :medium, position: 0 },
-  { title: "Add Carousel accessibility", description: "Keyboard navigation and ARIA labels for slides", status: :todo, priority: :high, position: 1 },
-  { title: "Document FilterForm DSL", description: "Write guide for search_fields and filter_attribute", status: :todo, priority: :low, position: 2 },
+  { title: "Audit existing icon usage", description: "Map all icon names used across AFAL apps", status: :done, priority: :low, position: 0,
+    phase: "Foundations", start_date: today - 60, due_date: today - 50, percent_complete: 100 },
+  { title: "Migrate to Lucide icons", description: "Replace custom SVGs with Lucide equivalents", status: :done, priority: :medium, position: 1,
+    phase: "Foundations", start_date: today - 49, due_date: today - 35, percent_complete: 100 },
+  { title: "Upgrade to daisyUI 5", description: "Update class names and verify all component previews", status: :in_progress, priority: :high, position: 0,
+    phase: "Components", start_date: today - 14, due_date: today + 7, percent_complete: 70 },
+  { title: "Add DataTable filter persistence", description: "Save active filters to cookies for page reload", status: :in_progress, priority: :medium, position: 1,
+    phase: "Components", start_date: today - 7, due_date: today + 10, percent_complete: 40 },
+  { title: "Build Kanban component", description: "Drag-and-drop board composing SortableList", status: :in_progress, priority: :high, position: 2,
+    phase: "Components", start_date: today - 10, due_date: today + 14, percent_complete: 55 },
+  { title: "Create FeedbackWidget", description: "Floating button with iframe drawer for Opina", status: :todo, priority: :medium, position: 0,
+    phase: "Components", start_date: today + 7, due_date: today + 21 },
+  { title: "Add Carousel accessibility", description: "Keyboard navigation and ARIA labels for slides", status: :todo, priority: :high, position: 1,
+    phase: "Quality", start_date: today + 14, due_date: today + 24 },
+  { title: "Document FilterForm DSL", description: "Write guide for search_fields and filter_attribute", status: :todo, priority: :low, position: 2,
+    phase: "Quality", start_date: today + 18, due_date: today + 28 },
   { title: "Explore Turbo Mount for charts", description: "Evaluate React-based charting via islands architecture", status: :backlog, priority: :low, position: 0 },
-  { title: "Add dark mode support", description: "Verify all components render correctly with dark theme", status: :backlog, priority: :medium, position: 1 },
-  { title: "Performance benchmark suite", description: "Measure render times for complex components", status: :backlog, priority: :low, position: 2 }
+  { title: "Add dark mode support", description: "Verify all components render correctly with dark theme", status: :backlog, priority: :medium, position: 1,
+    phase: "Quality", start_date: today + 25, due_date: today + 35 },
+  { title: "Performance benchmark suite", description: "Measure render times for complex components", status: :backlog, priority: :low, position: 2,
+    phase: "Quality" },
+  { title: "Cut v3.1.0 beta", description: "Tag the release once the timeline components land", status: :todo, priority: :high, position: 3,
+    phase: "Release", start_date: today + 42, due_date: today + 42, milestone: true }
 ]
 
 tasks_data.each do |data|
-  project.tasks.find_or_create_by!(title: data[:title]) do |task|
-    task.description = data[:description]
-    task.status = data[:status]
-    task.priority = data[:priority]
-    task.position = data[:position]
-  end
+  task = project.tasks.find_or_initialize_by(title: data[:title])
+  task.assign_attributes(data.except(:title))
+  task.save!
 end
 
 puts "Created #{Project.count} projects with #{Task.count} tasks"

--- a/test/bali/components/gantt/colors_test.rb
+++ b/test/bali/components/gantt/colors_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Visual-parity contract with the React island's ganttColors.js: every string
+# here is asserted VERBATIM. If a formula must change, change it in both
+# runtimes (phase 2 ports the island) or bars will differ between renderers.
+class BaliGanttColorsTest < ActiveSupport::TestCase
+  def test_neutral_matches_gantt_colors_js
+    assert_equal(
+      {
+        solid: "color-mix(in oklch, var(--color-base-content) 42%, transparent)",
+        fill: "color-mix(in oklch, var(--color-base-content) 10%, transparent)",
+        border: "color-mix(in oklch, var(--color-base-content) 30%, transparent)",
+        text: "color-mix(in oklch, var(--color-base-content) 62%, transparent)"
+      },
+      Bali::Gantt::Colors.neutral
+    )
+  end
+
+  def test_var_color_matches_gantt_colors_js
+    assert_equal(
+      {
+        solid: "var(--color-info)",
+        fill: "color-mix(in oklch, var(--color-info) 16%, transparent)",
+        border: "color-mix(in oklch, var(--color-info) 50%, transparent)",
+        text: "var(--color-info)"
+      },
+      Bali::Gantt::Colors.var_color("--color-info")
+    )
+  end
+
+  def test_default_status_map_matches_the_island
+    assert_equal "var(--color-info)", Bali::Gantt::Colors.status_color("in_progress")[:solid]
+    assert_equal "var(--color-warning)", Bali::Gantt::Colors.status_color("ready_for_review")[:solid]
+    assert_equal "var(--color-success)", Bali::Gantt::Colors.status_color(:complete)[:solid]
+    assert_equal Bali::Gantt::Colors.neutral, Bali::Gantt::Colors.status_color("backlog")
+    assert_equal Bali::Gantt::Colors.neutral, Bali::Gantt::Colors.status_color("cancelled")
+    assert_equal Bali::Gantt::Colors.neutral, Bali::Gantt::Colors.status_color("unknown")
+  end
+
+  def test_custom_status_vocabularies_map_through_vars
+    vars = { "done" => "--color-success" }
+
+    assert_equal "var(--color-success)", Bali::Gantt::Colors.status_color("done", vars: vars)[:solid]
+    assert_equal Bali::Gantt::Colors.neutral, Bali::Gantt::Colors.status_color("todo", vars: vars)
+  end
+
+  def test_hue_color_matches_gantt_colors_js
+    assert_equal(
+      {
+        solid: "oklch(0.62 0.15 25)",
+        fill: "oklch(0.62 0.15 25 / 0.15)",
+        border: "oklch(0.6 0.15 25 / 0.5)",
+        text: "oklch(0.46 0.16 25)"
+      },
+      Bali::Gantt::Colors.hue_color(25)
+    )
+    assert_equal Bali::Gantt::Colors.neutral, Bali::Gantt::Colors.hue_color(nil)
+  end
+
+  def test_hash_hue_matches_the_js_algorithm
+    # h = (h * 31 + charCode) % 360 over the string — hand-computed references.
+    assert_equal 0, Bali::Gantt::Colors.hash_hue("")
+    assert_equal 97 % 360, Bali::Gantt::Colors.hash_hue("a")
+    assert_equal ((97 * 31) + 98) % 360, Bali::Gantt::Colors.hash_hue("ab")
+    assert_equal Bali::Gantt::Colors.hash_hue("7"), Bali::Gantt::Colors.hash_hue(7)
+  end
+
+  def test_hash_hue_stays_in_range
+    assert_includes 0...360, Bali::Gantt::Colors.hash_hue("Ana Luz Durán")
+  end
+end

--- a/test/bali/components/gantt/component_test.rb
+++ b/test/bali/components/gantt/component_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliGanttComponentTest < ComponentTestCase
+  def payload
+    {
+      groups: [
+        { id: 1, name: "Discovery", status: "in_progress",
+          starts_on: "2026-01-05", ends_on: "2026-01-16" },
+        { id: 2, name: "Design" }
+      ],
+      items: [
+        { id: 10, group_id: 1, name: "Interviews", status: "in_progress",
+          starts_on: "2026-01-05", ends_on: "2026-01-16", percent_complete: 40,
+          assignee: { id: 7, name: "Ana Luz", initials: "AL" }, href: "/tasks/10" },
+        { id: 11, group_id: 1, name: "Summary", parent_id: 10, status: "complete",
+          starts_on: "2026-01-12", ends_on: "2026-01-16" },
+        { id: 12, group_id: 2, name: "Release", starts_on: "2026-02-06", milestone: true },
+        { id: 13, group_id: 2, name: "Unscheduled" }
+      ],
+      critical_ids: [ 10 ]
+    }
+  end
+
+  def component(**overrides)
+    Bali::Gantt::Component.new(data: payload, **overrides)
+  end
+
+  def test_renders_the_static_board
+    render_inline(component)
+
+    assert_selector(".bali-gantt[data-gantt-mode='static']")
+    assert_selector(".bali-gantt-canvas")
+    assert_selector("details.bali-gantt-group", count: 2)
+    assert_selector("summary", text: "Discovery")
+    assert_selector(".bali-gantt-row", count: 3)
+    assert_selector(".bali-gantt-gridline", minimum: 1)
+  end
+
+  def test_bars_carry_inline_geometry_and_status_colors
+    render_inline(component)
+
+    bar = page.find("a.bali-gantt-bar", match: :first)
+    assert_match(/left: 0px/, bar[:style])
+    assert_match(/width: 288px/, bar[:style]) # 12 days × 24 px/day (auto→day for this 33-day span)
+    assert_match(/color-mix\(in oklch, var\(--color-info\) 16%, transparent\)/, bar[:style])
+    assert_equal "true", bar["data-critical"]
+    assert_selector("a.bali-gantt-bar .bali-gantt-progress")
+  end
+
+  def test_group_own_dates_render_a_group_bar
+    render_inline(component)
+
+    assert_selector("summary .bali-gantt-group-bar", count: 1)
+  end
+
+  def test_milestones_render_as_diamonds_not_bars
+    render_inline(component)
+
+    assert_selector(".bali-gantt-milestone", count: 1)
+  end
+
+  def test_color_by_none_neutralizes_every_bar
+    render_inline(component(color_by: :none))
+
+    page.all(".bali-gantt-bar").each do |bar|
+      assert_match(/var\(--color-base-content\) 10%/, bar[:style])
+    end
+    assert_no_selector(".bali-gantt-swatch")
+  end
+
+  def test_legend_lists_only_present_statuses_in_catalog_order
+    render_inline(component)
+
+    labels = page.all(".bali-gantt-swatch").map { |swatch| swatch.find(:xpath, "..").text.strip }
+    assert_equal [ "In progress", "Complete" ], labels
+  end
+
+  def test_custom_status_catalog_drives_colors_and_labels
+    render_inline(component(statuses: [
+                              { value: "in_progress", label: "En curso", color: "--color-warning" },
+                              { value: "complete", label: "Hecho", color: "--color-success" }
+                            ]))
+
+    assert_text "En curso"
+    bar = page.find("a.bali-gantt-bar", match: :first)
+    assert_match(/var\(--color-warning\)/, bar[:style])
+  end
+
+  def test_zoom_links_rewrite_only_the_namespaced_param
+    with_request_url "/admin/projects/1?view=timeline&gantt_zoom=day" do
+      render_inline(component(zoom: "day"))
+    end
+
+    assert_link "Week", href: "/admin/projects/1?gantt_zoom=week&view=timeline"
+    assert_selector("a.btn-active", text: "Day")
+  end
+
+  def test_zoom_links_can_be_hidden
+    render_inline(component(zoom_links: false))
+
+    assert_no_selector(".join")
+  end
+
+  def test_truncation_is_announced_never_silent
+    render_inline(component(limit: 1))
+
+    assert_selector("[role='status'].alert-warning", text: /1 of 3|1 de 3/)
+  end
+
+  def test_undated_items_get_their_own_section
+    render_inline(component)
+
+    assert_selector(".bali-gantt-undated", text: "Unscheduled")
+    assert_selector(".bali-gantt-undated", text: /No dates/i)
+  end
+
+  def test_empty_data_renders_the_empty_state
+    render_inline(Bali::Gantt::Component.new(data: { items: [] }))
+
+    assert_selector(".empty-state-component")
+    assert_no_selector(".bali-gantt-canvas")
+  end
+
+  def test_interactive_mode_is_signed_but_not_available_yet
+    error = assert_raises(ArgumentError) do
+      Bali::Gantt::Component.new(data: payload, mode: :interactive)
+    end
+
+    assert_match(/phases 2-3/, error.message)
+  end
+
+  def test_unknown_mode_and_color_by_raise
+    assert_raises(ArgumentError) { Bali::Gantt::Component.new(data: payload, mode: :flying) }
+    assert_raises(ArgumentError) { Bali::Gantt::Component.new(data: payload, color_by: :phase) }
+  end
+
+  def test_accepts_a_prebuilt_data_document
+    doc = Bali::Gantt::Data.new(payload)
+    render_inline(Bali::Gantt::Component.new(data: doc))
+
+    assert_selector(".bali-gantt-canvas")
+  end
+
+  def test_assignee_chip_renders_initials
+    render_inline(component)
+
+    assert_selector(".bali-gantt-assignee", text: "AL")
+  end
+end

--- a/test/bali/components/gantt/data_test.rb
+++ b/test/bali/components/gantt/data_test.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliGanttDataTest < ActiveSupport::TestCase
+  def base_payload
+    {
+      groups: [
+        { id: 1, name: "Discovery" },
+        { id: 2, name: "Design" },
+        { id: 3, name: "Technical design", parent_id: 2 }
+      ],
+      items: [
+        { id: 10, group_id: 1, name: "Interviews", starts_on: "2026-01-05", ends_on: "2026-01-16" },
+        { id: 11, group_id: 1, name: "Summary", parent_id: 10, starts_on: "2026-01-12", ends_on: "2026-01-16" },
+        { id: 12, group_id: 2, name: "Wireframes", starts_on: "2026-01-19", ends_on: "2026-02-06" },
+        { id: 13, group_id: 3, name: "Schema", starts_on: nil, ends_on: nil }
+      ],
+      dependencies: [
+        { id: 1, predecessor_id: 10, successor_id: 12, dependency_type: "finish_to_start", lag_days: 2 }
+      ],
+      critical_ids: [ 10, 12 ]
+    }
+  end
+
+  def data(payload = base_payload, **kwargs)
+    Bali::Gantt::Data.new(payload, **kwargs)
+  end
+
+  def test_rejects_non_hash_payloads
+    error = assert_raises(Bali::Gantt::Data::InvalidError) { data([]) }
+    assert_match(/must be a Hash/, error.message)
+  end
+
+  def test_accepts_string_keys
+    parsed = data(base_payload.deep_stringify_keys)
+
+    assert_equal %w[Discovery Design], parsed.ordered_groups.reject(&:parent_id).map(&:name)
+    assert_equal Date.new(2026, 1, 5), parsed.window_starts_on
+  end
+
+  def test_orders_sub_groups_after_their_parent
+    assert_equal [ 1, 2, 3 ], data.ordered_groups.map(&:id)
+  end
+
+  def test_nests_sub_items_after_their_parent
+    assert_equal [ 10, 11 ], data.items_for(1).map(&:id)
+  end
+
+  def test_derives_window_from_items_and_groups_when_absent
+    parsed = data
+
+    assert_equal Date.new(2026, 1, 5), parsed.window_starts_on
+    assert_equal Date.new(2026, 2, 6), parsed.window_ends_on
+  end
+
+  def test_explicit_window_wins
+    parsed = data(base_payload.merge(window: { starts_on: "2026-01-01", ends_on: "2026-03-31" }))
+
+    assert_equal Date.new(2026, 1, 1), parsed.window_starts_on
+    assert_equal Date.new(2026, 3, 31), parsed.window_ends_on
+  end
+
+  def test_group_own_dates_extend_the_derived_window
+    payload = base_payload
+    payload[:groups][1][:starts_on] = "2025-12-01"
+    payload[:groups][1][:ends_on] = "2026-02-20"
+
+    parsed = data(payload)
+
+    assert_equal Date.new(2025, 12, 1), parsed.window_starts_on
+    assert_equal Date.new(2026, 2, 20), parsed.window_ends_on
+  end
+
+  def test_single_date_items_stay_on_the_axis_as_minimal_ranges
+    payload = base_payload
+    payload[:items] << { id: 14, group_id: 2, name: "Only start", starts_on: "2026-01-20" }
+    payload[:items] << { id: 15, group_id: 2, name: "Only end", ends_on: "2026-01-22" }
+
+    parsed = data(payload)
+    only_start = parsed.dated_items.find { |i| i.id == 14 }
+    only_end = parsed.dated_items.find { |i| i.id == 15 }
+
+    assert_equal [ Date.new(2026, 1, 20) ] * 2, [ only_start.starts_on, only_start.ends_on ]
+    assert_equal [ Date.new(2026, 1, 22) ] * 2, [ only_end.starts_on, only_end.ends_on ]
+  end
+
+  def test_inverted_ranges_clamp_to_their_start
+    payload = base_payload
+    payload[:items] << { id: 14, group_id: 2, name: "Inverted", starts_on: "2026-01-20", ends_on: "2026-01-10" }
+
+    item = data(payload).dated_items.find { |i| i.id == 14 }
+
+    assert_equal item.starts_on, item.ends_on
+  end
+
+  def test_undated_items_are_split_out
+    parsed = data
+
+    assert_equal [ 13 ], parsed.undated_items.map(&:id)
+    assert_equal 3, parsed.dated_total
+    assert_equal 1, parsed.undated_total
+  end
+
+  def test_limit_caps_dated_items_and_announces
+    parsed = data(base_payload, limit: 2)
+
+    assert_predicate parsed, :truncated?
+    assert_equal 3, parsed.dated_total
+    assert_equal [ 10, 11 ], parsed.dated_items.map(&:id)
+  end
+
+  def test_limit_drops_sub_items_whose_parent_fell_over_the_cap
+    payload = base_payload
+    # Reorder so the sub-item would survive while its parent does not.
+    payload[:items] = [
+      payload[:items][2],                                     # 12
+      payload[:items][0],                                     # 10 (parent)
+      payload[:items][1]                                      # 11 (sub of 10)
+    ]
+
+    parsed = data(payload, limit: 1)
+
+    assert_equal [ 12 ], parsed.dated_items.map(&:id)
+  end
+
+  def test_milestone_and_optional_fields_parse
+    payload = base_payload
+    payload[:items] << {
+      id: 20, group_id: 2, name: "Release", starts_on: "2026-02-06", milestone: true,
+      percent_complete: "150", slack_days: 4,
+      assignee: { id: 7, name: "Ana Luz", initials: "AL" }, href: "/tasks/20"
+    }
+
+    item = data(payload).dated_items.find { |i| i.id == 20 }
+
+    assert_predicate item, :milestone?
+    assert_equal 100, item.percent_complete # clamped
+    assert_equal 4, item.slack_days
+    assert_equal "AL", item.assignee.initials
+    assert_equal "/tasks/20", item.href
+  end
+
+  def test_critical_lookup
+    parsed = data
+
+    assert parsed.critical?(10)
+    assert parsed.critical?(parsed.dated_items.find { |i| i.id == 12 })
+    refute parsed.critical?(11)
+  end
+
+  def test_dependencies_parse_with_defaults
+    dep = data.dependencies.first
+
+    assert_equal [ 10, 12 ], [ dep.predecessor_id, dep.successor_id ]
+    assert_equal "finish_to_start", dep.dependency_type
+    assert_equal 2, dep.lag_days
+  end
+
+  def test_rejects_bad_iso_dates
+    payload = base_payload
+    payload[:items][0][:starts_on] = "05/01/2026"
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_rejects_unknown_group_references
+    payload = base_payload
+    payload[:items][0][:group_id] = 99
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_rejects_groups_nested_beyond_two_levels
+    payload = base_payload
+    payload[:groups] << { id: 4, name: "Too deep", parent_id: 3 }
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_rejects_items_nested_beyond_two_levels
+    payload = base_payload
+    payload[:items] << { id: 14, group_id: 1, name: "Too deep", parent_id: 11 }
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_rejects_sub_items_outside_their_parents_group
+    payload = base_payload
+    payload[:items][1][:group_id] = 2
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_rejects_items_without_id_or_name
+    payload = base_payload
+    payload[:items] << { group_id: 1, name: "No id" }
+
+    assert_raises(Bali::Gantt::Data::InvalidError) { data(payload) }
+  end
+
+  def test_ungrouped_items_form_an_implicit_section
+    payload = base_payload
+    payload[:items] << { id: 30, name: "Loose end", starts_on: "2026-01-07", ends_on: "2026-01-09" }
+
+    assert_equal [ 30 ], data(payload).ungrouped_items.map(&:id)
+  end
+end

--- a/test/bali/components/gantt/serializer_contract_test.rb
+++ b/test/bali/components/gantt/serializer_contract_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Validates the frozen Bali::Gantt contract against a REAL sample of
+# TDFlow::GanttSerializer output (test/fixtures/gantt/td_flow_gantt_serializer.json,
+# frozen from afal-apps 05/08/2026). `contract_from_serializer` below is the
+# rename mapping afal-apps adopts in phase 4 (D19: renames live in the host's
+# serializer, no aliases in the gem). If the contract cannot express something
+# the island consumes today, this test is where it surfaces.
+class BaliGanttSerializerContractTest < ActiveSupport::TestCase
+  FIXTURE = Rails.root.join("../../test/fixtures/gantt/td_flow_gantt_serializer.json")
+
+  def serializer_doc
+    @serializer_doc ||= JSON.parse(File.read(FIXTURE))
+  end
+
+  # stage→group, task→item, title→name, *_id renames. is_critical and row_kind
+  # are not mapped: the contract derives them (critical_ids / parent_id).
+  def contract_from_serializer(doc)
+    {
+      window: doc["window"],
+      groups: doc["stages"].map do |stage|
+        { id: stage["id"], name: stage["name"], parent_id: stage["parent_stage_id"],
+          position: stage["position"], status: stage["status"],
+          starts_on: stage["starts_on"], ends_on: stage["ends_on"] }
+      end,
+      items: doc["tasks"].map do |task|
+        { id: task["id"], group_id: task["stage_id"], parent_id: task["parent_task_id"],
+          name: task["title"], starts_on: task["starts_on"], ends_on: task["ends_on"],
+          status: task["status"], priority: task["priority"],
+          percent_complete: task["percent_complete"], assignee: task["assignee"],
+          slack_days: task["slack_days"] }
+      end,
+      dependencies: doc["dependencies"],
+      critical_ids: doc["critical_task_ids"]
+    }
+  end
+
+  def data
+    @data ||= Bali::Gantt::Data.new(contract_from_serializer(serializer_doc))
+  end
+
+  def test_the_real_serializer_sample_maps_into_a_valid_document
+    assert_predicate data, :any?
+    assert_equal 3, data.dated_total
+    assert_equal 1, data.undated_total
+  end
+
+  def test_window_survives_the_mapping
+    assert_equal Date.new(2026, 5, 4), data.window_starts_on
+    assert_equal Date.new(2026, 6, 5), data.window_ends_on
+  end
+
+  def test_nested_stages_keep_their_tree
+    groups = data.ordered_groups
+
+    assert_equal [ 11, 12, 13 ], groups.map(&:id)
+    assert_equal 12, groups.last.parent_id
+  end
+
+  def test_subtasks_keep_their_row_kind_via_parent_id
+    rows = data.items_for(11)
+
+    assert_equal [ 101, 102 ], rows.map(&:id)
+    assert rows.second.sub_item?, "row_kind: subtask must be derivable from parent_id"
+    refute rows.first.sub_item?
+  end
+
+  def test_is_critical_is_fully_recoverable_from_critical_ids
+    serializer_doc["tasks"].each do |task|
+      assert_equal task["is_critical"], data.critical?(task["id"]),
+                   "is_critical for task #{task['id']} lost in the mapping"
+    end
+  end
+
+  def test_optional_fields_the_island_consumes_survive
+    task = data.items_for(11).first
+
+    assert_equal 100, task.percent_complete
+    assert_equal 0, task.slack_days
+    assert_equal "high", task.priority
+    assert_equal "AD", task.assignee.initials
+
+    dep = data.dependencies.first
+    assert_equal [ "finish_to_start", 0 ], [ dep.dependency_type, dep.lag_days ]
+  end
+
+  def test_stage_own_dates_give_groups_their_bars
+    design = data.ordered_groups.second
+
+    assert_predicate design, :dated?
+    assert_equal Date.new(2026, 5, 18), design.starts_on
+  end
+end

--- a/test/bali/components/gantt/time_scale_test.rb
+++ b/test/bali/components/gantt/time_scale_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliGanttTimeScaleTest < ActiveSupport::TestCase
+  def scale(starts_on: Date.new(2026, 1, 5), ends_on: Date.new(2026, 3, 20), zoom: :week)
+    Bali::Gantt::TimeScale.new(starts_on: starts_on, ends_on: ends_on, zoom: zoom)
+  end
+
+  def test_px_per_day_matches_the_island_zoom_levels
+    # ZoomControls.jsx ZOOM_LEVELS: day 24, week 8, month 2.
+    assert_equal 24, scale(zoom: :day).px_per_day
+    assert_equal 8, scale(zoom: :week).px_per_day
+    assert_equal 2, scale(zoom: :month).px_per_day
+  end
+
+  def test_unknown_zoom_values_normalize_to_auto
+    assert_equal :auto, scale(zoom: "huge").zoom
+    assert_equal :auto, scale(zoom: nil).zoom
+  end
+
+  def test_auto_zoom_picks_density_from_the_window_span
+    assert_equal :day, scale(ends_on: Date.new(2026, 1, 31), zoom: :auto).resolved_zoom
+    assert_equal :week, scale(ends_on: Date.new(2026, 9, 30), zoom: :auto).resolved_zoom
+    assert_equal :month, scale(ends_on: Date.new(2029, 1, 5), zoom: :auto).resolved_zoom
+  end
+
+  def test_x_for_is_days_from_window_start_times_density
+    subject = scale(zoom: :week)
+
+    assert_equal 0, subject.x_for(Date.new(2026, 1, 5))
+    assert_equal 8 * 10, subject.x_for(Date.new(2026, 1, 15))
+  end
+
+  def test_total_width_includes_the_final_day
+    subject = scale(starts_on: Date.new(2026, 1, 5), ends_on: Date.new(2026, 1, 9), zoom: :day)
+
+    assert_equal 24 * 5, subject.total_width
+  end
+
+  def test_bar_geometry_is_end_inclusive_with_a_minimum_width
+    subject = scale(zoom: :day)
+
+    one_day = subject.bar_geometry(Date.new(2026, 1, 6), Date.new(2026, 1, 6))
+    assert_equal({ left: 24, width: 24 }, one_day)
+
+    thin = scale(zoom: :month).bar_geometry(Date.new(2026, 1, 6), Date.new(2026, 1, 6))
+    assert_equal Bali::Gantt::TimeScale::MIN_BAR_PX, thin[:width]
+  end
+
+  def test_bar_geometry_clamps_to_the_canvas
+    subject = scale(starts_on: Date.new(2026, 2, 1), ends_on: Date.new(2026, 2, 28), zoom: :day)
+
+    geometry = subject.bar_geometry(Date.new(2026, 1, 1), Date.new(2026, 3, 15))
+
+    assert_equal 0, geometry[:left]
+    assert_equal subject.total_width, geometry[:width]
+  end
+
+  def test_month_ticks_use_true_calendar_widths
+    subject = scale(starts_on: Date.new(2026, 1, 10), ends_on: Date.new(2026, 3, 10), zoom: :month)
+    ticks = subject.ticks
+
+    assert_equal 3, ticks.size
+    # First segment clips at the window start (Jan 10 → Feb 1 = 22 days).
+    assert_equal 0, ticks.first[:x]
+    assert_equal 22 * 2, ticks.first[:width]
+    # February renders its true 28-day width.
+    assert_equal 28 * 2, ticks.second[:width]
+    # Last segment clips at the inclusive window end (Mar 1 → Mar 11 = 10 days).
+    assert_equal 10 * 2, ticks.third[:width]
+  end
+
+  def test_week_ticks_start_on_monday_and_clip_at_the_window
+    subject = scale(starts_on: Date.new(2026, 1, 7), ends_on: Date.new(2026, 1, 27), zoom: :week)
+    ticks = subject.ticks
+
+    # 2026-01-07 is a Wednesday; the first segment runs Wed→Mon (5 days).
+    assert_equal 0, ticks.first[:x]
+    assert_equal 5 * 8, ticks.first[:width]
+    assert_equal 7 * 8, ticks.second[:width]
+  end
+
+  def test_day_ticks_enumerate_days
+    subject = scale(starts_on: Date.new(2026, 1, 5), ends_on: Date.new(2026, 1, 7), zoom: :day)
+
+    assert_equal %w[5 6 7], subject.ticks.map { |t| t[:label] }
+    assert_equal [ 0, 24, 48 ], subject.ticks.map { |t| t[:x] }
+  end
+
+  def test_bands_are_months_over_day_and_week_zoom_and_years_over_month_zoom
+    weekly = scale(starts_on: Date.new(2026, 1, 5), ends_on: Date.new(2026, 2, 10), zoom: :week)
+    assert_equal 2, weekly.bands.size
+    assert_match(/January/, weekly.bands.first[:label])
+
+    monthly = scale(starts_on: Date.new(2025, 11, 1), ends_on: Date.new(2026, 2, 1), zoom: :month)
+    assert_equal %w[2025 2026], monthly.bands.map { |b| b[:label] }
+  end
+
+  def test_today_marker_only_inside_the_window
+    inside = scale(starts_on: Date.current - 10, ends_on: Date.current + 10, zoom: :day)
+    assert_equal 10 * 24, inside.today_x
+
+    outside = scale(starts_on: Date.current + 5, ends_on: Date.current + 15, zoom: :day)
+    assert_nil outside.today_x
+  end
+
+  def test_invalid_without_dates
+    subject = Bali::Gantt::TimeScale.new(starts_on: nil, ends_on: nil)
+
+    refute_predicate subject, :valid?
+    assert_equal 0, subject.total_width
+    assert_empty subject.ticks
+    assert_empty subject.bands
+    assert_nil subject.today_x
+  end
+end

--- a/test/fixtures/gantt/td_flow_gantt_serializer.json
+++ b/test/fixtures/gantt/td_flow_gantt_serializer.json
@@ -1,0 +1,109 @@
+{
+  "__comment": "Frozen sample of TDFlow::GanttSerializer#as_json (afal-apps, app/models/td_flow/gantt_serializer.rb @ 05/08/2026). The Bali::Gantt::Data contract generalizes this shape; test/bali/components/gantt/serializer_contract_test.rb maps it with the documented renames (stages→groups, tasks→items, title→name, stage_id→group_id, parent_*_id→parent_id, critical_task_ids→critical_ids) and proves nothing the island consumes is lost.",
+  "tasks": [
+    {
+      "id": 101,
+      "stage_id": 11,
+      "parent_task_id": null,
+      "title": "Levantamiento de requerimientos",
+      "starts_on": "2026-05-04",
+      "ends_on": "2026-05-15",
+      "duration_days": 10,
+      "percent_complete": 100,
+      "status": "complete",
+      "priority": "high",
+      "is_critical": true,
+      "slack_days": 0,
+      "row_kind": "task",
+      "assignee": { "id": 7, "name": "Ana Luz Durán", "initials": "AD" }
+    },
+    {
+      "id": 102,
+      "stage_id": 11,
+      "parent_task_id": 101,
+      "title": "Entrevistas con usuarios",
+      "starts_on": "2026-05-06",
+      "ends_on": "2026-05-12",
+      "duration_days": 5,
+      "percent_complete": 60,
+      "status": "in_progress",
+      "priority": "normal",
+      "is_critical": false,
+      "slack_days": 3,
+      "row_kind": "subtask",
+      "assignee": null
+    },
+    {
+      "id": 103,
+      "stage_id": 12,
+      "parent_task_id": null,
+      "title": "Diseño de arquitectura",
+      "starts_on": "2026-05-18",
+      "ends_on": "2026-06-05",
+      "duration_days": 15,
+      "percent_complete": 0,
+      "status": "backlog",
+      "priority": "urgent",
+      "is_critical": true,
+      "slack_days": 0,
+      "row_kind": "task",
+      "assignee": { "id": 9, "name": "Bruno Ortega", "initials": "BO" }
+    },
+    {
+      "id": 104,
+      "stage_id": 13,
+      "parent_task_id": null,
+      "title": "Definir plan de pruebas",
+      "starts_on": null,
+      "ends_on": null,
+      "duration_days": null,
+      "percent_complete": 0,
+      "status": "backlog",
+      "priority": "low",
+      "is_critical": false,
+      "slack_days": 0,
+      "row_kind": "task",
+      "assignee": null
+    }
+  ],
+  "dependencies": [
+    {
+      "id": 9001,
+      "predecessor_id": 101,
+      "successor_id": 103,
+      "dependency_type": "finish_to_start",
+      "lag_days": 0
+    }
+  ],
+  "critical_task_ids": [101, 103],
+  "window": { "starts_on": "2026-05-04", "ends_on": "2026-06-05" },
+  "stages": [
+    {
+      "id": 11,
+      "name": "Descubrimiento",
+      "position": 1,
+      "status": "in_progress",
+      "parent_stage_id": null,
+      "starts_on": "2026-05-04",
+      "ends_on": "2026-05-15"
+    },
+    {
+      "id": 12,
+      "name": "Diseño",
+      "position": 2,
+      "status": "backlog",
+      "parent_stage_id": null,
+      "starts_on": "2026-05-18",
+      "ends_on": "2026-06-05"
+    },
+    {
+      "id": 13,
+      "name": "Diseño técnico",
+      "position": 0,
+      "status": "backlog",
+      "parent_stage_id": 12,
+      "starts_on": null,
+      "ends_on": null
+    }
+  ]
+}


### PR DESCRIPTION
> **NO MERGEAR: el contrato exige ratificar 704-D5..D9 (bloque B) — implementado según las recomendaciones.** El código va completo y verde; cuando Fede ratifique (o corrija) las decisiones, este draft se promueve.

Refs #704

## Qué entrega esta fase

Un solo componente con dos renderers; esta fase congela el **contrato de datos compartido** y entrega el modo **`:static` server-rendered** (port generalizado del tablero de portfolio de afal-apps).

### Los tres POROs

- **`Bali::Gantt::Data`** — parseo/validación del contrato: `{ window, groups[], items[], dependencies[], critical_ids[] }`. Grupos e items anidan **un nivel** vía `parent_id` (como stages/subtasks reales); fechas ISO8601; item con una sola fecha se dibuja como barra mínima (regla del portfolio); rango invertido se clava a su inicio; errores estructurales **truenan** en vez de soltar barras en silencio. `limit:` recorta ANTES de derivar la ventana, como el portfolio.
- **`Bali::Gantt::TimeScale`** — un solo sistema de coordenadas en **días**: `px_per_day` 24/8/2 (day/week/month, paridad exacta con `ZoomControls.jsx` para que la fase 2 comparta números), `:auto` por densidad de ventana (la regla "zoom fijo por rango" del portfolio), `MIN_BAR_PX`, fin inclusivo, ticks/bandas de calendario recortados al lienzo y hoy-línea.
- **`Bali::Gantt::Colors`** — las fórmulas `color-mix`/oklch de `ganttColors.js` **literales y asertadas verbatim** en tests (paridad visual entre renderers), con soporte de catálogos de estado del host.

### El componente `:static`

Header sticky de 2 niveles, `<details>` plegables por grupo (con barra rollup propia si el grupo trae fechas), hoy-línea, retícula, `color_by: :status/:none`, zoom por links con param namespaceado `gantt_zoom` (conserva el resto del query string), `group_label:`, `limit:` **anunciado**, sección "Sin fechas", diamante para `milestone: true` y ring CPM en `critical_ids`. Tokens `--gantt-*` en `@layer components`; locales `bali_view.gantt.*` en/es; previews Lookbook (playground `color_by`/`zoom`, catálogo custom, truncado, vacío).

Desviación consciente: la retícula NO va por gradiente — en coordenadas de días los meses miden 28–31 días y un gradiente de periodo fijo deriva; son divs absolutos, uno por tick (no por fila), exactos y baratos.

## Contrato congelado (según recomendaciones 704-D5..D9)

| Decisión | Implementado |
|---|---|
| **D5** | Núcleo + opcionales que la isla ya consume: `parent_id` en groups e items (2 niveles), `assignee {id,name,initials}`, `percent_complete`, `slack_days`, más `priority` (la isla lo consume para color-by) y `href` opcional (barras/nombres linkeables en :static) |
| **D6** | `milestone:` boolean opcional — diamante en `:static` |
| **D7** | CSS en `@layer components` |
| **D8** | `mode:` firmado ya; `:interactive` levanta `ArgumentError` con mensaje claro hasta fase 3 (#705/#719) |
| **D9** | `color_by: :status` y `:none` (cumple la promesa hecha a #667 en el CHANGELOG de v3) |

Renombres vs `TDFlow::GanttSerializer`: `stages→groups`, `tasks→items`, `title→name`, `stage_id→group_id`, `parent_*_id→parent_id`, `critical_task_ids→critical_ids`; `is_critical` y `row_kind` se **derivan**. `test/fixtures/gantt/td_flow_gantt_serializer.json` congela una muestra real del serializer y `serializer_contract_test.rb` prueba el mapeo (que en fase 4 vive en el serializer de afal-apps, D19 — sin aliases en la gema).

## Implementación completa en el dummy (requisito explícito)

`/admin/projects/:id?view=timeline` renderiza el gantt con **datos reales de seed** (no solo Lookbook): fases con rollup, avance, hito de release, dos tareas sin fechas a propósito, switch Board | Timeline y link "View Timeline" desde el índice canónico de `/admin`. `ProjectGantt` (dummy) es la implementación de referencia del contrato del lado host — la página sobre la que las fases 3/4 montan `:interactive` y el gate anti-flicker (D16).

## Verificación

- Minitest: **suite completa verde** (3833 runs, 0 fallos), incl. 65 tests nuevos de gantt (geometría, contrato, fórmulas verbatim, render).
- Rubocop: sin ofensas en lo nuevo.
- Previews Lookbook: los 4 variants responden 200 y verificados en browser.
- Página admin verificada en browser (puerto 3071): grupos plegando, zoom Day/Week/Month reescribiendo solo `gantt_zoom` (conserva `view=timeline`), hoy-línea, diamante, "No dates", leyenda solo con estados presentes.
- Cypress: no se tocó JS ni ningún spec visita `admin/projects` — no aplica.
- Pendiente para #719: `docs/api/gantt.md` (contratos de mutación/broadcast) y el delta de guía GanttChart→Gantt; la entrada de catálogo en `docs/guides/components.md` puede ir ahí o aquí si se prefiere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
