### PR TITLE
Topbar::UserMenu prefabricado + IconAction con badge Turbo-actualizable (#713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Bali::Topbar::UserMenu` — the prefabricated user dropdown** (#713). A preset of
+  `Bali::Dropdown` (the ActionsDropdown move), so keyboard navigation, Escape,
+  `aria-expanded` and `popover:` come with it — everything the hand-rolled
+  `<details class="dropdown">` menus in the apps never had. Trigger: `Bali::Avatar` with
+  `name:` (photo via `avatar_url:`, or derived initials with a deterministic colour, #712),
+  the name hidden on mobile, and a chevron. Panel: a non-actionable name/email header
+  (`Dropdown::Title`), the host's `with_item`s, then sign-out. `sign_out:` has **no default
+  route** — the item only renders when the call site passes `sign_out: { href: ... }`, so
+  the gem stays uncoupled from bali-auth; `method:` defaults to `:delete` and submits a
+  real form (`button_to`) that cannot degrade to a GET without JavaScript, with the
+  delete-confirm dialog off (pass `confirm:` to opt in). New `bali_view.topbar.user_menu.*`
+  locales (en/es).
+- **`Bali::Topbar::IconAction` — one icon button for the Topbar's `with_action` slot**
+  (#713). The notification bell packaged: a `<button>` (or `<a>` with `href:`) that
+  requires an accessible `label:`, with an optional badge — `badge: true` draws the dot, a
+  number draws a count pill (`Bali::Tag`), and `badge_id:` names the indicator `<span>` so
+  the host can `turbo_stream.replace` it (with `badge_id:` alone the span renders empty
+  and hidden, ready for a stream to light up). The component brings no polling and no
+  channel — only the target. The Topbar/AppLayout previews and the dummy admin topbar now
+  compose both components instead of hand-rolling the markup.
+
 - **`Bali::Gantt` — phase 1: the shared data contract and the server-rendered `:static` mode** (#704). One component, two renderers; this phase ships the foundation the React island (phases 2-3, #705/#719) will plug into:
   - `Bali::Gantt::Data` parses and validates the frozen contract — `{ window, groups[], items[], dependencies[], critical_ids[] }` with two-level group/item nesting (`parent_id`), ISO8601 dates, and the optional fields the real island already consumes: `assignee`, `percent_complete`, `slack_days`, `priority`, plus `milestone:` (rendered as a diamond) and `href`. Single-date items draw as minimum-width bars, inverted ranges clamp to their start, and structural errors raise instead of silently dropping bars. A frozen sample of `TDFlow::GanttSerializer` output validates the rename mapping (`test/fixtures/gantt/`).
   - `Bali::Gantt::TimeScale` — one day-based coordinate system shared with the future island (`px_per_day` 24/8/2 for day/week/month, exactly `ZoomControls.jsx`), `:auto` density picked from the window span, minimum bar width, inclusive ends, clipped calendar ticks/bands and the today marker.

--- a/app/components/bali/app_layout/previews/with_topbar.html.erb
+++ b/app/components/bali/app_layout/previews/with_topbar.html.erb
@@ -45,32 +45,19 @@
       <% end
 
       topbar.with_action do %>
-        <%= render Bali::Button::Component.new(
-          icon: 'bell', variant: :ghost, size: :sm,
-          class: 'btn-square', aria: { label: 'Notifications' }
-        ) %>
+        <%= render Bali::Topbar::IconAction::Component.new(icon: 'bell', label: 'Notifications') %>
       <% end
 
       topbar.with_action do %>
-        <%= render Bali::Button::Component.new(
-          icon: 'circle-help', variant: :ghost, size: :sm,
-          class: 'btn-square', aria: { label: 'Help' }
-        ) %>
+        <%= render Bali::Topbar::IconAction::Component.new(icon: 'circle-help', label: 'Help') %>
       <% end
 
       topbar.with_user_menu do %>
-        <%= render Bali::Dropdown::Component.new(align: :start, class: 'lg:dropdown-end') do |dropdown|
-          dropdown.with_trigger(variant: :ghost, class: 'btn-sm gap-2') do %>
-            <%= render Bali::Avatar::Component.new(size: :xs) do |avatar|
-              avatar.with_placeholder { 'AG' }
-            end %>
-            <span class="hidden md:inline">Ana García</span>
-            <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
-          <% end
-
-          dropdown.with_item(href: '#') { 'Profile' }
-          dropdown.with_item(href: '#') { 'Settings' }
-          dropdown.with_item(href: '#', class: 'text-error') { 'Sign out' }
+        <%= render Bali::Topbar::UserMenu::Component.new(
+          name: 'Ana García', email: 'ana@example.com', sign_out: { href: '#' }
+        ) do |menu|
+          menu.with_item(name: 'Profile', href: '#', icon: 'user')
+          menu.with_item(name: 'Settings', href: '#', icon: 'settings')
         end %>
       <% end
     end %>

--- a/app/components/bali/topbar/icon_action/component.rb
+++ b/app/components/bali/topbar/icon_action/component.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Bali
+  module Topbar
+    module IconAction
+      # One icon button for the Topbar's `with_action` slot — the notification
+      # bell packaged. A `<button>` by default, an `<a>` when given `href:`,
+      # always with an accessible name (`label:` is required: an icon-only
+      # control without one has no name at all).
+      #
+      # The badge is a Turbo-Stream-updatable target and nothing more: pass
+      # `badge_id:` and the indicator `<span>` gets that DOM id for the host to
+      # `turbo_stream.replace` — the component brings no polling and no channel.
+      # With `badge_id:` and no `badge:` it renders the span empty and hidden,
+      # so a stream can light it up later without a full re-render.
+      class Component < ApplicationViewComponent
+        BUTTON_CLASSES = "btn btn-ghost btn-sm btn-square"
+
+        # The bell-dot of the Topbar preview, verbatim: the `border-base-100`
+        # ring is what keeps the dot legible over the icon's strokes.
+        DOT_CLASSES = "bali-topbar-badge absolute top-1.5 right-1.5 size-2 " \
+                      "rounded-full bg-error border-2 border-base-100"
+
+        COUNT_CLASSES = "bali-topbar-badge absolute -top-1 -right-1"
+
+        # @param icon [String, Symbol] icon name (Bali::Icon pipeline).
+        # @param label [String] accessible name, e.g. t-ed "Notifications".
+        # @param href [String, nil] renders an `<a>` (navigation) instead of a
+        #   `<button>` (action) — the Button-vs-Link doctrine, one keyword.
+        # @param badge [true, Integer, String, nil] `true` draws the small dot;
+        #   a number or string draws a count pill; `nil` draws nothing.
+        # @param badge_id [String, nil] DOM id of the indicator span, so a Turbo
+        #   Stream can replace it.
+        # rubocop:disable Metrics/ParameterLists
+        def initialize(icon:, label:, href: nil, badge: nil, badge_id: nil, **options)
+          # rubocop:enable Metrics/ParameterLists
+          @icon = icon
+          @label = label
+          @href = href
+          @badge = badge
+          @badge_id = badge_id
+          @options = options
+        end
+
+        def call
+          inner = safe_join([
+                              render(Bali::Icon::Component.new(@icon, class: "size-5")),
+                              badge_html
+                            ].compact)
+
+          content_tag(tag_name, inner, **root_attributes)
+        end
+
+        private
+
+        def tag_name
+          @href.present? ? :a : :button
+        end
+
+        def root_attributes
+          attrs = @options.except(:class)
+          attrs[:class] = class_names(BUTTON_CLASSES, ("relative" if badge?), @options[:class])
+          attrs[:"aria-label"] ||= @label
+          attrs[:title] ||= @label
+          @href.present? ? attrs.merge(href: @href) : { type: "button" }.merge(attrs)
+        end
+
+        def badge?
+          !@badge.nil? || @badge_id.present?
+        end
+
+        # The badge is decoration over an already-labelled control: the
+        # accessible name is `label:`, so the span stays `aria-hidden` — a host
+        # that wants "3 unread" announced puts it in `label:` (or streams it).
+        def badge_html
+          return unless badge?
+
+          if @badge == true
+            tag.span(id: @badge_id, class: DOT_CLASSES, "aria-hidden": true)
+          elsif @badge.nil?
+            tag.span(id: @badge_id, class: "bali-topbar-badge", hidden: true,
+                     "aria-hidden": true)
+          else
+            # Rendered into a local first — a block that calls `render` itself
+            # comes back empty under `capture` (see ActionsDropdown's note).
+            pill = render(Bali::Tag::Component.new(text: @badge.to_s, color: :error, size: :xs))
+            tag.span(pill, id: @badge_id, class: COUNT_CLASSES, "aria-hidden": true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/topbar/preview.rb
+++ b/app/components/bali/topbar/preview.rb
@@ -27,6 +27,27 @@ module Bali
       def without_mobile_trigger
         render_with_template(template: "bali/topbar/previews/without_mobile_trigger")
       end
+
+      # @label User Menu
+      # The prefabricated user dropdown (`Bali::Topbar::UserMenu::Component`) for the
+      # `with_user_menu` slot: avatar (photo, or initials with a deterministic colour),
+      # name/email header, your items, and a sign-out entry.
+      #
+      # `sign_out:` has **no default route** — the item only renders when you pass
+      # `sign_out: { href: ... }` (`method:` defaults to `:delete` and submits a real
+      # form). With bali-auth: `sign_out: { href: bali_auth.sign_out_path }`.
+      def user_menu
+        render_with_template(template: "bali/topbar/previews/user_menu")
+      end
+
+      # @label Icon Actions
+      # `Bali::Topbar::IconAction::Component` — one icon button for the `with_action`
+      # slot. `badge: true` draws the dot, a number draws a count pill, and `badge_id:`
+      # names the indicator `<span>` so the host can `turbo_stream.replace` it (the
+      # component brings no polling and no channel — only the target).
+      def icon_actions
+        render_with_template(template: "bali/topbar/previews/icon_actions")
+      end
     end
   end
 end

--- a/app/components/bali/topbar/previews/default.html.erb
+++ b/app/components/bali/topbar/previews/default.html.erb
@@ -8,31 +8,23 @@
   <% end %>
 
   <% topbar.with_action do %>
-    <button type="button" class="btn btn-ghost btn-sm btn-square relative" aria-label="Notifications">
-      <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
-      <span class="absolute top-1.5 right-1.5 size-2 rounded-full bg-error border-2 border-base-100"></span>
-    </button>
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'bell', label: 'Notifications', badge: true, badge_id: 'preview-notifications-badge'
+    ) %>
   <% end %>
 
   <% topbar.with_action do %>
-    <button type="button" class="btn btn-ghost btn-sm btn-square" aria-label="Help">
-      <%= render Bali::Icon::Component.new('circle-help', class: 'size-5') %>
-    </button>
+    <%= render Bali::Topbar::IconAction::Component.new(icon: 'circle-help', label: 'Help') %>
   <% end %>
 
   <% topbar.with_user_menu do %>
-    <%= render Bali::Dropdown::Component.new(align: :start, class: 'lg:dropdown-end') do |dropdown| %>
-      <% dropdown.with_trigger(variant: :ghost, class: 'btn-sm gap-2') do %>
-        <%= render Bali::Avatar::Component.new(size: :xs) do |avatar| %>
-          <% avatar.with_placeholder { 'AG' } %>
-        <% end %>
-        <span class="hidden md:inline">Ana García</span>
-        <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
-      <% end %>
-      <% dropdown.with_item(href: '#') { 'Profile' } %>
-      <% dropdown.with_item(href: '#') { 'Settings' } %>
-      <li class="divider my-1"></li>
-      <% dropdown.with_item(href: '#', class: 'text-error') { 'Sign out' } %>
+    <%= render Bali::Topbar::UserMenu::Component.new(
+      name: 'Ana García',
+      email: 'ana@example.com',
+      sign_out: { href: '#' }
+    ) do |menu| %>
+      <% menu.with_item(name: 'Profile', href: '#', icon: 'user') %>
+      <% menu.with_item(name: 'Settings', href: '#', icon: 'settings') %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/bali/topbar/previews/icon_actions.html.erb
+++ b/app/components/bali/topbar/previews/icon_actions.html.erb
@@ -1,0 +1,38 @@
+<div class="flex flex-col gap-6 p-8">
+  <div class="flex items-center gap-4">
+    <%= render Bali::Topbar::IconAction::Component.new(icon: 'circle-help', label: 'Help') %>
+    <span class="text-sm text-base-content/60">No badge — plain icon button</span>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'bell', label: 'Notifications', badge: true
+    ) %>
+    <span class="text-sm text-base-content/60"><code>badge: true</code> — the dot</span>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'inbox', label: 'Inbox, 3 unread', badge: 3, badge_id: 'inbox-badge'
+    ) %>
+    <span class="text-sm text-base-content/60">
+      <code>badge: 3, badge_id: 'inbox-badge'</code> — count pill, Turbo-Stream-replaceable
+    </span>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'mail', label: 'Messages', badge_id: 'messages-badge'
+    ) %>
+    <span class="text-sm text-base-content/60">
+      <code>badge_id:</code> alone — hidden empty target a stream can light up later
+    </span>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'settings', label: 'Settings', href: '/lookbook'
+    ) %>
+    <span class="text-sm text-base-content/60"><code>href:</code> — renders an <code>&lt;a&gt;</code></span>
+  </div>
+</div>

--- a/app/components/bali/topbar/previews/user_menu.html.erb
+++ b/app/components/bali/topbar/previews/user_menu.html.erb
@@ -1,0 +1,40 @@
+<div class="flex flex-col gap-8 p-8 min-h-[400px]">
+  <div>
+    <p class="text-sm text-base-content/60 mb-2">
+      Full: photo, email, items and sign out (delete via a real form)
+    </p>
+    <%= render Bali::Topbar::UserMenu::Component.new(
+      name: 'Ana García López',
+      email: 'ana@example.com',
+      avatar_url: 'avatar.png',
+      align: :start,
+      sign_out: { href: '#' }
+    ) do |menu| %>
+      <% menu.with_item(name: 'Profile', href: '#', icon: 'user') %>
+      <% menu.with_item(name: 'Settings', href: '#', icon: 'settings') %>
+    <% end %>
+  </div>
+
+  <div>
+    <p class="text-sm text-base-content/60 mb-2">
+      No photo: initials derived from the name, deterministic colour (see Avatar)
+    </p>
+    <%= render Bali::Topbar::UserMenu::Component.new(
+      name: 'Benito Juárez',
+      email: 'benito@example.com',
+      align: :start,
+      sign_out: { href: '#' }
+    ) do |menu| %>
+      <% menu.with_item(name: 'Profile', href: '#', icon: 'user') %>
+    <% end %>
+  </div>
+
+  <div>
+    <p class="text-sm text-base-content/60 mb-2">
+      Without <code>sign_out:</code> the item simply is not there — no default route
+    </p>
+    <%= render Bali::Topbar::UserMenu::Component.new(name: 'Carla Ruiz', align: :start) do |menu| %>
+      <% menu.with_item(name: 'Profile', href: '#', icon: 'user') %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/bali/topbar/user_menu/component.rb
+++ b/app/components/bali/topbar/user_menu/component.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Bali
+  module Topbar
+    module UserMenu
+      # The prefabricated user dropdown for the Topbar's far-right slot: avatar
+      # (photo or derived initials), the user's name and email as a non-actionable
+      # header, the host's items, and a sign-out entry that submits a real form.
+      #
+      # A Bali::Dropdown with its trigger and header already chosen — the same
+      # move as Bali::ActionsDropdown, so keyboard, Escape, `aria-expanded` and
+      # `popover:` all come from the one controller instead of the hand-rolled
+      # `<details class="dropdown">` this replaces (which had none of them).
+      #
+      # There is NO default sign-out route on purpose (#713): the item only
+      # renders when the call site passes `sign_out: { href: ... }`, so the gem
+      # stays uncoupled from bali-auth and from any host's route names. The
+      # verb defaults to `:delete` — a sign-out that a crawler can GET must not
+      # be expressible by accident — which routes the item through DeleteLink's
+      # `button_to`: a real form submission, not an `<a>` that degrades to GET
+      # without JavaScript. The delete-confirm dialog is skipped (signing out is
+      # not destructive); pass `confirm:` in the hash to opt back in.
+      class Component < Dropdown::Component
+        SIGN_OUT_METHOD = :delete
+
+        # Absolute keys, for the reason Dropdown::Component::MENU_LABEL_KEY
+        # names: a relative key would resolve against this subclass's own scope.
+        TRIGGER_LABEL_KEY = "bali_view.topbar.user_menu.trigger_label"
+        SIGN_OUT_KEY = "bali_view.topbar.user_menu.sign_out"
+
+        SIGN_OUT_MESSAGE = "Bali::Topbar::UserMenu::Component: `sign_out:` takes a Hash " \
+                           "with `href:` — e.g. `sign_out: { href: sign_out_path }`. " \
+                           "`method:` defaults to :delete. There is no default route: " \
+                           "without `sign_out:` the item is simply not rendered."
+
+        # @param name [String] the user's full name. Feeds the trigger's avatar
+        #   (initials + deterministic colour, see Bali::Avatar) and the header.
+        # @param email [String, nil] second line of the header.
+        # @param avatar_url [String, nil] photo for the avatar; wins over initials.
+        # @param sign_out [Hash, nil] `{ href:, method: :delete }`. Extra keys
+        #   (`name:`, `confirm:`, `data:`, ...) reach the item. No hash, no item.
+        # @param align [Symbol] Dropdown's horizontal axis; `:end` here, because
+        #   the menu hangs off the far right of the Topbar.
+        # Every other keyword is Bali::Dropdown::Component's.
+        def initialize(name:, email: nil, avatar_url: nil, sign_out: nil, align: :end, **options)
+          @name = name
+          @email = email
+          @avatar_url = avatar_url
+          @sign_out = normalize_sign_out(sign_out)
+
+          super(align: align, **prepend_class_name(options, "bali-topbar-user-menu"))
+        end
+
+        # Slot order is registration order, so the surrounding entries are added
+        # here, around an explicit `content` call: header first, then the call
+        # site's `with_item`s (evaluated by `content`), then sign-out.
+        def before_render
+          header = header_content
+          with_item(tag: :title, class: "bali-topbar-user-menu-header") { header }
+          content
+          add_sign_out_item if @sign_out
+          super
+        end
+
+        # Avatar + name (hidden on mobile) + chevron. Rendered into locals first:
+        # a block that calls `render` itself comes back empty here — `capture`
+        # prefers the output buffer and discards the returned string (see the
+        # measurement note in Bali::ActionsDropdown#default_trigger).
+        def default_trigger
+          inner = safe_join([
+                              render(Bali::Avatar::Component.new(
+                                       name: @name, src: @avatar_url, size: :xs
+                                     )),
+                              tag.span(@name, class: "hidden md:inline"),
+                              render(Bali::Icon::Component.new("chevron-down", size: :small))
+                            ])
+
+          render(Dropdown::Trigger::Component.new(
+                   variant: :ghost,
+                   class: "btn-sm gap-2",
+                   "aria-label": t(TRIGGER_LABEL_KEY, name: @name)
+                 )) { inner }
+        end
+
+        private
+
+        # `tag: :title` (713-D3): the identity is not actionable, so it must not
+        # be a menuitem — Dropdown::Title is presentational and does not count
+        # towards `render?`, so a UserMenu with no items and no `sign_out:`
+        # renders nothing at all rather than a menu with nothing to choose.
+        def header_content
+          safe_join([
+            tag.span(@name, class: "block text-sm font-medium text-base-content"),
+            (tag.span(@email, class: "block text-xs font-normal text-base-content/60") if
+              @email.present?)
+          ].compact)
+        end
+
+        def normalize_sign_out(sign_out)
+          return nil if sign_out.nil?
+
+          sign_out = sign_out.symbolize_keys if sign_out.respond_to?(:symbolize_keys)
+          raise ArgumentError, SIGN_OUT_MESSAGE unless sign_out.is_a?(Hash) &&
+                                                       sign_out[:href].present?
+
+          { method: SIGN_OUT_METHOD }.merge(sign_out)
+        end
+
+        # Routed through the same `with_item` lambda as everything else, so
+        # `:delete` becomes DeleteLink's `button_to` (real form, text-error and
+        # `form_class: "contents"` for free) and any other verb becomes a Link
+        # with `data-turbo-method`. Signing out is not deleting a record, so the
+        # confirm dialog is off unless the caller asks for one.
+        def add_sign_out_item
+          opts = @sign_out.except(:href, :method)
+          method = @sign_out[:method].to_sym
+          opts[:name] ||= t(SIGN_OUT_KEY)
+          opts[:icon] ||= "log-out"
+          opts[:class] = class_names("bali-topbar-sign-out", opts[:class])
+
+          if method == SIGN_OUT_METHOD
+            opts[:skip_confirm] = true unless opts.key?(:confirm) || opts.key?(:skip_confirm)
+          else
+            opts[:class] = class_names("text-error", opts[:class])
+          end
+
+          with_item(href: @sign_out[:href], method: method, **opts)
+        end
+      end
+    end
+  end
+end

--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -546,3 +546,7 @@ en:
       card_moved: "%{card} moved to %{column}, position %{position} of %{total}"
     tabs:
       navigation: "Section navigation"
+    topbar:
+      user_menu:
+        trigger_label: "User menu for %{name}"
+        sign_out: "Sign out"

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -547,3 +547,7 @@ es:
       card_moved: "%{card} movida a %{column}, posición %{position} de %{total}"
     tabs:
       navigation: "Navegación de secciones"
+    topbar:
+      user_menu:
+        trigger_label: "Menú de usuario de %{name}"
+        sign_out: "Cerrar sesión"

--- a/cypress/e2e/topbar-user-menu.cy.js
+++ b/cypress/e2e/topbar-user-menu.cy.js
@@ -1,0 +1,62 @@
+// Bali::Topbar::UserMenu is a preset of Bali::Dropdown, so the point of this file is not
+// to re-test the menu mechanics (dropdown-controller.cy.js owns those) but to prove the
+// preset actually inherits them — the hand-rolled `<details class="dropdown">` it replaces
+// had no keyboard, no Escape and no aria-expanded at all — plus the two pieces the preset
+// adds: the presentational identity header and the sign-out `button_to` form.
+describe('Topbar::UserMenu', () => {
+  const userMenu = '.bali-topbar-user-menu'
+  const trigger = '[data-dropdown-target="trigger"]'
+  const menu = '[data-dropdown-target="menu"]'
+
+  const press = (key) => cy.focused().trigger('keydown', { key, bubbles: true, force: true })
+
+  beforeEach(() => {
+    cy.visit('/bali/topbar/user_menu')
+  })
+
+  it('inherits the dropdown keyboard: open, arrows over menuitems only, Escape', () => {
+    cy.get(userMenu).first().find(trigger).as('t')
+    cy.get('@t').should('have.attr', 'aria-expanded', 'false')
+
+    cy.get('@t').focus()
+    cy.get('@t').should('have.attr', 'aria-expanded', 'true')
+    cy.get(userMenu).first().find(menu).should('be.visible')
+
+    // The name/email header is role="presentation": the first ArrowDown must land on
+    // the first actionable item, not on the identity block.
+    press('ArrowDown')
+    cy.focused().should('have.attr', 'role', 'menuitem').and('contain', 'Profile')
+
+    press('Escape')
+    cy.focused().should('have.attr', 'data-dropdown-target', 'trigger')
+    cy.get(userMenu).first().find(menu).should('not.be.visible')
+    cy.get('@t').should('have.attr', 'aria-expanded', 'false')
+  })
+
+  it('shows the identity header outside the menuitem list', () => {
+    cy.get(userMenu).first().within(() => {
+      cy.get('.bali-topbar-user-menu-header')
+        .should('have.attr', 'role', 'presentation')
+        .and('contain', 'Ana García López')
+        .and('contain', 'ana@example.com')
+    })
+  })
+
+  it('renders sign out as a real delete form, reachable with the arrows', () => {
+    cy.get(userMenu).first().within(() => {
+      cy.get('form input[name="_method"]').should('have.value', 'delete')
+      cy.get('form button.bali-topbar-sign-out[role="menuitem"]').should('contain', 'Sign out')
+    })
+
+    cy.get(userMenu).first().find(trigger).focus()
+    press('ArrowUp') // wraps to the last item, which must be sign out
+    cy.focused().should('have.class', 'bali-topbar-sign-out')
+  })
+
+  it('renders no sign-out item when `sign_out:` was not given', () => {
+    cy.get(userMenu).eq(2).within(() => {
+      cy.get('.bali-topbar-sign-out').should('not.exist')
+      cy.get('form').should('not.exist')
+    })
+  })
+})

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -224,14 +224,18 @@ The AppLayout previews model both: "Topbar + Sidebar + Content" and
   <% end %>
 
   <% topbar.with_action do %>
-    <button class="btn btn-ghost btn-sm btn-square" aria-label="Notifications">
-      <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
-    </button>
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'bell', label: 'Notifications', badge: true, badge_id: 'notifications-badge'
+    ) %>
   <% end %>
 
   <% topbar.with_user_menu do %>
-    <%= render Bali::Dropdown::Component.new do |d| %>
-      <%# avatar + dropdown items %>
+    <%= render Bali::Topbar::UserMenu::Component.new(
+      name: current_user.name,
+      email: current_user.email,
+      sign_out: { href: sign_out_path }
+    ) do |menu| %>
+      <% menu.with_item(name: 'Profile', href: profile_path, icon: 'user') %>
     <% end %>
   <% end %>
 <% end %>
@@ -241,6 +245,45 @@ The AppLayout previews model both: "Topbar + Sidebar + Content" and
 - `menu_id` - DOM id of the sidebar the `lg:hidden` hamburger opens. Defaults to `Bali::SideMenu::Component::DEFAULT_ID`. Pass `nil` for layouts without a sidebar
 
 The root element is a `<header>` (the page's banner landmark) and the hamburger is a `Bali::SideMenu::Trigger::Component`.
+
+##### Topbar::UserMenu
+
+The prefabricated user dropdown for the `with_user_menu` slot — a preset of
+`Bali::Dropdown` (like `ActionsDropdown`), so keyboard navigation, Escape,
+`aria-expanded` and `popover:` come with it. The trigger is an avatar (photo
+via `avatar_url:`, or initials with a deterministic colour derived from
+`name:` — see Avatar), the name (hidden on mobile) and a chevron. The panel
+opens with a non-actionable name/email header, then your `with_item`s, then
+the sign-out entry.
+
+**Options:**
+- `name` (required) - the user's full name; feeds avatar, header and the trigger's `aria-label`
+- `email` - second line of the header; omitted when absent
+- `avatar_url` - photo for the avatar; wins over the derived initials
+- `sign_out` - `{ href:, method: :delete }`. **No default route**: without this hash the item is not rendered, so the gem stays uncoupled from bali-auth and from the host's route names. With bali-auth: `sign_out: { href: bali_auth.sign_out_path }`. The default `:delete` submits a real form (`button_to`) that cannot degrade to a GET; extra keys (`name:`, `confirm:`, `data:`, ...) reach the item
+- Everything else is `Bali::Dropdown::Component`'s (`align:` defaults to `:end` here)
+
+`with_item` is Dropdown's items lambda: `method:`, `icon:`, `modal:`, `drawer:`
+all work. A UserMenu with no items and no `sign_out:` renders nothing — a menu
+with nothing actionable in it is not a menu.
+
+##### Topbar::IconAction
+
+One icon button for the `with_action` slot — the notification bell packaged. A
+`<button>` by default, an `<a>` when given `href:`.
+
+```erb
+<%= render Bali::Topbar::IconAction::Component.new(
+  icon: 'bell', label: 'Notifications', badge: 3, badge_id: 'notifications-badge'
+) %>
+```
+
+**Options:**
+- `icon` (required) - icon name (Bali::Icon pipeline)
+- `label` (required) - accessible name (`aria-label` + `title`); an icon-only control without one has no name
+- `href` - renders an `<a>` (navigation) instead of a `<button>` (action)
+- `badge` - `true` draws the small dot; a number or string draws a count pill; `nil` draws nothing
+- `badge_id` - DOM id of the indicator `<span>`, so the host can `turbo_stream.replace` it. Alone (no `badge:`) it renders the span empty and hidden — a stream can light it up later. The component brings no polling and no channel, only the target
 
 #### Card
 

--- a/spec/dummy/app/views/layouts/_admin_topbar.html.erb
+++ b/spec/dummy/app/views/layouts/_admin_topbar.html.erb
@@ -30,33 +30,26 @@
   <% end %>
 
   <% topbar.with_action do %>
-    <button type="button" class="btn btn-ghost btn-sm btn-square relative" aria-label="Notifications">
-      <%= render Bali::Icon::Component.new('bell', class: 'size-5') %>
-      <span class="absolute top-1.5 right-1.5 size-2 rounded-full bg-error border-2 border-base-100"></span>
-    </button>
+    <%= render Bali::Topbar::IconAction::Component.new(
+      icon: 'bell', label: 'Notifications', badge: true, badge_id: 'admin-notifications-badge'
+    ) %>
   <% end %>
 
   <% topbar.with_action do %>
-    <button type="button" class="btn btn-ghost btn-sm btn-square" aria-label="Help">
-      <%= render Bali::Icon::Component.new('circle-help', class: 'size-5') %>
-    </button>
+    <%= render Bali::Topbar::IconAction::Component.new(icon: 'circle-help', label: 'Help') %>
   <% end %>
 
   <% topbar.with_user_menu do %>
-    <%= render Bali::Dropdown::Component.new(align: :start, class: 'lg:dropdown-end') do |dropdown| %>
-      <% dropdown.with_trigger(variant: :ghost, class: 'btn-sm gap-2') do %>
-        <%# La identidad sale de `current_user`, no de dos strings sueltos: quien nombra el
-            topbar ES el dueño de las vistas guardadas de /admin/movies. %>
-        <%= render Bali::Avatar::Component.new(size: :xs) do |avatar| %>
-          <% avatar.with_placeholder { current_user.name.split.map(&:first).join } %>
-        <% end %>
-        <span class="hidden md:inline"><%= current_user.name %></span>
-        <%= render Bali::Icon::Component.new('chevron-down', size: :small) %>
-      <% end %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.profile') } %>
-      <% dropdown.with_item(href: admin_settings_path) { t('navbar.settings') } %>
-      <li class="divider my-1"></li>
-      <% dropdown.with_item(href: logout_path, class: 'text-error', data: { turbo_method: :delete }) { t('navbar.sign_out') } %>
+    <%# La identidad sale de `current_user`, no de dos strings sueltos: quien nombra el
+        topbar ES el dueño de las vistas guardadas de /admin/movies. Sin ruta mágica de
+        sign_out: el `href:` va explícito y el verbo es :delete por default (#713). %>
+    <%= render Bali::Topbar::UserMenu::Component.new(
+      name: current_user.name,
+      email: "#{current_user.name.parameterize}@example.com",
+      sign_out: { href: logout_path, name: t('navbar.sign_out') }
+    ) do |menu| %>
+      <% menu.with_item(name: t('navbar.profile'), href: admin_settings_path, icon: 'user') %>
+      <% menu.with_item(name: t('navbar.settings'), href: admin_settings_path, icon: 'settings') %>
     <% end %>
   <% end %>
 <% end %>

--- a/test/bali/components/topbar_icon_action_test.rb
+++ b/test/bali/components/topbar_icon_action_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliTopbarIconActionComponentTest < ComponentTestCase
+  def test_renders_a_labelled_icon_button
+    render_inline(Bali::Topbar::IconAction::Component.new(icon: "bell", label: "Notifications"))
+
+    assert_selector('button[type="button"].btn.btn-ghost.btn-sm.btn-square' \
+                    '[aria-label="Notifications"][title="Notifications"]')
+    assert_selector("button span.icon-component.size-5 svg")
+  end
+
+  def test_renders_a_link_when_given_href
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications", href: "/notifications"
+                  ))
+
+    assert_selector('a[href="/notifications"].btn.btn-square[aria-label="Notifications"]')
+    assert_no_selector("button")
+    assert_no_selector("a[type]")
+  end
+
+  def test_badge_true_draws_the_dot
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications", badge: true
+                  ))
+
+    assert_selector("button.relative span.bali-topbar-badge.bg-error[aria-hidden='true']")
+  end
+
+  def test_numeric_badge_draws_a_count_pill
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications", badge: 3
+                  ))
+
+    assert_selector("button.relative span.bali-topbar-badge .badge.badge-error.badge-xs",
+                    text: "3")
+  end
+
+  def test_badge_id_names_the_turbo_stream_target
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications", badge: true,
+                    badge_id: "notifications-badge"
+                  ))
+
+    assert_selector("span#notifications-badge.bali-topbar-badge")
+  end
+
+  def test_badge_id_without_badge_renders_an_empty_hidden_target
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications", badge_id: "notifications-badge"
+                  ))
+
+    assert_selector("span#notifications-badge[hidden]", visible: false)
+    assert_selector("button.relative")
+  end
+
+  def test_no_badge_no_target_no_relative
+    render_inline(Bali::Topbar::IconAction::Component.new(icon: "bell", label: "Help"))
+
+    assert_no_selector(".bali-topbar-badge", visible: :all)
+    assert_no_selector("button.relative")
+  end
+
+  def test_passes_through_options
+    render_inline(Bali::Topbar::IconAction::Component.new(
+                    icon: "bell", label: "Notifications",
+                    class: "custom", data: { action: "notifications#open" }
+                  ))
+
+    assert_selector('button.btn.custom[data-action="notifications#open"]')
+  end
+end

--- a/test/bali/components/topbar_user_menu_test.rb
+++ b/test/bali/components/topbar_user_menu_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Bali::Topbar::UserMenu is a preset of Bali::Dropdown (like ActionsDropdown), so the menu
+# mechanics — controller, keyboard, roles — are asserted once in dropdown_test.rb. What this
+# file asserts is the preset: the avatar+name trigger, the identity header, the item order,
+# and the sign-out contract (#713: no default route, `:delete` by default, real form).
+class BaliTopbarUserMenuComponentTest < ComponentTestCase
+  def sign_out
+    { href: "/logout" }
+  end
+
+  def test_it_is_a_dropdown
+    assert_operator(Bali::Topbar::UserMenu::Component, :<, Bali::Dropdown::Component)
+  end
+
+  def test_renders_a_dropdown_aligned_to_the_end
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: sign_out))
+    assert_selector("div.dropdown.dropdown-end.bali-topbar-user-menu")
+    assert_selector('[data-controller="dropdown"]')
+  end
+
+  def test_trigger_carries_avatar_with_derived_initials_name_and_chevron
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: sign_out))
+
+    assert_selector('[data-dropdown-target="trigger"] .avatar-placeholder', text: "AG")
+    assert_selector('[data-dropdown-target="trigger"] span.hidden.md\\:inline',
+                    text: "Ana García")
+    assert_selector('[data-dropdown-target="trigger"] svg', count: 1) # the chevron
+  end
+
+  def test_trigger_uses_the_photo_when_avatar_url_is_given
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García", avatar_url: "/ana.jpg", sign_out: sign_out
+                  ))
+    assert_selector('[data-dropdown-target="trigger"] img[src="/ana.jpg"]')
+  end
+
+  def test_trigger_has_an_accessible_name_with_the_user_name
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: sign_out))
+    assert_selector('[data-dropdown-target="trigger"][aria-label="User menu for Ana García"]')
+  end
+
+  def test_header_shows_name_and_email_and_is_not_a_menuitem
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García", email: "ana@example.com", sign_out: sign_out
+                  ))
+
+    assert_selector("span.menu-title.bali-topbar-user-menu-header", text: "Ana García")
+    assert_selector("span.menu-title", text: "ana@example.com")
+    assert_selector('span.menu-title[role="presentation"]')
+    assert_no_selector('[role="menuitem"].bali-topbar-user-menu-header')
+  end
+
+  def test_header_omits_the_email_line_when_absent
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: sign_out))
+    assert_selector(".bali-topbar-user-menu-header span", count: 1)
+  end
+
+  def test_items_render_between_header_and_sign_out
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García", sign_out: sign_out
+                  )) do |menu|
+      menu.with_item(name: "Profile", href: "/profile")
+      menu.with_item(name: "Settings", href: "/settings")
+    end
+
+    texts = page.all("ul li").map(&:text)
+    assert_match(/Ana García/, texts.first)
+    assert_match(/Profile/, texts[1])
+    assert_match(/Settings/, texts[2])
+    assert_match(/Sign out/, texts.last)
+  end
+
+  def test_without_sign_out_there_is_no_sign_out_item
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García")) do |menu|
+      menu.with_item(name: "Profile", href: "/profile")
+    end
+
+    assert_no_selector(".bali-topbar-sign-out")
+    assert_no_text("Sign out")
+  end
+
+  # 713-D1: `method: :delete` is the hash's default and routes through DeleteLink's
+  # `button_to` — a real form that cannot degrade to a GET without JavaScript.
+  def test_sign_out_is_a_real_delete_form_without_confirm
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: sign_out))
+
+    assert_selector('form[action="/logout"][method="post"]')
+    assert_selector('form input[name="_method"][value="delete"]', visible: false)
+    assert_selector("form button.bali-topbar-sign-out", text: "Sign out")
+    assert_selector("form button svg") # log-out icon
+    assert_no_selector("form[data-turbo-confirm]")
+  end
+
+  def test_sign_out_takes_a_custom_label_and_confirm
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García",
+                    sign_out: { href: "/logout", name: "Log out", confirm: "Leave?" }
+                  ))
+
+    assert_selector("form button", text: "Log out")
+    assert_selector('form[data-turbo-confirm="Leave?"]')
+  end
+
+  def test_sign_out_with_another_method_becomes_a_turbo_method_link
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García", sign_out: { href: "/logout", method: :post }
+                  ))
+
+    assert_selector('a[href="/logout"][data-turbo-method="post"].text-error', text: "Sign out")
+    assert_no_selector("form")
+  end
+
+  def test_sign_out_without_href_raises
+    error = assert_raises(ArgumentError) do
+      Bali::Topbar::UserMenu::Component.new(name: "Ana García", sign_out: { method: :delete })
+    end
+    assert_match(/sign_out/, error.message)
+  end
+
+  def test_renders_nothing_with_no_items_and_no_sign_out
+    # The header is presentational and does not count towards Dropdown#render?:
+    # a user menu with nothing actionable in it renders no menu at all.
+    render_inline(Bali::Topbar::UserMenu::Component.new(name: "Ana García"))
+    assert_no_selector(".dropdown")
+  end
+
+  def test_items_keep_the_dropdown_lambda_powers
+    render_inline(Bali::Topbar::UserMenu::Component.new(
+                    name: "Ana García", sign_out: sign_out
+                  )) do |menu|
+      menu.with_item(name: "Profile", href: "/profile", icon: "user")
+    end
+
+    assert_selector('a[role="menuitem"] svg')
+  end
+end


### PR DESCRIPTION
Refs #713 (PR1-2 del plan: UserMenu + IconAction). Depende de #712, ya mergeado en 3.1.

## Qué empaqueta

Las 3 apps (gc, costa-norte, identity) arman el mismo dropdown de usuario a mano con `<details class="dropdown">` — sin flechas, sin Escape, sin `aria-expanded`. El slot `user_menu` del Topbar era un hueco vacío. Esto lo llena con dos componentes:

### `Bali::Topbar::UserMenu::Component`

Preset de `Bali::Dropdown` (el mismo movimiento que `ActionsDropdown`: lo único propio es el trigger y el armado del panel), así que teclado, Escape, `aria-expanded` y `popover:` vienen del controller existente.

- **Trigger**: `Bali::Avatar` con `name:`/`avatar_url:` (iniciales derivadas + color determinístico de #712), nombre oculto en móvil, chevron. `aria-label` interpolado con el nombre.
- **Cabecera**: nombre/email como `Dropdown::Title` (`tag: :title`, decisión 713-D3) — presentacional, no cuenta para `render?` ni entra en la navegación por flechas.
- **Items**: `renders_many` delegado a la lambda de `Dropdown#with_item` (method:, icon:, modal:, drawer: gratis), entre la cabecera y el sign out.
- **Sign out (713-D1)**: **sin ruta default** — el item solo aparece con `sign_out: { href: ... }` explícito; cero acoplamiento a bali-auth (el snippet `bali_auth.sign_out_path` va en docs). `method:` default `:delete`, que sale por `DeleteLink` como `button_to` real (no degrada a GET sin JS), sin confirm salvo `confirm:` explícito. Sin `href:` → `ArgumentError`.

### `Bali::Topbar::IconAction::Component`

La campana del preview empaquetada (713-D4): `<button>` (o `<a>` con `href:`) con `label:` accesible obligatorio. `badge: true` = punto, número = contador (`Bali::Tag`), `badge_id:` = id del `<span>` para `turbo_stream.replace` — con `badge_id:` solo, target vacío y oculto listo para que un stream lo encienda. Sin polling ni canal.

## Adopción interna

Los previews del Topbar y del AppLayout (`with_topbar`) y el `_admin_topbar` del dummy dejan de armar el markup a mano y componen los dos componentes nuevos. Variantes de Lookbook nuevas: `topbar/user_menu` y `topbar/icon_actions`.

## Verificación

- Minitest: suite completa verde (3993 runs; los archivos nuevos `topbar_user_menu_test.rb` y `topbar_icon_action_test.rb` cubren contrato de sign_out, orden de items, cabecera presentacional, badges y passthrough).
- Cypress (electron): `topbar-user-menu.cy.js` nuevo (4) + `dropdown-controller.cy.js` (11) + `app-shell-chrome.cy.js` (6) — 21/21 verdes.
- Browser (dummy en worktree): previews `topbar/default`, `topbar/user_menu`, `topbar/icon_actions`, `app_layout/with_topbar` y `/admin` verificados con screenshots — menú abre/cierra, Escape, iniciales con color determinístico, foto, punto y contador del badge, sin errores de consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
