### PR TITLE
Tema afal canónico en la gema + borrador afal-dark + fix del glob @source (#718 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Bali::Gantt::Colors` — the exact `color-mix`/oklch formulas of the island's `ganttColors.js` (verbatim-asserted in tests) so both renderers are visually identical; default status map plus support for host status catalogs.
   - `Bali::Gantt::Component` `mode: :static` — sticky two-tier header, collapsible `<details>` groups (with their own rollup bars), today line, grid, `color_by: :status/:none`, zoom by links on a namespaced `gantt_zoom` param, `group_label:`, an announced `limit:` cap (never silent) and a "No dates" section. This closes the `color_by:` promise made to #667. `mode: :interactive` is part of the signature already and raises with a clear message until phase 3.
   - Structural `--gantt-*` tokens in `@layer components`, `bali_view.gantt.*` locales (en/es), Lookbook previews, and a full dummy reference: `/admin/projects/:id?view=timeline` renders the timeline from seeded schedule data through `ProjectGantt`, a host-side reference implementation of the contract.
+- **The AFAL brand theme ships in the gem: `css/themes/afal.css`** (#718). Canonical copy
+  of the `[data-theme="afal"]` block that gobierno-corporativo, afal-apps, identity and
+  opina carried byte-identically in their own CSS — same plain unlayered `[data-theme]`
+  format as `costa-norte.css`, importable via
+  `@import "bali-view-components/css/themes/afal.css"` with no `package.json` change (the
+  `./css/themes/*.css` export wildcard already covered it). Hosts should delete their
+  local block in the same commit that adds the import — see the
+  [v3 → v3.1 migration guide](docs/guides/migration-v3-to-v31.md). Note for adopters:
+  from now on a color change in this file propagates to every host on its next bump;
+  such changes will always be announced as a visual change in this file.
+- **A `css/themes/afal-dark.css` DRAFT** (#718). All four AFAL hosts have long declared
+  `afal-dark` in their daisyUI plugin config without any definition existing anywhere;
+  this is the first actual design — derived from the light theme (same gray ramp
+  inverted, brand hues lifted one Tailwind step with `-950` content pairs, status colors
+  unchanged, every pair measured >= 4.5:1 WCAG AA). **Experimental**: no app activates it
+  and tokens may change before it is announced stable. Preview both themes in Lookbook
+  under *Theme Sampler* (new `afal` and `afal_dark` previews with their own layouts).
+- **Custom themes guide covers AFAL** (`docs/guides/custom-themes.md`): the adoption
+  path, the phantom `themes: afal --default, afal-dark` plugin note, and the
+  `@custom-variant dark` extension `afal-dark` needs for `dark:` utilities to fire.
+- **Theme regression tests**: every file in `app/assets/stylesheets/bali/themes/` is
+  asserted complete (the 26 required variables plus `color-scheme` and the
+  `[data-theme]` selector matching its filename), and the ThemeSampler previews get a
+  request test so a broken theme preview fails the build.
+
+### Fixed
+
+- **`docs/guides/installation.md` documented an incomplete `@source` glob** (#718): it
+  scanned `*.{rb,erb}` but not `.js`, and some Tailwind classes are written from
+  JavaScript (`modal/index.js` swaps a drawer's submit button for
+  `loading loading-spinner loading-sm`), so the spinner rendered unstyled in apps that
+  copied the documented glob. The canonical glob is now `*.{rb,erb,js}`, and the guide
+  also documents the optional vendor/bundle glob that only matches on CI with a vendored
+  bundle (and why a non-matching `@source` is harmless).
 
 ## [v3.1.0.beta.1] - 2026-08-05
 

--- a/app/assets/stylesheets/bali/themes/afal-dark.css
+++ b/app/assets/stylesheets/bali/themes/afal-dark.css
@@ -1,0 +1,57 @@
+/*
+ * AFAL Dark Theme for DaisyUI 5 — DRAFT / EXPERIMENTAL
+ *
+ * Dark variant derived from themes/afal.css (#718). The four host apps have
+ * declared `afal-dark` in their daisyUI plugin config without a definition
+ * existing anywhere — this file is the first actual design, pending visual
+ * approval in the ThemeSampler; expect token adjustments before it is
+ * announced as stable. No app activates it today.
+ *
+ * Derivation rules (from the light theme):
+ * - Surfaces invert down the same gray ramp: base-100/200/300 become
+ *   gray-900/800/700 and base-content becomes gray-200.
+ * - Brand hues are kept but lifted one Tailwind step (500 -> 400) so they
+ *   hold contrast on dark surfaces, paired with -950 content colors.
+ *   Every pair measures >= 4.5:1 (WCAG AA).
+ * - Status colors are identical to the light theme: those pastels already
+ *   sit on dark content colors that pass AA on both schemes.
+ * - Structural tokens (radius/size/border/depth/noise) are identical.
+ *
+ * Usage:
+ *   @import "bali-view-components/css/themes/afal-dark.css";
+ *   <html data-theme="afal-dark">
+ *
+ * If your app uses `dark:` utilities, extend your @custom-variant so they
+ * also fire under this theme (see docs/guides/custom-themes.md).
+ */
+[data-theme="afal-dark"] {
+  color-scheme: dark;
+  --color-primary: oklch(71.37% 0.1434 254.624);           /* #60A5FA (blue-400) */
+  --color-primary-content: oklch(28.23% 0.0874 267.935);   /* #172554 (blue-950) */
+  --color-secondary: oklch(70.90% 0.1592 293.541);         /* #A78BFA (violet-400) */
+  --color-secondary-content: oklch(28.27% 0.1351 291.089); /* #2E1065 (violet-950) */
+  --color-accent: oklch(83.69% 0.1644 84.429);             /* #FBBF24 (amber-400) */
+  --color-accent-content: oklch(27.91% 0.0742 45.635);     /* #451A03 (amber-950) */
+  --color-neutral: oklch(37.29% 0.0306 259.733);           /* #374151 (gray-700) */
+  --color-neutral-content: oklch(96.70% 0.0029 264.542);   /* #F3F4F6 (gray-100) */
+  --color-base-100: oklch(21.01% 0.0318 264.665);          /* #111827 (gray-900) */
+  --color-base-200: oklch(27.81% 0.0296 256.848);          /* #1F2937 (gray-800) */
+  --color-base-300: oklch(37.29% 0.0306 259.733);          /* #374151 (gray-700) */
+  --color-base-content: oklch(92.76% 0.0058 264.531);      /* #E5E7EB (gray-200) */
+  --color-info: oklch(75.85% 0.1374 231.617);              /* #3ABFF8 */
+  --color-info-content: oklch(27.15% 0.0553 231.935);      /* #002B3D */
+  --color-success: oklch(77.33% 0.1529 163.103);           /* #36D399 */
+  --color-success-content: oklch(28.38% 0.0623 161.934);   /* #003320 */
+  --color-warning: oklch(83.30% 0.1642 83.424);            /* #FBBD23 */
+  --color-warning-content: oklch(28.79% 0.0590 85.336);    /* #382800 */
+  --color-error: oklch(71.22% 0.1649 22.151);              /* #F87272 */
+  --color-error-content: oklch(24.99% 0.1025 29.234);      /* #470000 */
+  --radius-selector: 0.5rem;
+  --radius-field: 0.375rem;
+  --radius-box: 0.5rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}

--- a/app/assets/stylesheets/bali/themes/afal.css
+++ b/app/assets/stylesheets/bali/themes/afal.css
@@ -1,0 +1,44 @@
+/*
+ * AFAL Theme for DaisyUI 5
+ *
+ * Light variant. Canonical copy of the [data-theme="afal"] block that
+ * gobierno-corporativo, afal-apps, identity and opina carried byte-identically
+ * in their own CSS (#718) — the hex comments trace every value back to the
+ * original Tailwind palette. Delete the local copy when importing this file.
+ * Brand: Grupo AFAL
+ *
+ * Usage:
+ *   @import "bali-view-components/css/themes/afal.css";
+ *   <html data-theme="afal">
+ */
+[data-theme="afal"] {
+  color-scheme: light;
+  --color-primary: oklch(62.31% 0.1880 259.815);         /* #3B82F6 */
+  --color-primary-content: oklch(100% 0 0);               /* #FFFFFF */
+  --color-secondary: oklch(60.56% 0.2189 292.717);       /* #8B5CF6 */
+  --color-secondary-content: oklch(100% 0 0);             /* #FFFFFF */
+  --color-accent: oklch(76.86% 0.1647 70.080);           /* #F59E0B */
+  --color-accent-content: oklch(0% 0 0);                  /* #000000 */
+  --color-neutral: oklch(27.81% 0.0296 256.848);         /* #1F2937 */
+  --color-neutral-content: oklch(100% 0 0);               /* #FFFFFF */
+  --color-base-100: oklch(100% 0 0);                      /* #FFFFFF */
+  --color-base-200: oklch(96.70% 0.0029 264.542);        /* #F3F4F6 */
+  --color-base-300: oklch(92.76% 0.0058 264.531);        /* #E5E7EB */
+  --color-base-content: oklch(27.81% 0.0296 256.848);    /* #1F2937 */
+  --color-info: oklch(75.85% 0.1374 231.617);            /* #3ABFF8 */
+  --color-info-content: oklch(27.15% 0.0553 231.935);    /* #002B3D */
+  --color-success: oklch(77.33% 0.1529 163.103);         /* #36D399 */
+  --color-success-content: oklch(28.38% 0.0623 161.934); /* #003320 */
+  --color-warning: oklch(83.30% 0.1642 83.424);          /* #FBBD23 */
+  --color-warning-content: oklch(28.79% 0.0590 85.336);  /* #382800 */
+  --color-error: oklch(71.22% 0.1649 22.151);            /* #F87272 */
+  --color-error-content: oklch(24.99% 0.1025 29.234);    /* #470000 */
+  --radius-selector: 0.5rem;
+  --radius-field: 0.375rem;
+  --radius-box: 0.5rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}

--- a/app/components/bali/theme_sampler/afal/preview.rb
+++ b/app/components/bali/theme_sampler/afal/preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Bali
+  module ThemeSampler
+    module Afal
+      # Previews Bali components under the AFAL brand theme shipped with the
+      # gem (css/themes/afal.css). One preview class per theme because the
+      # layout — where `data-theme` lands on <html> — is class-level in
+      # Lookbook: there is no per-example layout.
+      class Preview < ApplicationViewComponentPreview
+        layout "lookbook_afal"
+
+        # @label AFAL Theme
+        # Buttons, cards, alerts, badges and form inputs rendered under the
+        # AFAL brand theme (light).
+        def default
+          render_with_template(locals: { model: Movie.new })
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/theme_sampler/afal/previews/default.html.erb
+++ b/app/components/bali/theme_sampler/afal/previews/default.html.erb
@@ -1,0 +1,156 @@
+<div class="space-y-8">
+  <%# ── Color Palette ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Color Palette</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+      <% %w[primary secondary accent neutral info success warning error].each do |color| %>
+        <div>
+          <div class="bg-<%= color %> text-<%= color %>-content rounded-lg p-4 text-center text-sm font-medium">
+            <%= color %>
+          </div>
+        </div>
+      <% end %>
+      <% %w[base-100 base-200 base-300].each do |base| %>
+        <div>
+          <div class="bg-<%= base %> border border-base-300 text-base-content rounded-lg p-4 text-center text-sm font-medium">
+            <%= base %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <%# ── Buttons ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Buttons</h2>
+    <div class="flex flex-wrap gap-2">
+      <%= render Bali::Button::Component.new(name: 'Primary', color: :primary) %>
+      <%= render Bali::Button::Component.new(name: 'Secondary', color: :secondary) %>
+      <%= render Bali::Button::Component.new(name: 'Accent', color: :accent) %>
+      <%= render Bali::Button::Component.new(name: 'Neutral', variant: :neutral) %>
+      <%= render Bali::Button::Component.new(name: 'Ghost', variant: :ghost) %>
+      <%= render Bali::Button::Component.new(name: 'Link', variant: :link) %>
+    </div>
+    <div class="flex flex-wrap gap-2 mt-3">
+      <%= render Bali::Button::Component.new(name: 'Info', variant: :info) %>
+      <%= render Bali::Button::Component.new(name: 'Success', variant: :success) %>
+      <%= render Bali::Button::Component.new(name: 'Warning', variant: :warning) %>
+      <%= render Bali::Button::Component.new(name: 'Error', variant: :error) %>
+    </div>
+    <div class="flex flex-wrap gap-2 mt-3">
+      <%= render Bali::Button::Component.new(name: 'Small', variant: :primary, size: :sm) %>
+      <%= render Bali::Button::Component.new(name: 'Medium', variant: :primary, size: :md) %>
+      <%= render Bali::Button::Component.new(name: 'Large', variant: :primary, size: :lg) %>
+      <%= render Bali::Button::Component.new(name: 'Disabled', variant: :primary, disabled: true) %>
+      <%= render Bali::Button::Component.new(name: 'Loading', variant: :primary, loading: true) %>
+    </div>
+  </section>
+
+  <%# ── Badges / Tags ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Tags / Badges</h2>
+    <div class="flex flex-wrap gap-2">
+      <%= render Bali::Tag::Component.new(text: 'Primary', color: :primary) %>
+      <%= render Bali::Tag::Component.new(text: 'Secondary', color: :secondary) %>
+      <%= render Bali::Tag::Component.new(text: 'Accent', color: :accent) %>
+      <%= render Bali::Tag::Component.new(text: 'Info', color: :info) %>
+      <%= render Bali::Tag::Component.new(text: 'Success', color: :success) %>
+      <%= render Bali::Tag::Component.new(text: 'Warning', color: :warning) %>
+      <%= render Bali::Tag::Component.new(text: 'Error', color: :error) %>
+    </div>
+  </section>
+
+  <%# ── Alerts ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Alerts</h2>
+    <div class="space-y-2">
+      <%= render(Bali::Alert::Component.new(color: :info)) { 'This is an informational message.' } %>
+      <%= render(Bali::Alert::Component.new(color: :success)) { 'Operation completed successfully.' } %>
+      <%= render(Bali::Alert::Component.new(color: :warning)) { 'Please review before continuing.' } %>
+      <%= render(Bali::Alert::Component.new(color: :error)) { 'Something went wrong. Please try again.' } %>
+    </div>
+  </section>
+
+  <%# ── Card ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Card</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <%= render Bali::Card::Component.new do |card| %>
+        <h3 class="card-title">Board Meeting Q3</h3>
+        <p>Agenda approved. Minutes pending signature from two committee members.</p>
+        <div class="card-actions justify-end">
+          <%= render Bali::Button::Component.new(name: 'Review', variant: :primary, size: :sm) %>
+          <%= render Bali::Button::Component.new(name: 'Details', variant: :ghost, size: :sm) %>
+        </div>
+      <% end %>
+
+      <%= render Bali::Card::Component.new do |card| %>
+        <h3 class="card-title">Compliance Status</h3>
+        <div class="flex gap-2 flex-wrap">
+          <%= render Bali::Tag::Component.new(text: '18 Signed', color: :success) %>
+          <%= render Bali::Tag::Component.new(text: '4 Pending', color: :warning) %>
+          <%= render Bali::Tag::Component.new(text: '2 Overdue', color: :error) %>
+        </div>
+        <div class="mt-2">
+          <%= render Bali::Progress::Component.new(value: 75, color: :primary) %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <%# ── Navbar (primary) ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Navbar (primary)</h2>
+    <%= render Bali::Navbar::Component.new(color: :primary, sticky: false, fullscreen: true) do |nav| %>
+      <% nav.with_brand do %>
+        <%= render Bali::Link::Component.new(name: 'Grupo AFAL', href: '#', variant: :ghost, class: 'text-xl') %>
+      <% end %>
+      <% nav.with_menu do |menu| %>
+        <% menu.with_start_item(name: 'Dashboard', href: '#') %>
+        <% menu.with_start_item(name: 'Documents', href: '#') %>
+        <% menu.with_start_item(name: 'Committees', href: '#') %>
+        <%= menu.with_end_item(tag_name: :div) do %>
+          <%= render Bali::Button::Component.new(name: 'New Document', variant: :secondary, size: :sm) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </section>
+
+  <%# ── Navbar (neutral) ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Navbar (neutral)</h2>
+    <%= render Bali::Navbar::Component.new(color: :neutral, sticky: false, fullscreen: true) do |nav| %>
+      <% nav.with_brand do %>
+        <%= render Bali::Link::Component.new(name: 'Grupo AFAL', href: '#', variant: :ghost, class: 'text-xl') %>
+      <% end %>
+      <% nav.with_menu do |menu| %>
+        <% menu.with_start_item(name: 'Dashboard', href: '#') %>
+        <% menu.with_start_item(name: 'Documents', href: '#') %>
+        <% menu.with_start_item(name: 'Committees', href: '#') %>
+      <% end %>
+    <% end %>
+  </section>
+
+  <%# ── Form Inputs ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Form Inputs</h2>
+    <%= form_with(model: model, url: '/lookbook', builder: Bali::FormBuilder) do |form| %>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl">
+        <%= form.text_group :name, placeholder: 'Enter name' %>
+        <%= form.select_group :genre, [['Action', 'action'], ['Drama', 'drama'], ['Comedy', 'comedy']] %>
+        <%= form.date_group :created_at %>
+        <%= form.boolean_group :indie %>
+      </div>
+    <% end %>
+  </section>
+
+  <%# ── Progress Bars ── %>
+  <section>
+    <h2 class="text-xl font-bold mb-4">Progress</h2>
+    <div class="space-y-2 max-w-md">
+      <%= render Bali::Progress::Component.new(value: 85, color: :primary) %>
+      <%= render Bali::Progress::Component.new(value: 60, color: :secondary) %>
+      <%= render Bali::Progress::Component.new(value: 40, color: :accent) %>
+    </div>
+  </section>
+</div>

--- a/app/components/bali/theme_sampler/afal_dark/preview.rb
+++ b/app/components/bali/theme_sampler/afal_dark/preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Bali
+  module ThemeSampler
+    module AfalDark
+      # Previews Bali components under the DRAFT afal-dark theme
+      # (css/themes/afal-dark.css). Same sampler template as the AFAL light
+      # preview, different layout — flip between the two to compare the
+      # palettes on identical content. This is the visual gate for the draft:
+      # the theme is experimental until it is approved here.
+      class Preview < ApplicationViewComponentPreview
+        layout "lookbook_afal_dark"
+
+        # @label AFAL Dark Theme (draft)
+        # The draft dark variant rendered over the same content as the AFAL
+        # light preview.
+        def default
+          render_with_template(
+            template: "bali/theme_sampler/afal/previews/default",
+            locals: { model: Movie.new }
+          )
+        end
+      end
+    end
+  end
+end

--- a/docs/guides/custom-themes.md
+++ b/docs/guides/custom-themes.md
@@ -6,6 +6,8 @@ Bali ships optional DaisyUI themes that you can import alongside the default `li
 
 | Theme | File | Description |
 |-------|------|-------------|
+| `afal` | `css/themes/afal.css` | Grupo AFAL brand - light variant with blue/violet/amber palette |
+| `afal-dark` | `css/themes/afal-dark.css` | **Draft / experimental** - dark variant derived from `afal`, pending visual approval |
 | `costa-norte` | `css/themes/costa-norte.css` | Costa Norte brand - light variant with teal/gold palette |
 
 ## Installation
@@ -39,6 +41,44 @@ Or apply it to a specific section:
   <!-- This section uses Costa Norte colors -->
 </div>
 ```
+
+## The AFAL Theme
+
+`afal` is the canonical copy of the `[data-theme="afal"]` block that gobierno-corporativo,
+afal-apps, identity and opina used to carry byte-identically in their own CSS. If your app
+still has a local copy, delete it **in the same commit** that adds the import — while both
+exist, whichever appears later in the compiled CSS wins, silently.
+
+```css
+@import "bali-view-components/css/themes/afal.css";
+@import "bali-view-components/css/themes/afal-dark.css"; /* optional, draft */
+```
+
+```html
+<html data-theme="afal">
+```
+
+Listing `afal` in your `@plugin "daisyui" { themes: ... }` block is **not** what makes the
+theme work — daisyUI does not know these names, and listing an unknown name registers
+nothing. The theming comes entirely from the unlayered `[data-theme="afal"]` block, which
+wins over daisyUI's own themes by layer order. You can drop `afal` and `afal-dark` from the
+plugin's `themes:` list when you adopt the imports.
+
+### `afal-dark` (draft) and the `dark:` variant
+
+`afal-dark` is an experimental first design — no app activates it yet, and its tokens may
+change before it is announced as stable. Preview it in Lookbook under
+*Theme Sampler → Afal Dark*.
+
+If your app defines a `@custom-variant dark` so `dark:` utilities follow the theme (all
+AFAL hosts do), `dark:` will **not** fire under `afal-dark` unless you extend the variant:
+
+```css
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *, [data-theme=afal-dark], [data-theme=afal-dark] *));
+```
+
+Without this, components styled with `dark:` utilities keep their light-theme styling even
+though the daisyUI palette around them has gone dark.
 
 ## Creating Your Own Theme
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -69,12 +69,27 @@ Create `app/assets/tailwind/application.css` (or similar):
 /* =============================================
    Bali ViewComponents - Tailwind class scanning
    =============================================
-   IMPORTANT: Tailwind v4 needs to scan Bali's Ruby and ERB files
+   IMPORTANT: Tailwind v4 needs to scan Bali's Ruby, ERB *and JS* files
    to detect utility classes used in components. The gem installs
    to a system directory outside your project, but the npm package
    mirrors all source files in node_modules.
+
+   `.js` is not optional: some controllers write class names from
+   JavaScript (e.g. `modal/index.js` swaps the submit button for
+   `loading loading-spinner loading-sm` while a drawer form is in
+   flight). Without scanning `.js`, those classes never reach your
+   compiled CSS and the spinner renders unstyled.
 */
-@source "../../../node_modules/bali-view-components/app/**/*.{rb,erb}";
+@source "../../../node_modules/bali-view-components/app/**/*.{rb,erb,js}";
+
+/* Optional - CI with a vendored bundle only. `ruby/setup-ruby` with
+   `bundler-cache: true` vendors gems into vendor/bundle, so this glob
+   scans the *gem's* copy of the same tree. It does not match in local
+   (rbenv/rvm) or Docker (BUNDLE_PATH) setups, and that is fine: a
+   @source with no matches adds no classes and raises no error. With
+   both globs, CI scans gem and npm copies alike, so if the two ever
+   skew, the union of classes keeps the build complete. */
+@source "../../../vendor/bundle/ruby/*/bundler/gems/bali-view-components-*/**/*.{erb,rb}";
 
 /* =============================================
    Bali CSS Import
@@ -101,7 +116,7 @@ Create `app/assets/tailwind/application.css` (or similar):
 }
 ```
 
-> **Note**: The `@source` directive is required because Bali components define Tailwind classes in Ruby files (e.g., `'flex gap-2 btn-primary'`). Without it, Tailwind won't detect these classes and components will appear unstyled.
+> **Note**: The `@source` directive is required because Bali components define Tailwind classes in Ruby files (e.g., `'flex gap-2 btn-primary'`) and in JavaScript. Without it, Tailwind won't detect these classes and components will appear unstyled.
 
 ### Overriding Bali styles
 
@@ -327,7 +342,10 @@ Bali components define Tailwind classes in Ruby files (e.g., `'flex gap-2 btn-pr
 **Fix:** Ensure your `@source` directive scans Bali's source files in node_modules:
 
 ```css
-/* Correct - scans all Ruby and ERB files */
+/* Correct - scans Ruby, ERB and JS files */
+@source "../../../node_modules/bali-view-components/app/**/*.{rb,erb,js}";
+
+/* Wrong - misses JS-written classes (the drawer submit spinner, for one) */
 @source "../../../node_modules/bali-view-components/app/**/*.{rb,erb}";
 
 /* Wrong - only scans ERB, misses Ruby files where most classes are defined */
@@ -340,7 +358,7 @@ Bali components define Tailwind classes in Ruby files (e.g., `'flex gap-2 btn-pr
 
 The Tailwind build isn't scanning Bali component files.
 
-**Fix:** Ensure `@source` paths in your CSS point to `node_modules/bali-view-components/app/**/*.{rb,erb}`.
+**Fix:** Ensure `@source` paths in your CSS point to `node_modules/bali-view-components/app/**/*.{rb,erb,js}`.
 
 ### "Unknown Stimulus controller"
 

--- a/docs/guides/migration-v3-to-v31.md
+++ b/docs/guides/migration-v3-to-v31.md
@@ -74,3 +74,49 @@ instead: the name keeps working, the glyph changes. The full before/after table 
 migrating from v1/v2 as well.
 
 *Lands with the #902 PR; details land with it.*
+
+---
+
+## Adoption notes (additive — not part of the five)
+
+Everything below is opt-in housekeeping: nothing renders differently until you act.
+
+### Adopt the gem-shipped AFAL theme (#718)
+
+v3.1 publishes the AFAL brand theme in the gem — `css/themes/afal.css`, plus a **draft**
+`afal-dark` — so the `[data-theme="afal"]` block your app carries by hand can finally be
+deleted.
+
+**Every app, in the SAME commit** (while both copies exist, whichever comes later in the
+compiled CSS silently wins):
+
+1. Add the import to your Tailwind entry point:
+
+   ```css
+   @import "bali-view-components/css/themes/afal.css";
+   ```
+
+2. Delete your local copy:
+   - **gobierno-corporativo, afal-apps, identity, opina**: delete the
+     `[data-theme="afal"]` block from `app/assets/tailwind/application.css`. The gem file
+     is byte-identical to it, so nothing changes visually.
+   - **centinela-web**: delete `app/assets/tailwind/themes/afal.css` (and its import).
+     **Expect a visible delta** — centinela's copy came from an independent OKLCH
+     conversion of the same hex values, so its secondary (a darker, differently-hued
+     violet), accent, neutral and the five status pairs all shift to the canonical
+     values. Screenshot before/after in the adoption PR.
+
+3. Optionally clean the phantom declaration: `afal --default, afal-dark` inside
+   `@plugin "daisyui" { themes: ... }` never registered anything (daisyUI does not know
+   those names — the unlayered `[data-theme]` block does all the work). Keep or drop it;
+   dropping it removes the implication that daisyUI defines these themes.
+
+`afal-dark` remains **draft/experimental**: no app activates it today, and its tokens may
+change before it is announced as stable. If you want to try it, see
+[Custom Themes](custom-themes.md) — including the `@custom-variant dark` extension needed
+for `dark:` utilities to fire under it.
+
+While migrating, also fix your `@source` glob if it scans only `{rb,erb}`: Bali writes
+some classes from JavaScript (the drawer submit spinner among them), so the canonical glob
+is `node_modules/bali-view-components/app/**/*.{rb,erb,js}` — see
+[Installation](installation.md).

--- a/spec/dummy/app/assets/tailwind/application.css
+++ b/spec/dummy/app/assets/tailwind/application.css
@@ -36,3 +36,5 @@
 
 /* Bali custom themes */
 @import "bali-view-components/css/themes/costa-norte.css";
+@import "bali-view-components/css/themes/afal.css";
+@import "bali-view-components/css/themes/afal-dark.css";

--- a/spec/dummy/app/views/layouts/lookbook_afal.html.erb
+++ b/spec/dummy/app/views/layouts/lookbook_afal.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html data-theme="afal">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", media: 'all' %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  </head>
+  <body class="p-4 bg-base-100">
+    <%= yield %>
+  </body>
+</html>

--- a/spec/dummy/app/views/layouts/lookbook_afal_dark.html.erb
+++ b/spec/dummy/app/views/layouts/lookbook_afal_dark.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html data-theme="afal-dark">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", media: 'all' %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  </head>
+  <body class="p-4 bg-base-100">
+    <%= yield %>
+  </body>
+</html>

--- a/test/bali/themes_test.rb
+++ b/test/bali/themes_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Un tema a medias no falla: la variable que falta la hereda del tema que quedó
+# antes en la cascada, y el bug se ve como "un color raro" meses después. Este
+# test lee cada archivo de app/assets/stylesheets/bali/themes/ y exige el set
+# completo de variables que documenta docs/guides/custom-themes.md, además de
+# `color-scheme` y de que el selector [data-theme] coincida con el nombre del
+# archivo (un typo ahí publica un tema inactivable).
+class BaliThemesTest < ActiveSupport::TestCase
+  THEMES_DIR = Bali::Engine.root.join("app/assets/stylesheets/bali/themes")
+
+  REQUIRED_VARIABLES = %w[
+    --color-base-100 --color-base-200 --color-base-300 --color-base-content
+    --color-primary --color-primary-content
+    --color-secondary --color-secondary-content
+    --color-accent --color-accent-content
+    --color-neutral --color-neutral-content
+    --color-info --color-info-content
+    --color-success --color-success-content
+    --color-warning --color-warning-content
+    --color-error --color-error-content
+    --radius-selector --radius-field --radius-box
+    --size-selector --size-field
+    --border --depth --noise
+  ].freeze
+
+  def theme_files
+    Dir[THEMES_DIR.join("*.css").to_s].sort
+  end
+
+  def test_the_expected_themes_ship_with_the_gem
+    assert_equal(%w[afal-dark.css afal.css costa-norte.css],
+                 theme_files.map { |file| File.basename(file) })
+  end
+
+  def test_every_shipped_theme_is_complete
+    theme_files.each do |file|
+      css = File.read(file)
+      name = File.basename(file, ".css")
+
+      assert_match(/^\[data-theme="#{Regexp.escape(name)}"\]\s*\{/, css,
+                   "#{name}.css no define [data-theme=\"#{name}\"] al inicio de línea")
+      assert_match(/color-scheme:\s*(light|dark);/, css,
+                   "#{name}.css no declara color-scheme")
+
+      REQUIRED_VARIABLES.each do |variable|
+        assert_match(/#{Regexp.escape(variable)}:\s*[^;]+;/, css,
+                     "#{name}.css no define #{variable}")
+      end
+    end
+  end
+
+  # El bloque de afal.css es la copia canónica del que las apps llevaban a mano
+  # (#718): los valores de marca no cambian sin ser un cambio visual anunciado.
+  def test_the_afal_brand_values_stay_canonical
+    css = File.read(THEMES_DIR.join("afal.css"))
+
+    assert_includes(css, "--color-primary: oklch(62.31% 0.1880 259.815)")
+    assert_includes(css, "--color-secondary: oklch(60.56% 0.2189 292.717)")
+    assert_includes(css, "--color-accent: oklch(76.86% 0.1647 70.080)")
+    assert_includes(css, "--radius-field: 0.375rem")
+    assert_includes(css, "color-scheme: light")
+  end
+
+  def test_the_afal_dark_draft_declares_a_dark_scheme
+    css = File.read(THEMES_DIR.join("afal-dark.css"))
+
+    assert_includes(css, "color-scheme: dark")
+    assert_match(/DRAFT/, css, "afal-dark.css debe declararse borrador hasta su aprobación visual")
+  end
+end

--- a/test/requests/theme_sampler_previews_test.rb
+++ b/test/requests/theme_sampler_previews_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Los previews del ThemeSampler son la puerta de revisión visual de los temas
+# empaquetados (#718): cada tema renderiza el mismo muestrario bajo su propio
+# layout, que estampa data-theme en <html>. Nada más los ejercita — los tests
+# de componente no renderizan previews y Cypress no los visita — así que sin
+# esto un layout borrado o un preview roto deja la puerta 500eando en verde.
+class ThemeSamplerPreviewsTest < ActionDispatch::IntegrationTest
+  PREVIEWS = {
+    "/lookbook/preview/bali/theme_sampler/costa_norte" => "costa-norte",
+    "/lookbook/preview/bali/theme_sampler/afal/default" => "afal",
+    "/lookbook/preview/bali/theme_sampler/afal_dark/default" => "afal-dark"
+  }.freeze
+
+  def test_each_theme_preview_renders_under_its_theme
+    PREVIEWS.each do |path, theme|
+      get path
+      assert_response :ok, "#{path} no renderizó"
+      assert_select "html[data-theme=?]", theme
+      assert_select "section h2", { text: "Color Palette" },
+                    "#{path} renderizó sin el muestrario"
+    end
+  end
+end


### PR DESCRIPTION
Refs #718 (PR 1 del issue: la gema. Quedan fuera el chrome oscuro del SideMenu y los 5 PRs de adopción externos.)

## Qué trae

### `css/themes/afal.css` — el tema canónico (decisión 718-D1)
Copia del bloque `[data-theme="afal"]` que gc, afal-apps, identity y opina llevaban a mano. **Verificado byte-idéntico entre las cuatro antes de copiar** (md5 `f4da119f…` en las cuatro; el bloque de la gema da el mismo hash). Formato plain `[data-theme]` sin capa, patrón `costa-norte.css` — el theming real lo hace el bloque, no el plugin de daisyUI, y el wildcard `./css/themes/*.css` del `package.json` ya lo exporta sin tocar nada. Centinela migra sabiendo que su conversión OKLCH independiente cambia de matiz (aviso explícito en la guía de migración).

### `css/themes/afal-dark.css` — BORRADOR a revisión visual (decisión 718-D2)
`afal-dark` no existía en ningún repo: las cuatro apps lo declaran en el plugin desde hace un año sin definición. Este es el primer diseño real, **marcado draft/experimental en el header y en docs**, para que lo apruebes o recortes viéndolo en el ThemeSampler:

- Superficies: la misma rampa de grises invertida (base-100/200/300 → gray-900/800/700, base-content → gray-200).
- Marca: mismos hues subidos un paso Tailwind (500 → 400) con contenidos `-950`. **Todos los pares miden ≥ 4.5:1 (WCAG AA)**; conversiones hex→OKLCH validadas reproduciendo exactamente los 6 valores del bloque canónico.
- Estados: idénticos al light (los pasteles clásicos ya van sobre contenidos oscuros que pasan AA en ambos esquemas).
- Tokens estructurales: idénticos.

Si el borrador no convence, degradar a "solo afal.css" es quitar un archivo y dos previews — nadie lo activa hoy.

### Fix del glob `@source` sin `.js` (hallazgo del spec)
`installation.md` documentaba `*.{rb,erb}`: `modal/index.js` escribe `loading loading-spinner loading-sm` desde JS y el spinner de los drawers salía sin CSS en las apps que copiaban el glob documentado. Ahora el glob canónico es `*.{rb,erb,js}` y se documenta el bloque completo (npm obligatorio + `vendor/bundle` opcional solo-CI, prosa portada del comentario de afal-apps).

### Lookbook, docs y tests
- Previews `Theme Sampler → Afal / Afal Dark` con layouts propios que estampan `data-theme` en `<html>`. **Desviación del plan**: el spec pedía variantes en `Bali::ThemeSampler::Preview` con layout por variante, pero en Lookbook 2.3.14 el layout es class-level (`preview_entity.rb:167`) — una clase de preview por tema, misma plantilla compartida para comparar paletas sobre contenido idéntico.
- `custom-themes.md`: sección AFAL (declaración fantasma del plugin + el `@custom-variant dark` que afal-dark necesita para que `dark:` dispare).
- `migration-v3-to-v31.md`: notas de adopción aditivas (fuera del bloque de los cinco cambios anunciados), lista por app y regla "borra tu bloque local en el MISMO commit del import".
- Tests: `BaliThemesTest` (28 variables requeridas por cada tema de `themes/`, selector = nombre de archivo, valores de marca congelados) + request test de los tres previews del sampler.
- CHANGELOG bajo `[Unreleased]`, con el aviso de que a partir de ahora un cambio de color en la gema se propaga a todos los hosts y se anuncia como visual change.

## Verificación

- Minitest completo: **3975 runs, 0 failures** (incluye los 5 tests nuevos).
- Rubocop limpio en los archivos nuevos.
- Browser (puerto 3090): los tres previews del sampler responden 200 y se revisaron con screenshots — el light idéntico a las apps, el dark coherente en paleta, navbars, forms y progress.
- Cypress: no se tocó JS (solo CSS/ERB/Ruby de previews); no aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
