### PR TITLE
fix(icon): el mapping deja de sombrear 5 nombres Lucide vigentes (#902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Bali::Gantt::Component` `mode: :static` — sticky two-tier header, collapsible `<details>` groups (with their own rollup bars), today line, grid, `color_by: :status/:none`, zoom by links on a namespaced `gantt_zoom` param, `group_label:`, an announced `limit:` cap (never silent) and a "No dates" section. This closes the `color_by:` promise made to #667. `mode: :interactive` is part of the signature already and raises with a clear message until phase 3.
   - Structural `--gantt-*` tokens in `@layer components`, `bali_view.gantt.*` locales (en/es), Lookbook previews, and a full dummy reference: `/admin/projects/:id?view=timeline` renders the timeline from seeded schedule data through `ProjectGantt`, a host-side reference implementation of the contract.
 
+### Changed
+
+- **Five icon names stop being shadowed and now draw their real Lucide glyph** (#902). `trash`, `cog`, `expand`, `indent` and `outdent` were `LucideMapping` keys redirecting to a different drawing (`trash-2`, `settings`, `maximize`, `indent-increase`, `indent-decrease`), which made the glyph lucide.dev shows for those names unreachable — silently. The entries are removed; each name keeps resolving through the direct-Lucide step. Write the old target name to keep the previous drawing — the before/after table is in the [v3 → v3.1 migration guide](docs/guides/migration-v3-to-v31.md) (and, because it reaches v1/v2 hosts on their jump, in the [v2 → v3 guide](docs/guides/migration-v2-to-v3.md)). Measured across all pinned v3 hosts: zero call sites of the five. Related, in the same change:
+  - `check-circle => circle-check`, `edit => pencil` and `plus-circle => circle-plus` stay mapped as documented exceptions — their "honest" spellings are deprecated Lucide aliases (a legacy glyph, and a name whose real rename is `square-pen`), so removal would make drawings worse, not truer. The shadowing test freezes the surviving set and pins the removed names to the direct-Lucide step.
+  - The 60 identity entries (`"check" => "check"`, …) are gone — verified no-op, the direct-Lucide step resolves every one of them identically. "Did you mean" suggestions now draw from the full Lucide set instead of the mapping's keys, so `arrow_left` still suggests `arrow-left` (and any Lucide name typo gets suggestions, which it previously did not).
+  - `Bali::DeleteLink`'s default icon is now spelled `trash-2` internally — same drawing as always.
+
 ## [v3.1.0.beta.1] - 2026-08-05
 
 ### Added

--- a/app/components/bali/actions_dropdown/previews/default.html.erb
+++ b/app/components/bali/actions_dropdown/previews/default.html.erb
@@ -2,6 +2,6 @@
   <%= render Bali::ActionsDropdown::Component.new do |c|
     c.with_item(name: 'Edit', icon: 'edit', href: '#')
     c.with_item(name: 'Export', icon: 'file-export', href: '#')
-    c.with_item(name: 'Delete', icon: 'trash', href: '#', method: :delete)
+    c.with_item(name: 'Delete', icon: 'trash-2', href: '#', method: :delete)
   end %>
 </div>

--- a/app/components/bali/actions_dropdown/previews/popover.html.erb
+++ b/app/components/bali/actions_dropdown/previews/popover.html.erb
@@ -2,6 +2,6 @@
   <%= render Bali::ActionsDropdown::Component.new(popover: true) do |c|
     c.with_item(name: 'Edit', icon: 'edit', href: '#')
     c.with_item(name: 'Export', icon: 'file-export', href: '#')
-    c.with_item(name: 'Delete', icon: 'trash', href: '#', method: :delete)
+    c.with_item(name: 'Delete', icon: 'trash-2', href: '#', method: :delete)
   end %>
 </div>

--- a/app/components/bali/actions_dropdown/previews/with_custom_icon.html.erb
+++ b/app/components/bali/actions_dropdown/previews/with_custom_icon.html.erb
@@ -1,6 +1,6 @@
 <div class="flex justify-center items-center min-h-[200px] p-8">
   <%= render Bali::ActionsDropdown::Component.new(icon: 'more') do |c|
     c.with_item(name: 'Edit', icon: 'edit', href: '#')
-    c.with_item(name: 'Delete', icon: 'trash', href: '#', method: :delete)
+    c.with_item(name: 'Delete', icon: 'trash-2', href: '#', method: :delete)
   end %>
 </div>

--- a/app/components/bali/actions_dropdown/previews/with_custom_trigger.html.erb
+++ b/app/components/bali/actions_dropdown/previews/with_custom_trigger.html.erb
@@ -7,6 +7,6 @@
     c.with_trigger(variant: :outline, class: 'btn-sm') { 'Actions ▾' }
     c.with_item(name: 'Edit', icon: 'edit', href: '#')
     c.with_item(name: 'Export', icon: 'file-export', href: '#')
-    c.with_item(name: 'Delete', icon: 'trash', href: '#', method: :delete)
+    c.with_item(name: 'Delete', icon: 'trash-2', href: '#', method: :delete)
   end %>
 </div>

--- a/app/components/bali/card/preview.rb
+++ b/app/components/bali/card/preview.rb
@@ -60,7 +60,7 @@ module Bali
       # Add an icon to draw attention to the card's purpose.
       def header_with_icon
         render Card::Component.new(class: 'w-96') do |c|
-          c.with_header(title: 'Settings', subtitle: 'Manage your preferences', icon: 'cog')
+          c.with_header(title: 'Settings', subtitle: 'Manage your preferences', icon: 'settings')
 
           tag.p('Icons help users quickly identify the card\'s purpose.')
         end

--- a/app/components/bali/data_table/previews/with_grid_mode.html.erb
+++ b/app/components/bali/data_table/previews/with_grid_mode.html.erb
@@ -43,7 +43,7 @@
             <% end %>
 
             <% card.with_action(href: '#', class: 'btn-ghost btn-sm') do %>
-              <%= render Bali::Icon::Component.new('expand', class: 'w-4 h-4') %>
+              <%= render Bali::Icon::Component.new('maximize', class: 'w-4 h-4') %>
             <% end %>
             <% card.with_action(href: '#', class: 'btn-ghost btn-sm') do %>
               <%= render Bali::Icon::Component.new('edit', class: 'w-4 h-4') %>

--- a/app/components/bali/delete_link/component.rb
+++ b/app/components/bali/delete_link/component.rb
@@ -20,7 +20,9 @@ module Bali
       # `text-error` on top of it would be red text on a red fill.
       COLOURLESS_VARIANTS = %i[ghost link].freeze
 
-      DEFAULT_ICON = "trash"
+      # Spelled `trash-2` since #902: the mapping entry that made `trash` draw
+      # this glyph is gone, and the default keeps the drawing it always had.
+      DEFAULT_ICON = "trash-2"
 
       # The one component where `icon:` is not the old value under a new name: it also
       # takes `true`, which is what the pair `icon: true` + `icon_name: 'x'` collapsed into.

--- a/app/components/bali/dropdown/previews/popover.html.erb
+++ b/app/components/bali/dropdown/previews/popover.html.erb
@@ -10,7 +10,7 @@
 
         c.with_item(name: 'Edit', href: '#', icon: 'pencil')
         c.with_item(name: 'Export', href: '#', icon: 'download')
-        c.with_item(name: 'Delete', href: '#', method: :delete, icon: 'trash')
+        c.with_item(name: 'Delete', href: '#', method: :delete, icon: 'trash-2')
       end %>
     </div>
   </div>
@@ -23,7 +23,7 @@
 
         c.with_item(name: 'Edit', href: '#', icon: 'pencil')
         c.with_item(name: 'Export', href: '#', icon: 'download')
-        c.with_item(name: 'Delete', href: '#', method: :delete, icon: 'trash')
+        c.with_item(name: 'Delete', href: '#', method: :delete, icon: 'trash-2')
       end %>
     </div>
   </div>

--- a/app/components/bali/icon/component.rb
+++ b/app/components/bali/icon/component.rb
@@ -27,6 +27,19 @@ module Bali
     class Component < ApplicationViewComponent
       attr_reader :name, :tag_name, :options
 
+      # Every name the direct-Lucide step can serve, enumerated from the SVG
+      # files the gem ships (lucide-rails has no list API). Only the error
+      # path reads it — it feeds "did you mean" for names the mapping no
+      # longer carries, e.g. `arrow_left` → `arrow-left` (#902 removed the
+      # identity entries that used to cover those). Memoized: the set is
+      # fixed for the life of the process.
+      def self.lucide_icon_names
+        @lucide_icon_names ||= LucideRails::GEM_ROOT
+                               .glob("icons/stripped/*.svg")
+                               .map { |file| file.basename(".svg").to_s }
+                               .sort.freeze
+      end
+
       SIZES = {
         small: "size-4",
         medium: "size-8",
@@ -166,13 +179,15 @@ module Bali
       # Matching ignores the difference between dashes and underscores, because
       # the removed legacy step accepted both spellings of every name it
       # served — without that, `arrow_left` suggests nothing at all instead of
-      # the `arrow-left` that replaces it.
+      # the `arrow-left` that replaces it. Candidates cover everything the
+      # pipeline can actually serve: the mapping's keys, the full Lucide set,
+      # and the kept icons.
       #
       # @param name [String] the icon name that wasn't found
       # @return [Array<String>] up to 3 similar icon names
       def find_similar_icons(name)
         needle = comparable_name(name)
-        all_names = LucideMapping.bali_names + KeptIcons::ALL
+        all_names = LucideMapping.bali_names + self.class.lucide_icon_names + KeptIcons::ALL
 
         all_names.select do |candidate|
           comparable = comparable_name(candidate)

--- a/app/components/bali/icon/lucide_mapping.rb
+++ b/app/components/bali/icon/lucide_mapping.rb
@@ -10,15 +10,34 @@ module Bali
     #   LucideMapping.find('edit') # => 'pencil'
     #   LucideMapping.find('unknown') # => nil
     #
-    # rubocop:disable Metrics/ClassLength
     class LucideMapping
       # This map is consulted BEFORE the name is tried as a Lucide icon, so a
       # key that is itself a current Lucide name and points at a different
       # glyph shadows the real icon — the honest spelling becomes unreachable,
-      # with no error and no warning. Do not add entries like that; the test
-      # freezes the known leftovers so the set can only shrink (see the
-      # shadowing test in lucide_mapping_test.rb, and the issue it names for
-      # the five still pending a decision).
+      # with no error and no warning. Do not add entries like that; the
+      # shadowing test in lucide_mapping_test.rb freezes the set so it can
+      # only shrink. `trash`, `cog`, `expand`, `indent` and `outdent` were
+      # removed for exactly that (#902) and now draw their real Lucide glyph.
+      #
+      # Three shadowing entries stay, deliberately:
+      #
+      # * `check-circle` => `circle-check`: Lucide renamed check-circle to
+      #   circle-check in 2023, and the `check-circle` file lucide-rails still
+      #   ships is the legacy glyph (the check overflowing the circle).
+      #   Pointing at the modern canonical drawing is the correct behaviour,
+      #   and the entry keeps working the day lucide-rails drops the file.
+      # * `edit` => `pencil`: `edit` in Lucide is a deprecated alias whose
+      #   real rename was `square-pen` — NOT `pencil`. The target is the
+      #   v1/v2 visual continuity, chosen on purpose; dropping the entry
+      #   would swap every measured call site from a pencil to a
+      #   pencil-in-square without gaining a current name.
+      # * `plus-circle` => `circle-plus`: same rename story as check-circle,
+      #   but the legacy file draws the same thing — the entry only protects
+      #   against the alias file being dropped.
+      #
+      # Identity entries ("check" => "check", …) are dead weight — the
+      # direct-Lucide step resolves them identically — and the same test
+      # keeps them out.
       #
       # Mapping from Bali icon names to Lucide icon names
       MAPPING = {
@@ -29,142 +48,76 @@ module Bali
         "info-circle" => "info",
         "info-circle-alt" => "info",
         "success" => "circle-check",
-        "check" => "check",
         "check-circle" => "circle-check",
         "times" => "x",
         "times-circle" => "circle-x",
         "question_circle" => "circle-help",
 
         # Arrows & Navigation
-        "arrow-left" => "arrow-left",
-        "arrow-right" => "arrow-right",
         "arrow-right-up" => "arrow-up-right",
         "arrow-back" => "chevron-left",
         "arrow-forward" => "chevron-right",
-        "chevron-down" => "chevron-down",
-        "chevron-left" => "chevron-left",
-        "chevron-right" => "chevron-right",
         "chevron-doble-down" => "chevrons-down",
         "chevron-doble-up" => "chevrons-up",
         "angle-double-down" => "chevrons-down",
         "angle-double-up" => "chevrons-up",
         "long-arrow-alt-left" => "arrow-left",
         "external-link-alt" => "external-link",
-        "expand" => "maximize",
-
-        # Text Formatting
-        "align-left" => "align-left",
-        "align-center" => "align-center",
-        "align-right" => "align-right",
-        "bold" => "bold",
-        "italic" => "italic",
-        "underline" => "underline",
-        "strikethrough" => "strikethrough",
-        "indent" => "indent-increase",
-        "outdent" => "indent-decrease",
 
         # Files & Documents
         "attachment" => "paperclip",
         "file-export" => "file-output",
         "file-certificate" => "file-badge",
-        "copy" => "copy",
-        "sticky-note" => "sticky-note",
 
         # Actions
         "edit" => "pencil",
         "edit-alt" => "pen",
-        "pen" => "pen",
-        "trash" => "trash-2",
         "trash-alt" => "trash",
-        "plus" => "plus",
         "plus-circle" => "circle-plus",
-        "minus" => "minus",
-        "search" => "search",
         "search-minus" => "zoom-out",
         "search-plus" => "zoom-in",
-        "filter" => "filter",
         "filter-alt" => "sliders-horizontal",
-        "download" => "download",
-        "upload" => "upload",
         "cloud-upload-alt" => "cloud-upload",
         "print" => "printer",
 
         # UI Elements
-        "cog" => "settings",
         "ellipsis-h" => "ellipsis",
         "more" => "more-horizontal",
-        "list" => "list",
-        "table" => "table",
         "dashboard" => "layout-dashboard",
-        "home" => "home",
-        "door-open" => "door-open",
-        "bookmark" => "bookmark",
-        "star" => "star",
-        "bell" => "bell",
         "notification" => "bell-ring",
         "handle" => "grip-vertical",
-        "link" => "link",
         "link-alt" => "link-2",
 
-        # Media
-        "image" => "image",
-        "images" => "images",
-        "camera" => "camera",
-
         # Communication
-        "mail" => "mail",
         "comment" => "message-circle",
-        "phone" => "phone",
         "phone-plus" => "phone-call",
         "square-phone" => "phone",
 
         # Users
-        "user" => "user",
-        "users" => "users",
-        "user-plus" => "user-plus",
         "address-book" => "contact",
         "face-profile" => "user",
 
         # Business & Finance
         "business" => "building-2",
-        "store" => "store",
-        "wallet" => "wallet",
         "wallet-alt" => "wallet-cards",
-        "credit-card" => "credit-card",
         "credit-card-alt" => "credit-card",
-        "coins" => "coins",
-        "receipt" => "receipt",
-        "shopping-cart" => "shopping-cart",
-        "tags" => "tags",
-        "badge-percent" => "badge-percent",
 
         # Calendar & Time
         "calendar-alt" => "calendar",
-        "clock" => "clock",
 
         # Charts
-        "chart-line" => "chart-line",
         "project-diagram" => "workflow",
 
         # Objects
-        "lightbulb" => "lightbulb",
-        "gift" => "gift",
-        "truck" => "truck",
         "truck-loading" => "truck",
         "trophy-alt" => "trophy",
-        "weight" => "weight",
         "books" => "library",
         "box-archive" => "archive",
         "checklist" => "list-checks",
-        "shapes" => "shapes",
-        "infinity" => "infinity",
         "magic-wand" => "wand-2",
-        "sparkles" => "sparkles",
         "fire-alt" => "flame",
-        "snowflake" => "snowflake",
 
         # People & Body
-        "baby" => "baby",
         "child" => "baby",
         "running" => "person-standing",
 
@@ -173,12 +126,9 @@ module Bali
         "capsules" => "pill",
 
         # Places & Travel
-        "bed" => "bed",
         "chair" => "armchair",
         "map-marker-alt" => "map-pin",
         "map-marked-alt" => "map",
-        "pin" => "pin",
-        "toilet" => "toilet",
 
         # Food & Drink
         "cutlery" => "utensils",
@@ -223,6 +173,5 @@ module Bali
         MAPPING.values.uniq
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/app/components/bali/image_field/previews/with_custom_clear_button.html.erb
+++ b/app/components/bali/image_field/previews/with_custom_clear_button.html.erb
@@ -3,7 +3,7 @@
     <% c.with_input(form: f, method: :avatar) %>
     <% c.with_clear_button do %>
       <%= render Bali::Button::Component.new(
-            icon: :trash,
+            icon: 'trash-2',
             type: :button,
             variant: :error,
             class: 'btn-circle btn-sm absolute -top-2 -right-2 hidden group-hover:flex max-md:flex',

--- a/app/components/bali/list/preview.rb
+++ b/app/components/bali/list/preview.rb
@@ -36,7 +36,7 @@ module Bali
                 name: 'Delete',
                 variant: :error,
                 size: :sm,
-                icon: 'trash'
+                icon: 'trash-2'
               ))
             end
           end
@@ -58,7 +58,7 @@ module Bali
                 variant: :error,
                 size: :sm,
                 outline: true,
-                icon: 'trash'
+                icon: 'trash-2'
               ))
             end
           end
@@ -75,7 +75,7 @@ module Bali
                 name: 'Delete',
                 variant: :ghost,
                 size: :sm,
-                icon: 'trash'
+                icon: 'trash-2'
               ))
             end
 

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -699,7 +699,7 @@ is a preset of this one, not a second implementation.
 <%= render Bali::Dropdown::Component.new(align: :end) do |dd| %>
   <% dd.with_trigger { "Options" } %>
   <% dd.with_item(name: "Edit", href: "/edit", icon: "pencil") %>
-  <% dd.with_item(name: "Delete", href: "/things/1", method: :delete, icon: "trash") %>
+  <% dd.with_item(name: "Delete", href: "/things/1", method: :delete, icon: "trash-2") %>
 <% end %>
 ```
 
@@ -740,7 +740,7 @@ Dropdown keyword plus `icon:` for the trigger (default `"ellipsis-h"`).
 ```erb
 <%= render Bali::ActionsDropdown::Component.new(align: :end, popover: true) do |c| %>
   <% c.with_item(name: "Edit", icon: "pencil", href: edit_movie_path(movie)) %>
-  <% c.with_item(name: "Delete", icon: "trash", href: movie_path(movie), method: :delete) %>
+  <% c.with_item(name: "Delete", icon: "trash-2", href: movie_path(movie), method: :delete) %>
 <% end %>
 ```
 
@@ -1640,7 +1640,7 @@ Vertical list of rows (DaisyUI `list`) where each item has a title, subtitle, op
     <% i.with_title('First item') %>
     <% i.with_subtitle('Description of the first item') %>
     <% i.with_action do %>
-      <%= render Bali::Button::Component.new(name: 'Delete', variant: :error, size: :sm, icon: 'trash') %>
+      <%= render Bali::Button::Component.new(name: 'Delete', variant: :error, size: :sm, icon: 'trash-2') %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/guides/migration-v2-to-v3.md
+++ b/docs/guides/migration-v2-to-v3.md
@@ -611,6 +611,28 @@ Icon 'money-bill-wave' is not available. Check available icons at: https://lucid
 `money-bill-wave` is the one that still gets no suggestion, and correctly so — no surviving
 name resembles it. Take the alternative from the table above.
 
+### Five names now draw their real Lucide glyph (v3.1)
+
+This one lands in v3.1, not v3.0, but if you are migrating from v1/v2 you will jump
+straight past the boundary, so it belongs in your sweep. Five legacy map entries used to
+shadow current Lucide names with a *different* drawing — you read lucide.dev, wrote the
+name, and got another glyph. The entries are gone (#902); the names keep resolving, as the
+icon lucide.dev actually shows:
+
+| Name | Drew in v2/v3.0 | Draws since v3.1 | Want the old drawing? |
+|---|---|---|---|
+| `trash` | `trash-2` — bin with two inner vertical lines | Lucide `trash` — plain bin | write `trash-2` |
+| `cog` | `settings` — gear with a single toothed outline | Lucide `cog` — double cog wheel | write `settings` |
+| `expand` | `maximize` — four corner brackets | Lucide `expand` — diagonal out-pointing arrows | write `maximize` |
+| `indent` | `indent-increase` | Lucide `indent` — same shape, legacy encoding | write `indent-increase` |
+| `outdent` | `indent-decrease` | Lucide `outdent` — same shape, legacy encoding | write `indent-decrease` |
+
+Two shadowing entries stay on purpose, so grep for these five only: `check-circle` still
+draws `circle-check` and `edit` still draws `pencil` — their "honest" spellings are
+deprecated Lucide aliases (a legacy glyph, and a name whose real rename is `square-pen`),
+so removing them would make drawings worse, not truer. The full reasoning lives in
+`lucide_mapping.rb` and in [the v3 → v3.1 guide](migration-v3-to-v31.md).
+
 ### `Bali::Icon::Options` only lists what ships as SVG
 
 `Options.icons` used to be the 166 legacy SVGs merged with `Bali.custom_icons`. It is now the

--- a/docs/guides/migration-v3-to-v31.md
+++ b/docs/guides/migration-v3-to-v31.md
@@ -68,9 +68,37 @@ an `<a>` instead of wrapping a link inside a `<div>`.
 
 ## Five shadowed icons change their drawing (#902)
 
-Five icon names that Bali's legacy SVGs were shadowing resolve to their Lucide drawing
-instead: the name keeps working, the glyph changes. The full before/after table lands here
-— and also in [the v2 → v3 guide](migration-v2-to-v3.md), because it affects anyone
-migrating from v1/v2 as well.
+**What changes.** `Bali::Icon` consults the legacy name map (`LucideMapping`) *before*
+trying a name as a Lucide icon, so a map key that is itself a current Lucide name and
+points at a different glyph made the honest drawing of that name unreachable — you read
+lucide.dev, wrote the name, and Bali silently drew something else. Five such entries are
+removed. The names keep resolving; what they draw changes:
 
-*Lands with the #902 PR; details land with it.*
+| Name | Drew until v3.0 | Draws in v3.1 | Want the old drawing? |
+|---|---|---|---|
+| `trash` | `trash-2` — bin with two inner vertical lines | Lucide `trash` — plain bin | write `trash-2` |
+| `cog` | `settings` — gear with a single toothed outline | Lucide `cog` — double cog wheel | write `settings` |
+| `expand` | `maximize` — four corner brackets | Lucide `expand` — diagonal out-pointing arrows | write `maximize` |
+| `indent` | `indent-increase` | Lucide `indent` — same shape, legacy encoding | write `indent-increase` |
+| `outdent` | `indent-decrease` | Lucide `outdent` — same shape, legacy encoding | write `indent-decrease` |
+
+**Who is affected.** Measured across every host in the org (124 one-line call sites of all
+shadowed names): the pinned v3 hosts have **zero** call sites of these five — the visible
+delta lands on v1/v2 hosts the day they migrate, which is why the same table also sits in
+[the v2 → v3 guide](migration-v2-to-v3.md). `indent`/`outdent` have zero call sites
+anywhere and draw the same shape anyway; `trash` is the only name with real surface, and
+its delta is the two lines inside the bin. `Bali::DeleteLink`'s default icon is unchanged
+visually — it now spells its default `trash-2` internally.
+
+**What deliberately does not change.** `check-circle => circle-check` and `edit => pencil`
+stay mapped, documented as exceptions in `lucide_mapping.rb`: their "honest" spellings are
+deprecated Lucide aliases — `check-circle` ships as a legacy glyph (the check overflowing
+the circle), and `edit`'s real rename is `square-pen`, so dropping either entry would make
+drawings worse, not truer. `plus-circle => circle-plus` also stays: it draws the same
+thing and only protects against the alias file disappearing. The 60 identity entries
+(`"check" => "check"`, …) were removed too — a no-op, since the direct-Lucide step
+resolves those names identically.
+
+The shadowing test (`test/bali/components/icon/lucide_mapping_test.rb`) freezes the three
+surviving entries and pins the five removed names to the direct-Lucide step, so the set
+can only shrink from here.

--- a/spec/dummy/app/views/admin/movies/_characters_list.html.erb
+++ b/spec/dummy/app/views/admin/movies/_characters_list.html.erb
@@ -22,7 +22,7 @@
             </div>
           </div>
           <%= render Bali::ActionsDropdown::Component.new(align: :end) do |dropdown| %>
-            <% dropdown.with_item(href: admin_movie_character_path(movie, character), method: :delete, icon: 'trash', class: 'text-error') { 'Remove' } %>
+            <% dropdown.with_item(href: admin_movie_character_path(movie, character), method: :delete, icon: 'trash-2', class: 'text-error') { 'Remove' } %>
           <% end %>
         </div>
       <% end %>

--- a/spec/dummy/app/views/admin/movies/_listing.html.erb
+++ b/spec/dummy/app/views/admin/movies/_listing.html.erb
@@ -163,7 +163,7 @@
                   <% dropdown.with_item(
                     href: admin_movie_path(movie),
                     method: :delete,
-                    icon: 'trash',
+                    icon: 'trash-2',
                     data: { turbo_confirm: t('movies.show.confirm_delete', name: movie.name) },
                     class: 'text-error'
                   ) { t('movies.actions.delete') } %>

--- a/spec/dummy/app/views/admin/studios/_listing.html.erb
+++ b/spec/dummy/app/views/admin/studios/_listing.html.erb
@@ -92,7 +92,7 @@
                 <% dropdown.with_item(
                   name: t('studios.actions.delete'),
                   href: admin_studio_path(studio),
-                  icon: 'trash',
+                  icon: 'trash-2',
                   method: :delete,
                   data: { turbo_confirm: t('studios.confirm_delete', name: studio.name) },
                   class: 'text-error'

--- a/spec/dummy/app/views/movies/_characters_list.html.erb
+++ b/spec/dummy/app/views/movies/_characters_list.html.erb
@@ -24,7 +24,7 @@
             </div>
           </div>
           <%= render Bali::ActionsDropdown::Component.new(align: :end) do |dropdown| %>
-            <% dropdown.with_item(href: movie_character_path(movie, character), method: :delete, icon: 'trash', class: 'text-error') { 'Remove' } %>
+            <% dropdown.with_item(href: movie_character_path(movie, character), method: :delete, icon: 'trash-2', class: 'text-error') { 'Remove' } %>
           <% end %>
         </div>
       <% end %>

--- a/spec/dummy/app/views/pages/showcase.html.erb
+++ b/spec/dummy/app/views/pages/showcase.html.erb
@@ -548,7 +548,7 @@
             <%= render Bali::ActionsDropdown::Component.new(align: :end) do |dropdown| %>
               <% dropdown.with_item(href: '#', icon: 'download') { t('showcase.download') } %>
               <% dropdown.with_item(href: '#', icon: 'share-2') { t('showcase.share') } %>
-              <% dropdown.with_item(href: '#', icon: 'trash', class: 'text-error') { t('common.delete') } %>
+              <% dropdown.with_item(href: '#', icon: 'trash-2', class: 'text-error') { t('common.delete') } %>
             <% end %>
           <% end %>
         <% end %>
@@ -563,7 +563,7 @@
             <%= render Bali::ActionsDropdown::Component.new(align: :end) do |dropdown| %>
               <% dropdown.with_item(href: '#', icon: 'download') { t('showcase.download') } %>
               <% dropdown.with_item(href: '#', icon: 'share-2') { t('showcase.share') } %>
-              <% dropdown.with_item(href: '#', icon: 'trash', class: 'text-error') { t('common.delete') } %>
+              <% dropdown.with_item(href: '#', icon: 'trash-2', class: 'text-error') { t('common.delete') } %>
             <% end %>
           <% end %>
         <% end %>
@@ -578,7 +578,7 @@
             <%= render Bali::ActionsDropdown::Component.new(align: :end) do |dropdown| %>
               <% dropdown.with_item(href: '#', icon: 'download') { t('showcase.download') } %>
               <% dropdown.with_item(href: '#', icon: 'share-2') { t('showcase.share') } %>
-              <% dropdown.with_item(href: '#', icon: 'trash', class: 'text-error') { t('common.delete') } %>
+              <% dropdown.with_item(href: '#', icon: 'trash-2', class: 'text-error') { t('common.delete') } %>
             <% end %>
           <% end %>
         <% end %>

--- a/test/bali/components/icon/lucide_mapping_test.rb
+++ b/test/bali/components/icon/lucide_mapping_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 class BaliIconLucideMappingTest < ActiveSupport::TestCase
   def test_find_returns_lucide_name_for_mapped_bali_icon
     assert_equal("pencil", Bali::Icon::LucideMapping.find("edit"))
-    assert_equal("trash-2", Bali::Icon::LucideMapping.find("trash"))
-    assert_equal("settings", Bali::Icon::LucideMapping.find("cog"))
+    assert_equal("circle-check", Bali::Icon::LucideMapping.find("check-circle"))
+    assert_equal("trash", Bali::Icon::LucideMapping.find("trash-alt"))
   end
 
   def test_find_returns_nil_for_unmapped_icons
@@ -19,8 +19,8 @@ class BaliIconLucideMappingTest < ActiveSupport::TestCase
   end
 
   def test_mapped_returns_true_for_mapped_icons
-    assert(Bali::Icon::LucideMapping.mapped?("user"))
-    assert(Bali::Icon::LucideMapping.mapped?("check"))
+    assert(Bali::Icon::LucideMapping.mapped?("edit"))
+    assert(Bali::Icon::LucideMapping.mapped?("plus-circle"))
   end
 
   def test_mapped_returns_false_for_unmapped_icons
@@ -31,9 +31,8 @@ class BaliIconLucideMappingTest < ActiveSupport::TestCase
   def test_bali_names_returns_all_bali_icon_names_that_have_mappings
     names = Bali::Icon::LucideMapping.bali_names
     assert_includes(names, "edit")
-    assert_includes(names, "trash")
-    assert_includes(names, "user")
-    assert_includes(names, "check")
+    assert_includes(names, "check-circle")
+    assert_includes(names, "trash-alt")
     refute_includes(names, "visa")
     refute_includes(names, "whatsapp")
   end
@@ -41,33 +40,59 @@ class BaliIconLucideMappingTest < ActiveSupport::TestCase
   def test_lucide_names_returns_unique_lucide_names_used_in_mappings
     names = Bali::Icon::LucideMapping.lucide_names
     assert_includes(names, "pencil")
-    assert_includes(names, "trash-2")
-    assert_includes(names, "user")
-    assert_includes(names, "check")
+    assert_includes(names, "circle-check")
+    assert_includes(names, "trash")
     assert_equal(names.size, names.uniq.size)
   end
 
   # Resolution consults MAPPING before trying the name as a Lucide icon, so a
   # key that is ALSO a current Lucide name and points at a different glyph
   # shadows the real icon: the honest spelling of that name becomes
-  # unreachable, silently. `grid` and `file-signature` were removed for exactly
-  # that. The keys below are the known leftovers, frozen in BOTH directions —
-  # a new shadowing entry fails this test, and removing one obliges updating
-  # the list, which is the paper trail we want. Measured SVG against SVG on
-  # lucide-rails 0.7.4 (what Gemfile.lock pins — the determinism comes from the
-  # lock, not from the gemspec cap): only `plus-circle` still draws the same
-  # thing as its target; the other seven redirect to a genuinely different
-  # glyph, and #902 tracks deciding each of them.
+  # unreachable, silently. `grid` and `file-signature` were removed for
+  # exactly that pre-v3.0, and #902 removed `trash`, `cog`, `expand`,
+  # `indent` and `outdent` (see REMOVED_SHADOWED_KEYS below). The keys here
+  # are the deliberate survivors, frozen in BOTH directions — a new shadowing
+  # entry fails this test, and removing one obliges updating the list, which
+  # is the paper trail we want. Measured SVG against SVG on lucide-rails
+  # 0.7.4 (what Gemfile.lock pins — the determinism comes from the lock, not
+  # from the gemspec cap): `plus-circle` draws the same thing as its target;
+  # `check-circle` and `edit` redirect on purpose, because their "honest"
+  # spellings are deprecated Lucide aliases — a legacy glyph and a name whose
+  # real rename is `square-pen`. The header of lucide_mapping.rb tells the
+  # full story.
   KNOWN_SHADOWED_KEYS = %w[
     plus-circle
-    check-circle cog edit expand indent outdent trash
+    check-circle edit
   ].freeze
+
+  # The five keys #902 removed: each was shadowing a current Lucide name with
+  # a different glyph. They must stay out of MAPPING, and their honest
+  # spelling must keep resolving through the pipeline's step 2 — if either
+  # half fails, the shadowing came back or the pinned lucide-rails dropped
+  # the file, and both deserve a red build.
+  REMOVED_SHADOWED_KEYS = %w[cog expand indent outdent trash].freeze
 
   def test_no_mapping_key_shadows_a_current_lucide_name_beyond_the_known_set
     shadowed = Bali::Icon::LucideMapping::MAPPING
                  .select { |key, target| key != target && lucide_icon?(key) }
                  .keys.sort
     assert_equal(KNOWN_SHADOWED_KEYS.sort, shadowed)
+  end
+
+  def test_removed_shadowed_keys_stay_out_of_the_mapping_and_resolve_as_lucide
+    REMOVED_SHADOWED_KEYS.each do |name|
+      refute(Bali::Icon::LucideMapping.mapped?(name),
+             "#{name} was removed from MAPPING by #902; do not reintroduce it")
+      assert(lucide_icon?(name),
+             "#{name} must resolve as a direct Lucide icon (pipeline step 2)")
+    end
+  end
+
+  def test_mapping_carries_no_identity_entries
+    identity = Bali::Icon::LucideMapping::MAPPING.select { |key, target| key == target }.keys
+    assert_empty(identity,
+                 "identity entries are dead weight — the direct-Lucide step already " \
+                 "resolves these names: #{identity.inspect}")
   end
 
   def test_mapping_constant_is_frozen


### PR DESCRIPTION
## Resumen

`Bali::Icon` consulta `LucideMapping` ANTES de probar el nombre como icono Lucide directo, así que una clave que además es un nombre Lucide vigente y apunta a OTRO glifo sombrea el icono real: el dev lee lucide.dev, escribe el nombre, y Bali dibuja otra cosa — sin error ni warning. Este PR ejecuta la decisión 902-1 (medición org-wide del 05/08: 124 call sites en los 8 repos):

- **Se quitan** `trash`, `cog`, `expand`, `indent` y `outdent` del mapping: cada nombre pasa a dibujar su glifo Lucide real vía el paso 2 del pipeline. Cero call sites en los hosts v3 pinneados; el delta visual les llega a los hosts v1/v2 el día que migren, vía guía.
- **Se conservan** `check-circle => circle-check` y `edit => pencil` como excepciones documentadas en el propio `lucide_mapping.rb`: sus grafías "honestas" son aliases deprecados de Lucide (un glifo legacy con el check desbordando el círculo, y un nombre cuyo rename real es `square-pen`, no `pencil`). Quitarlas empeoraría el dibujo en 91 call sites medidos sin ganar semántica vigente. `plus-circle` también se queda (dibuja lo mismo; solo protege contra el drop del alias).
- **Fuera las 60 entradas identidad** (`"check" => "check"`, …): no-op verificado — las 60 resuelven idéntico por el paso Lucide directo (comprobado contra los SVG de lucide-rails 0.7.4).

## Detalles

- Los call sites internos conservan su dibujo de siempre: `trash` → `trash-2` (previews, vistas del dummy, ejemplos de `components.md` y el `DEFAULT_ICON` de `DeleteLink`), `cog` → `settings`, `expand` → `maximize`. Diff visual cero, medido contra el path data de los SVG renderizados por el server en el puerto 3089.
- Las entradas identidad eran las que alimentaban el "did you mean" (`arrow_left` → `arrow-left`); las sugerencias ahora beben del set Lucide completo enumerado de la gema, así que ese caso sigue funcionando y cualquier typo de nombre Lucide gana sugerencias que antes no tenía (lo cazó el test de `icon_test.rb` en la primera pasada).
- `KNOWN_SHADOWED_KEYS` encoge a `%w[plus-circle check-circle edit]`; un test nuevo fija que las 5 removidas NO están en el mapping y siguen resolviendo por el paso 2 (una reintroducción accidental o un drop del archivo en lucide-rails rompen el build), y otro impide que vuelvan entradas identidad.
- Cambio anunciado (T1): sección #902 rellenada en `migration-v3-to-v31.md` con la tabla antes/después, y la MISMA tabla en `migration-v2-to-v3.md` (única excepción de T3: quien migra desde v1/v2 salta directo a v3.1). Dato medido para la tabla: `indent`/`outdent` dibujan la misma forma que sus targets (encoding legacy vs actual), así que su remoción ni se ve.

## Tests

- Minitest completo: 3972 runs, 0 failures, 0 errors.
- Rubocop limpio en los archivos tocados.
- Sin Cypress: no se tocó JS.
- Verificación en el server del dummy (puerto 3089): `icon/lucide_mapped_icons` lista solo las 3 excepciones; `actions_dropdown/default`, `list/with_actions` y `/showcase` dibujan el path de `trash-2` (`M10 11v6`); `data_table/with_grid_mode?view=grid` dibuja el de `maximize`.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
