### PR TITLE
FormBuilder: error: explícito por campo y fundación de size: (#723 PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **FormBuilder: `error:` option — external errors per field** (#723). Every field group now
+  accepts `error:` (String, Array, or nil/false for "nothing"), carrying a message that never
+  lived in `object.errors` — a rodauth view rendering `form_with url:` with no object, or any
+  non-ActiveModel validator. The explicit error rides the exact plumbing model errors already
+  use: the `.text-error` message paragraph, the `aria-invalid`/`aria-describedby` pair, and the
+  family's `*-error` class on the control. When the model also has errors on the field the two
+  sources join rather than replace, explicit first. On the two-hash families (`select_*`,
+  `slim_select_*`, `time_zone_select_*`, `radio_*`) it is a group option and works from either
+  hash. A new contract test (`external_error_option_test.rb`) makes every group helper declare
+  its outcome — full dress, message only, or silent — so no family can drift out unnoticed.
+- **FormBuilder: `size:` density variants — foundation** (#723). On the text-input families,
+  `size:` with a Symbol (`:xs`/`:sm`/`:md`/`:lg`/`:xl`) now renders the daisyUI `input-*`
+  density class instead of the attribute; an Integer — or a String, which is what `size: "4"`
+  always meant — keeps meaning the HTML `size` attribute and passes through untouched, and an
+  unknown Symbol raises instead of leaking into the markup (the contract `submit_field`/
+  `submit_group` already enforced through `ButtonTaxonomy`, now asserted for both mechanisms).
+  The per-family maps (`select-*`, `textarea-*`, `file-input-*`, `range-*`) build on this
+  foundation in a follow-up PR.
+
 - **`Bali::Gantt` — phase 1: the shared data contract and the server-rendered `:static` mode** (#704). One component, two renderers; this phase ships the foundation the React island (phases 2-3, #705/#719) will plug into:
   - `Bali::Gantt::Data` parses and validates the frozen contract — `{ window, groups[], items[], dependencies[], critical_ids[] }` with two-level group/item nesting (`parent_id`), ISO8601 dates, and the optional fields the real island already consumes: `assignee`, `percent_complete`, `slack_days`, `priority`, plus `milestone:` (rendered as a diamond) and `href`. Single-date items draw as minimum-width bars, inverted ranges clamp to their start, and structural errors raise instead of silently dropping bars. A frozen sample of `TDFlow::GanttSerializer` output validates the rename mapping (`test/fixtures/gantt/`).
   - `Bali::Gantt::TimeScale` — one day-based coordinate system shared with the future island (`px_per_day` 24/8/2 for day/week/month, exactly `ZoomControls.jsx`), `:auto` density picked from the window span, minimum bar width, inclusive ends, clipped calendar ticks/bands and the today marker.

--- a/app/components/bali/form/text/preview.rb
+++ b/app/components/bali/form/text/preview.rb
@@ -64,6 +64,26 @@ module Bali
             locals: { model: form_record }
           )
         end
+
+        # @label With External Error
+        # A model-less form (`form_with url:` — the rodauth shape): `error:`
+        # carries the message a non-ActiveModel validator produced. Strings and
+        # arrays both work; nil/false render nothing, so the raw return of the
+        # validator can be passed unconditionally.
+        def with_external_error
+          render_with_template(
+            template: 'bali/form/text/previews/with_external_error'
+          )
+        end
+
+        # @label Sizes
+        # `size:` with a Symbol is the daisyUI density variant; an Integer keeps
+        # meaning the HTML `size` attribute (width in characters).
+        def sizes
+          render_with_template(
+            template: 'bali/form/text/previews/sizes'
+          )
+        end
       end
     end
   end

--- a/app/components/bali/form/text/previews/sizes.html.erb
+++ b/app/components/bali/form/text/previews/sizes.html.erb
@@ -1,0 +1,9 @@
+<%= form_with(url: '/', builder: Bali::FormBuilder) do |form| %>
+  <%= form.text_group :extra_small, size: :xs, placeholder: 'size: :xs' %>
+  <%= form.text_group :small, size: :sm, placeholder: 'size: :sm' %>
+  <%= form.text_group :medium, size: :md, placeholder: 'size: :md' %>
+  <%= form.text_group :large, size: :lg, placeholder: 'size: :lg' %>
+  <%= form.text_group :extra_large, size: :xl, placeholder: 'size: :xl' %>
+  <%= form.text_group :attribute_size, size: 8,
+                      help: 'size: 8 is the HTML attribute — width in characters' %>
+<% end %>

--- a/app/components/bali/form/text/previews/with_external_error.html.erb
+++ b/app/components/bali/form/text/previews/with_external_error.html.erb
@@ -1,0 +1,7 @@
+<%= form_with(url: '/', builder: Bali::FormBuilder) do |form| %>
+  <%= form.text_group :login, error: 'No account with this login', required: true %>
+  <%= form.password_group :password,
+                          error: ['Too short', 'Cannot match the login'],
+                          help: '12 characters minimum' %>
+  <%= form.text_group :nickname, error: nil, help: 'error: nil renders a normal field' %>
+<% end %>

--- a/docs/guides/form-builder.md
+++ b/docs/guides/form-builder.md
@@ -646,11 +646,33 @@ These options work across most field types:
 |--------|-------------|
 | `label` | Custom label text (default: humanized attribute name) |
 | `help` | Help text displayed below input |
+| `error` | Explicit error message(s) for the field — see [External Errors](#external-errors-error) |
 | `placeholder` | Input placeholder |
 | `disabled` | Disable the input |
 | `readonly` | Make input read-only |
 | `class` | Additional CSS classes |
 | `data` | Data attributes hash |
+
+### Density (`size:`)
+
+`size:` is the one option with two meanings on a form control, and both work:
+
+- **Symbol** — the daisyUI density variant: `:xs`, `:sm`, `:md`, `:lg`, `:xl`.
+  The class joins the control's base classes and no `size` attribute is emitted.
+- **Integer** (or String) — the HTML `size` attribute it has always been: width
+  in characters on an `<input>`, visible rows on a `<select>`.
+
+```erb
+<%= f.text_group :code, size: :sm %>   <%# <input class="input input-sm ..."> %>
+<%= f.text_group :code, size: 8 %>     <%# <input size="8" class="input ..."> %>
+<%= f.submit_group "Save", size: :sm %> <%# <button class="btn btn-primary btn-sm"> %>
+```
+
+A Symbol outside the variant list raises `ArgumentError` instead of leaking
+`size="tiny"` into the markup. The text-input families and the submit pair
+resolve the variant today; `select-*`, `textarea-*`, `file-input-*` and
+`range-*` land in a follow-up of #723 (checkbox, switch, radio and slim_select
+already had their own `size:`).
 
 ---
 
@@ -665,13 +687,32 @@ Bali FormBuilder automatically displays validation errors:
 
 The input gets `input-error` class and error messages appear below.
 
-### Manual Error Display
+### External Errors (`error:`)
+
+`error:` carries a message that never lived in `object.errors` — because the
+form has no object (`form_with url:`), or because something other than
+ActiveModel validated the field. It takes a String, an Array of them, or
+nil/false (both render nothing), so the raw return of the validator can be
+passed unconditionally:
 
 ```erb
-<% if @user.errors[:email].any? %>
-  <p class="text-error text-sm"><%= @user.errors[:email].join(", ") %></p>
+<%# A rodauth view: no model, the error comes from rodauth itself %>
+<%= form_with url: rodauth.login_path, builder: Bali::FormBuilder do |f| %>
+  <%= f.email_group :login, error: rodauth.field_error(rodauth.login_param), required: true %>
+  <%= f.password_group :password, error: rodauth.field_error("password") %>
+  <%= f.submit_group rodauth.login_button %>
 <% end %>
 ```
+
+The explicit error rides the same plumbing model errors use: the message
+paragraph, `aria-invalid` + `aria-describedby`, and the family's `*-error`
+class on the control. When the model **also** has errors on the field, the two
+join rather than replace — explicit first — mirroring how an error and a help
+message both render.
+
+On the two-hash families (`select_*`, `slim_select_*`, `time_zone_select_*`,
+`radio_*`) `error:` is a group option: pass it top-level, next to `label:`
+(inside `html:` also works).
 
 ---
 

--- a/lib/bali/form_builder/boolean_fields.rb
+++ b/lib/bali/form_builder/boolean_fields.rb
@@ -90,7 +90,7 @@ module Bali
           CHECKBOX_CLASS,
           SIZES[options[:size]],
           COLORS[options[:color]],
-          (errors?(method) ? "checkbox-error" : nil),
+          (errors?(method, options) ? "checkbox-error" : nil),
           options[:class]
         ].compact.join(" ")
 

--- a/lib/bali/form_builder/html_utils.rb
+++ b/lib/bali/form_builder/html_utils.rb
@@ -10,6 +10,16 @@ module Bali
       INPUT_ADDON_BASE_CLASS = "input join-item grow"
       TEXTAREA_BASE_CLASS = "textarea w-full"
 
+      # `size:` is the one key with two legitimate meanings on a form control:
+      # daisyUI's density variant and the HTML attribute of the same name (width
+      # in characters on an `<input>`, visible rows on a `<select>`). A Symbol
+      # out of the family's map is the variant; an Integer — or a String, which
+      # is what `size: "4"` has always meant — keeps meaning the attribute and
+      # passes through untouched. See `size_variant`.
+      INPUT_SIZES = {
+        xs: "input-xs", sm: "input-sm", md: "input-md", lg: "input-lg", xl: "input-xl"
+      }.freeze
+
       # daisyUI 5 dropped `label-text-alt`; `fieldset-label` is its successor for
       # the messages under a control. Unlike `.label` — the other candidate — it
       # is a block-level flex container with no `white-space: nowrap`, so a long
@@ -29,9 +39,11 @@ module Bali
       # Options the wrapper markup consumes: the fieldset caption, the help text
       # under the control, the `.control` div and the addons around the input.
       # `control_id` is the id the caption's `for` points at — read by
-      # FieldGroupWrapper, never an attribute of the input itself.
+      # FieldGroupWrapper, never an attribute of the input itself. `error` is
+      # the caller's own message for the field — rendered by `error_and_help`
+      # next to the model's, never an attribute.
       WRAPPER_OPTIONS = %i[
-        label help control_class control_data addon_left addon_right addon_class
+        label help error control_class control_data addon_left addon_right addon_class
         field_class field_data control_id
       ].freeze
 
@@ -186,13 +198,13 @@ module Bali
       # from what the field *could* have.
       def aria_attributes(method, options = {})
         described_by = [
-          (error_message_id(method) if errors?(method)),
+          (error_message_id(method) if errors?(method, options)),
           (help_message_id(method) if options[:help].present?)
         ].compact
 
         {
           "aria-describedby": described_by.presence&.join(" "),
-          "aria-invalid": ("true" if errors?(method))
+          "aria-invalid": ("true" if errors?(method, options))
         }.compact
       end
 
@@ -230,13 +242,14 @@ module Bali
 
       def field_options(method, options)
         attributes = html_attributes(options)
+        attributes.delete(:size) if size_variant(options)
 
         if PATTERN_TYPES.include?(options[:pattern_type])
           attributes[:pattern] = localized_number_pattern
         end
 
         attributes[:class] = field_class_name(
-          method, "#{input_base_class(options)} #{options[:class]}"
+          method, "#{input_base_class(options)} #{options[:class]}", options: options
         )
         merge_aria_attributes(attributes, method, options)
       end
@@ -244,7 +257,8 @@ module Bali
       def textarea_field_options(method, options, stimulus: false)
         attributes = html_attributes(options)
         attributes[:class] = field_class_name(
-          method, "#{TEXTAREA_BASE_CLASS} #{options[:class]}", error_class: "textarea-error"
+          method, "#{TEXTAREA_BASE_CLASS} #{options[:class]}",
+          error_class: "textarea-error", options: options
         )
 
         if stimulus
@@ -297,14 +311,15 @@ module Bali
       # control's `aria-describedby` at them. Emitting the id is all that
       # happens here; wiring it onto the input belongs to that issue.
       def error_and_help(method, options = {})
-        safe_join([ error_message(method), help_message(method, options) ].compact)
+        safe_join([ error_message(method, options), help_message(method, options) ].compact)
       end
 
-      def error_message(method)
-        return unless errors?(method)
+      def error_message(method, options = {})
+        return unless errors?(method, options)
 
         content_tag(
-          :p, full_errors(method), class: ERROR_MESSAGE_CLASS, id: error_message_id(method)
+          :p, full_errors(method, options),
+          class: ERROR_MESSAGE_CLASS, id: error_message_id(method)
         )
       end
 
@@ -325,20 +340,27 @@ module Bali
         field_id(method, "help")
       end
 
-      def field_class_name(method, class_name = "input", error_class: "input-error")
-        return class_name unless errors?(method)
+      def field_class_name(method, class_name = "input", error_class: "input-error", options: {})
+        return class_name unless errors?(method, options)
 
         "#{class_name} #{error_class}"
       end
 
-      def errors?(method)
-        object.respond_to?(:errors) && object.errors.key?(method)
+      # A field is in error when the model says so or the caller does. `error:`
+      # is the caller's channel (#723): the message rodauth or any other
+      # non-ActiveModel validator produced, on a form that may not even have an
+      # object. String or Array of them; nil and false both mean "nothing", so
+      # `error: rodauth.field_error(param)` can be written unconditionally.
+      def errors?(method, options = {})
+        explicit_errors(options).any? ||
+          (object.respond_to?(:errors) && object.errors.key?(method))
       end
 
-      def full_errors(method)
-        return "" unless object.respond_to?(:errors)
-
-        safe_join(object.errors.full_messages_for(method), ", ")
+      # The two sources join rather than replace, explicit first — the mirror
+      # of the error+help decision above: both are true, so both render, and
+      # the caller's message is the more specific one.
+      def full_errors(method, options = {})
+        safe_join(explicit_errors(options) + model_errors(method), ", ")
       end
 
       # rubocop:disable Style/OptionalBooleanParameter
@@ -375,11 +397,44 @@ module Bali
 
       private
 
+      # The caller's `error:`, normalized to the array of messages worth
+      # rendering. nil disappears on its own; `false` and `""` are dropped by
+      # the presence check, which is what lets a call site pass the raw return
+      # of its validator without guarding it first.
+      def explicit_errors(options)
+        Array(options[:error]).select(&:present?)
+      end
+
+      def model_errors(method)
+        return [] unless object.respond_to?(:errors)
+
+        object.errors.full_messages_for(method)
+      end
+
+      # The daisyUI class `size:` names, or nil when the option means the HTML
+      # attribute (see INPUT_SIZES). Only Symbols are read as variants —
+      # `size: 4` and `size: "4"` keep their attribute meaning untouched — and
+      # a Symbol the map does not know raises instead of leaking `size="tiny"`
+      # into the markup, the same contract ButtonTaxonomy already enforces for
+      # the submit button.
+      def size_variant(options, map = INPUT_SIZES)
+        size = options[:size]
+        return unless size.is_a?(Symbol)
+
+        map.fetch(size) do
+          raise ArgumentError,
+                "size: #{size.inspect} is not a size variant. " \
+                "Valid: #{map.keys.map(&:inspect).join(', ')}. " \
+                "An Integer passes through as the HTML size attribute."
+        end
+      end
+
       # Add join-item class when addons are present for proper DaisyUI join pattern
       def input_base_class(options)
         has_addons = options[:addon_left].present? || options[:addon_right].present?
+        base = has_addons ? INPUT_ADDON_BASE_CLASS : INPUT_BASE_CLASS
 
-        has_addons ? INPUT_ADDON_BASE_CLASS : INPUT_BASE_CLASS
+        [ base, size_variant(options) ].compact.join(" ")
       end
 
       def field_with_addons(field, left:, right:)

--- a/lib/bali/form_builder/radio_fields.rb
+++ b/lib/bali/form_builder/radio_fields.rb
@@ -117,7 +117,7 @@ module Bali
           RADIO_CLASS,
           SIZES[size],
           COLORS[color],
-          (errors?(method) ? "radio-error" : nil),
+          (errors?(method, options) ? "radio-error" : nil),
           custom_class
         ].compact.join(" ")
 

--- a/lib/bali/form_builder/range_fields.rb
+++ b/lib/bali/form_builder/range_fields.rb
@@ -97,7 +97,7 @@ module Bali
           "w-full",
           SIZES[options[:size]],
           COLORS[options[:color]],
-          (errors?(method) ? "range-error" : nil),
+          (errors?(method, options) ? "range-error" : nil),
           options[:class]
         ].compact.join(" ")
 

--- a/lib/bali/form_builder/select_fields.rb
+++ b/lib/bali/form_builder/select_fields.rb
@@ -26,7 +26,7 @@ module Bali
         group = group_options(options, html_options)
 
         attributes = html_attributes(html_options)
-        attributes[:class] = select_classes(method, html_options[:class])
+        attributes[:class] = select_classes(method, group, html_options[:class])
         apply_input_name_options(options, attributes)
         merge_aria_attributes(attributes, method, group)
 
@@ -36,8 +36,11 @@ module Bali
 
       private
 
-      def select_classes(method, additional_classes = nil)
-        base = field_class_name(method, BASE_CLASSES, error_class: "select-error")
+      # `options` is the merged group hash — `error:` may arrive top-level or in
+      # `html:`, and `group_options` has already read both.
+      def select_classes(method, options, additional_classes = nil)
+        base = field_class_name(method, BASE_CLASSES, error_class: "select-error",
+                                        options: options)
         [ base, additional_classes ].compact.join(" ")
       end
     end

--- a/lib/bali/form_builder/shared_date_utils.rb
+++ b/lib/bali/form_builder/shared_date_utils.rb
@@ -148,7 +148,7 @@ module Bali
 
       def alt_input_class(method, options)
         base_class = options[:alt_input_class] || HtmlUtils::INPUT_BASE_CLASS
-        field_class_name(method, base_class)
+        field_class_name(method, base_class, options: options)
       end
 
       def previous_date_button

--- a/lib/bali/form_builder/slim_select_fields.rb
+++ b/lib/bali/form_builder/slim_select_fields.rb
@@ -47,7 +47,7 @@ module Bali
         attributes = widget_attributes(merged_html)
         attributes[:class] = field_class_name(
           method, class_names([ SELECT_CLASS, merged_html[:class] ].compact),
-          error_class: "select-error"
+          error_class: "select-error", options: group
         )
         merge_aria_attributes(attributes, method, group)
 

--- a/lib/bali/form_builder/switch_fields.rb
+++ b/lib/bali/form_builder/switch_fields.rb
@@ -81,7 +81,7 @@ module Bali
           TOGGLE_CLASS,
           SIZES[options[:size]],
           COLORS[options[:color]],
-          (errors?(method) ? "toggle-error" : nil),
+          (errors?(method, options) ? "toggle-error" : nil),
           options[:class]
         ].compact.join(" ")
 

--- a/lib/bali/form_builder/time_zone_select_fields.rb
+++ b/lib/bali/form_builder/time_zone_select_fields.rb
@@ -42,7 +42,8 @@ module Bali
       # not carry it points the control at nothing while the paragraph renders
       # anyway — a description that exists on screen and not in the a11y tree.
       def time_zone_html_options(method, html_options, group = html_options)
-        base = field_class_name(method, BASE_CLASSES, error_class: "select-error")
+        base = field_class_name(method, BASE_CLASSES, error_class: "select-error",
+                                        options: group)
 
         attributes = html_attributes(html_options).except(:class).merge(
           class: [ base, html_options[:class] ].compact.join(" ")

--- a/test/bali/form_builder/external_error_option_test.rb
+++ b/test/bali/form_builder/external_error_option_test.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `error:` is the caller's own message for a field (#723): what rodauth — or any
+# validator that is not ActiveModel — produced, on a form that may not have an
+# object at all. It joins the model's errors rather than replacing them, the
+# caller's message first, and rides the exact plumbing model errors already
+# use: the `.text-error` paragraph, the `aria-describedby`/`aria-invalid` pair,
+# and the family's `*-error` class on the control.
+#
+# Not every family has all three to offer, so — like `required_option_test` —
+# every group helper has to declare its outcome by name: the full dress, the
+# message alone, or nothing at all (the families that never rendered field
+# messages, model errors included). Anything undeclared is the drift this test
+# exists for.
+class BaliFormBuilderExternalErrorOptionTest < FormBuilderTestCase
+  MESSAGE = "External message"
+
+  # Message paragraph + aria pair + the family's error class on the control.
+  MARKS_CONTROL = {
+    "text_group" => [ ->(b, o) { b.text_group(:name, **o) }, "input-error" ],
+    "email_group" => [ ->(b, o) { b.email_group(:name, **o) }, "input-error" ],
+    "url_group" => [ ->(b, o) { b.url_group(:name, **o) }, "input-error" ],
+    "password_group" => [ ->(b, o) { b.password_group(:name, **o) }, "input-error" ],
+    "number_group" => [ ->(b, o) { b.number_group(:budget, **o) }, "input-error" ],
+    "month_group" => [ ->(b, o) { b.month_group(:release_date, **o) }, "input-error" ],
+    "date_group" => [ ->(b, o) { b.date_group(:release_date, **o) }, "input-error" ],
+    "datetime_group" => [ ->(b, o) { b.datetime_group(:release_date, **o) }, "input-error" ],
+    "time_group" => [ ->(b, o) { b.time_group(:duration, **o) }, "input-error" ],
+    "search_group" => [ ->(b, o) { b.search_group(:name, **o) }, "input-error" ],
+    "currency_group" => [ ->(b, o) { b.currency_group(:budget, **o) }, "input-error" ],
+    "percentage_group" => [ ->(b, o) { b.percentage_group(:budget, **o) }, "input-error" ],
+    "numeric_group" => [ ->(b, o) { b.numeric_group(:budget, **o) }, "input-error" ],
+    "step_number_group" => [ ->(b, o) { b.step_number_group(:duration, **o) }, "input-error" ],
+    "text_area_group" => [ ->(b, o) { b.text_area_group(:synopsis, **o) }, "textarea-error" ],
+    "range_group" => [ ->(b, o) { b.range_group(:rating, **o) }, "range-error" ],
+    "boolean_group" => [ ->(b, o) { b.boolean_group(:indie, **o) }, "checkbox-error" ],
+    "switch_group" => [ ->(b, o) { b.switch_group(:indie, **o) }, "toggle-error" ],
+    "select_group" => [ ->(b, o) { b.select_group(:status, [], **o) }, "select-error" ],
+    "slim_select_group" => [ ->(b, o) { b.slim_select_group(:status, [], **o) }, "select-error" ],
+    "time_zone_select_group" => [ ->(b, o) { b.time_zone_select_group(:name, **o) },
+                                  "select-error" ],
+    "radio_group" => [ ->(b, o) { b.radio_group(:status, [ %w[One 1] ], **o) }, "radio-error" ],
+    # The error class lands on the `<trix-editor>`: the widget goes through
+    # `field_options` like a text input, so it dresses like one.
+    "rich_text_area_group" => [ ->(b, o) { b.rich_text_area_group(:synopsis, **o) },
+                                "input-error" ]
+  }.freeze
+
+  # Message paragraph only. `file_group`'s native input is hidden behind the
+  # browse button, so its class would color nothing (the aria pair still lands
+  # on it). The two editors and the toggler composite render widgets that carry
+  # no error dress today — model errors get exactly the same treatment.
+  MESSAGE_ONLY = {
+    "file_group" => ->(b, o) { b.file_group(:name, **o) },
+    "rich_text_group" => ->(b, o) { b.rich_text_group(:synopsis, **o) },
+    "block_editor_group" => ->(b, o) { b.block_editor_group(:synopsis, **o) },
+    "radio_buttons_group" => ->(b, o) { b.radio_buttons_group(:status, { a: [ %w[One 1] ] }, **o) }
+  }.freeze
+
+  # Families that render no field messages at all — for model errors too, and
+  # since before this option existed. Named so the silence stays a decision:
+  # moving one out of here means giving it the message paragraph, not deleting
+  # the line.
+  NO_MESSAGE = {
+    "coordinates_polygon_group" => ->(b, o) { b.coordinates_polygon_group(:name, **o) },
+    "recurrent_event_rule_group" => ->(b, o) { b.recurrent_event_rule_group(:rule, **o) },
+    "direct_upload_group" => ->(b, o) { b.direct_upload_group(:name, **o) },
+    "time_period_group" => ->(b, o) { b.time_period_group(:release_date, [ %w[T t] ], **o) },
+    "submit_group" => ->(b, o) { b.submit_group("Save", **o) }
+  }.freeze
+
+  # Renders a button and a container for nested records, never a control of its
+  # own, and needs a real association to render at all.
+  UNSWEPT_GROUPS = %w[dynamic_fields_group].freeze
+
+  def test_every_group_helper_is_covered_by_this_sweep
+    swept = MARKS_CONTROL.keys + MESSAGE_ONLY.keys + NO_MESSAGE.keys + UNSWEPT_GROUPS
+    uncovered = live_group_helpers - swept
+
+    assert_empty uncovered,
+                 "Group helpers with no `error:` expectation, so nothing says what the " \
+                 "explicit error does there: #{uncovered.sort.inspect}. Add each to " \
+                 "MARKS_CONTROL, MESSAGE_ONLY or NO_MESSAGE."
+  end
+
+  def test_explicit_error_reaches_message_aria_and_control_class
+    failures = MARKS_CONTROL.filter_map do |name, (render, error_class)|
+      html = render.call(builder, { error: MESSAGE })
+      problems = [
+        (:message unless error_paragraphs(html) == [ MESSAGE ]),
+        (:aria_invalid if invalid_elements(html).empty?),
+        (:aria_describedby unless described_by_error?(html)),
+        ("class #{error_class}" unless class_on_some_element?(html, error_class))
+      ].compact
+      "#{name}: missing #{problems.inspect}" if problems.any?
+    end
+
+    assert_empty failures, "`error:` did not fully dress the control:\n#{failures.join("\n")}"
+  end
+
+  def test_explicit_error_renders_the_message_where_only_the_message_fits
+    failures = MESSAGE_ONLY.filter_map do |name, render|
+      html = render.call(builder, { error: MESSAGE })
+      "#{name}: #{error_paragraphs(html).inspect}" unless error_paragraphs(html) == [ MESSAGE ]
+    end
+
+    assert_empty failures, "`error:` message paragraph missing:\n#{failures.join("\n")}"
+  end
+
+  def test_explicit_error_stays_silent_where_no_messages_render
+    failures = NO_MESSAGE.filter_map do |name, render|
+      html = render.call(builder, { error: MESSAGE })
+      "#{name}" if error_paragraphs(html).any?
+    end
+
+    assert_empty failures,
+                 "Families declared message-less rendered one — move them out of " \
+                 "NO_MESSAGE:\n#{failures.join("\n")}"
+  end
+
+  # D723-2: union, explicit first — the mirror of the error+help decision.
+  def test_explicit_error_joins_the_models_errors_explicit_first
+    resource.errors.add(:name, "is invalid")
+
+    html = builder.text_group(:name, error: MESSAGE)
+
+    assert_equal [ "#{MESSAGE}, Name is invalid" ], error_paragraphs(html)
+  end
+
+  def test_an_array_of_errors_renders_joined_in_order
+    html = builder.text_group(:name, error: [ "Too short", "Too plain" ])
+
+    assert_equal [ "Too short, Too plain" ], error_paragraphs(html)
+  end
+
+  # nil, false and "" all mean "nothing to add", so a call site can pass the
+  # raw return of `rodauth.field_error(param)` without guarding it first.
+  def test_blank_errors_render_nothing
+    [ nil, false, "" ].each do |blank|
+      html = builder.text_group(:name, error: blank)
+
+      assert_empty error_paragraphs(html), "error: #{blank.inspect} rendered a paragraph"
+      assert_empty invalid_elements(html), "error: #{blank.inspect} marked the control invalid"
+    end
+  end
+
+  # The consumer the option exists for: `form_with url:` and no object. The
+  # ids come out bare (`login_error`), and the whole dress still applies.
+  def test_a_builder_without_an_object_carries_the_explicit_error
+    html = objectless_builder.text_group(:login, error: "Bad login")
+
+    assert_equal [ "Bad login" ], error_paragraphs(html)
+    assert_html html, "input.input-error[aria-invalid='true'][aria-describedby='login_error']"
+    assert_html html, "p.text-error#login_error"
+  end
+
+  def test_a_builder_without_an_object_and_without_an_error_stays_clean
+    html = objectless_builder.text_group(:login, error: nil)
+
+    assert_empty error_paragraphs(html)
+    assert_empty invalid_elements(html)
+  end
+
+  # The two-hash families accept the option on either side: `group_options`
+  # reads the wrapper keys out of both, primary hash first.
+  def test_select_families_accept_error_inside_html_too
+    html = builder.select_group(:status, [], html: { error: MESSAGE })
+
+    assert_equal [ MESSAGE ], error_paragraphs(html)
+    assert_html html, "select.select-error[aria-invalid='true']"
+  end
+
+  private
+
+  def error_paragraphs(html)
+    Nokogiri::HTML5.fragment(html.to_s).css("p.text-error").map(&:text)
+  end
+
+  def invalid_elements(html)
+    Nokogiri::HTML5.fragment(html.to_s).css("[aria-invalid='true']").map(&:name)
+  end
+
+  def described_by_error?(html)
+    Nokogiri::HTML5.fragment(html.to_s).css("[aria-describedby]").any? do |node|
+      node["aria-describedby"].split.any? { |id| id.end_with?("_error") }
+    end
+  end
+
+  def class_on_some_element?(html, error_class)
+    Nokogiri::HTML5.fragment(html.to_s).css("[class~='#{error_class}']").any?
+  end
+
+  def live_group_helpers
+    deprecated = Bali::FormBuilder::DeprecatedNames.instance_methods.map(&:to_s)
+
+    Bali::FormBuilder.instance_methods.map(&:to_s).grep(/_group\z/) - deprecated
+  end
+
+  def objectless_builder
+    @objectless_builder ||= Bali::FormBuilder.new(nil, nil, vc_test_controller.view_context, {})
+  end
+
+  def builder
+    @builder ||= Bali::FormBuilder.new("movie", resource, vc_test_controller.view_context, {})
+  end
+end

--- a/test/bali/form_builder/options_contract_test.rb
+++ b/test/bali/form_builder/options_contract_test.rb
@@ -12,7 +12,8 @@ require "test_helper"
 class BaliFormBuilderOptionsContractTest < FormBuilderTestCase
   # One value per reserved key, so a leak shows up as an attribute in the markup.
   RESERVED_VALUES = {
-    label: "Leaked label", help: "Leaked help", control_class: "leaked-control",
+    label: "Leaked label", help: "Leaked help", error: "Leaked error",
+    control_class: "leaked-control",
     control_data: { leaked: "control" }, addon_class: "leaked-addon",
     field_class: "leaked-field", field_data: { leaked: "field" },
     control_id: "leaked-control-id",

--- a/test/bali/form_builder/size_option_test.rb
+++ b/test/bali/form_builder/size_option_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `size:` is the one option with two legitimate meanings on a form control
+# (#723, D723-3): daisyUI's density variant and the HTML attribute of the same
+# name — width in characters on an `<input>`, visible rows on a `<select>`.
+# The contract this file freezes:
+#
+#   - a Symbol out of the family's map is the variant: the class joins the
+#     control's base classes and the attribute is NOT emitted;
+#   - an Integer — or a String, which is what `size: "4"` always meant — keeps
+#     meaning the attribute and passes through untouched;
+#   - a Symbol the map does not know raises, instead of leaking `size="tiny"`
+#     into the markup. Same contract ButtonTaxonomy enforces for the submit
+#     button, which is the family that already had `size:` before this PR.
+#
+# This is the foundation: the text-input families resolve through
+# `input_base_class`, and the per-family maps (`select-*`, `textarea-*`,
+# `file-input-*`, `range-*`) build on `size_variant` in the follow-up PR.
+class BaliFormBuilderSizeOptionTest < FormBuilderTestCase
+  INPUT_VARIANTS = {
+    xs: "input-xs", sm: "input-sm", md: "input-md", lg: "input-lg", xl: "input-xl"
+  }.freeze
+
+  def test_a_symbol_is_the_daisyui_variant_and_never_the_attribute
+    INPUT_VARIANTS.each do |symbol, css_class|
+      html = builder.text_field(:name, size: symbol)
+
+      assert_html html, "input.#{css_class}"
+      refute_html html, "input[size]"
+    end
+  end
+
+  def test_the_variant_travels_through_the_group_too
+    html = builder.text_group(:name, size: :sm)
+
+    assert_html html, "fieldset input.input-sm"
+    refute_html html, "input[size]"
+  end
+
+  def test_an_integer_keeps_meaning_the_html_attribute
+    html = builder.text_field(:name, size: 4)
+
+    assert_html html, "input[size='4']"
+    refute_html html, "input[class*='input-4']"
+    INPUT_VARIANTS.each_value { |css_class| refute_html html, "input.#{css_class}" }
+  end
+
+  # The subtle case out of the #723 analysis: a host passing the attribute as a
+  # String must not change meaning when the Symbol variant exists.
+  def test_a_string_keeps_meaning_the_html_attribute
+    html = builder.text_field(:name, size: "4")
+
+    assert_html html, "input[size='4']"
+  end
+
+  def test_an_unknown_symbol_raises_instead_of_leaking_into_the_markup
+    error = assert_raises(ArgumentError) { builder.text_field(:name, size: :tiny) }
+
+    assert_includes error.message, ":tiny"
+    assert_includes error.message, ":xs"
+  end
+
+  def test_the_variant_joins_the_addon_base_class
+    html = builder.currency_field(:budget, size: :xl)
+
+    assert_html html, ".join input.join-item.input-xl"
+    refute_html html, "input[size]"
+  end
+
+  # D723-3 includes the submit pair. It resolves through ButtonTaxonomy, which
+  # already discriminates and raises on unknowns — asserted here so the two
+  # mechanisms cannot drift apart.
+  def test_submit_field_and_group_map_the_same_symbols_to_btn_classes
+    assert_html builder.submit_field("Save", size: :sm), "button.btn.btn-sm"
+    assert_html builder.submit_group("Save", size: :sm), "button.btn.btn-sm"
+    assert_raises(ArgumentError) { builder.submit_field("Save", size: :tiny) }
+  end
+
+  private
+
+  def builder
+    @builder ||= Bali::FormBuilder.new("movie", resource, vc_test_controller.view_context, {})
+  end
+end


### PR DESCRIPTION
Primero de la serie A-E de #723: la fundación que toca las firmas compartidas de `html_utils` (el cuarteto `errors?`/`full_errors`/`error_message`/`field_class_name`, usado por las ~34 familias) para que los PRs B (size: por familia) y D (char_counter) se rebasen encima sin volver a tocarlas.

## `error:` externo por campo (D723-1, D723-2)

- Toda familia acepta `error:` — String, Array, o nil/false ("no hay nada que decir"), así que `error: rodauth.field_error(param)` se pasa sin guard.
- Viaja por el mismo plumbing que los errores del modelo: párrafo `.text-error`, par `aria-invalid`/`aria-describedby` y la clase `*-error` del control. Con errores del modelo presentes se **unen, el explícito primero** — espejo de la decisión error+help.
- Funciona sin objeto (`form_with url:` — el caso de las 25 vistas rodauth de identity), con ids bare (`login_error`).
- En las familias de dos hashes (`select_*`, `slim_select_*`, `time_zone_select_*`, `radio_*`) es opción de grupo: top-level o dentro de `html:`, ambas llegan.
- `:error` entra a `WRAPPER_OPTIONS`, así que la extracción única lo quita del HTML (probado en el sweep de `options_contract_test`).

## Fundación de `size:` (D723-3)

- **Symbol** = variante daisyUI (`:xs`/`:sm`/`:md`/`:lg`/`:xl`): la clase `input-*` se resuelve en el punto único (`input_base_class`/`size_variant`) y el atributo NO se emite.
- **Integer o String** = el atributo HTML `size` de siempre, pasa intacto (`size: "4"` no cambia de significado).
- Symbol desconocido levanta `ArgumentError` en vez de filtrar `size="tiny"` al markup — el mismo contrato que `ButtonTaxonomy` ya imponía en `submit_field`/`submit_group` (`btn-sm`), ahora asertado para ambos mecanismos.
- Los mapas por familia (`select-*`, `textarea-*`, `file-input-*`, `range-*`) vienen en el PR B reutilizando `size_variant`.

## Tests

- `external_error_option_test.rb` (calca de `required_option_test.rb`): cada `*_group` declara su resultado por nombre — vestido completo (24 familias), solo mensaje (4), o silencio (5, las que nunca renderizaron mensajes de campo) — y el barrido de cobertura falla si aparece una familia sin pronunciarse.
- `size_option_test.rb`: congela la discriminación Symbol/Integer/String, el raise del Symbol desconocido, el camino de addons y el par submit.
- Suite completa: **3987 runs, 0 failures, 0 errors**. Rubocop limpio. Sin JS tocado (no aplica Cypress).
- Verificado en browser (Lookbook): previews nuevos `bali/form/text/with_external_error` (forma rodauth sin modelo) y `bali/form/text/sizes` (escalera de densidades + atributo).

## Docs

- `docs/guides/form-builder.md`: sección "External Errors (`error:`)" (reemplaza el bloque de HTML crudo de "Manual Error Display") y "Density (`size:`)" en Common Options.
- CHANGELOG bajo [Unreleased].

Refs #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
