### PR TITLE
feat(qr-code): Bali::QrCode, con rqrcode como dependencia opcional (#926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::QrCode` — QR codes generated server-side, with `rqrcode` as an optional dependency** (#926). `render Bali::QrCode::Component.new(payload: movie_url(@movie))` emits inline SVG: no JavaScript, no image request, nothing to serve. `payload:` is required; `size:` (pixels, default 200) and `level:` (error correction `:l`/`:m`/`:q`/`:h`, default `:m`) are the whole API. The gem it encodes with is **not** in the gemspec — three apps in the org render QR codes and the rest would carry it for nothing — so it is required lazily and its absence raises `Bali::QrCode::Component::MissingDependency`, a `LoadError` subclass whose message names the line to add (`gem "rqrcode", "~> 3.1"`) instead of leaving a host with `cannot load such file`. Same contract as the optional npm peers in `package.json`. Black on white with the spec's four-module quiet zone, neither configurable: a scanner reads dark-on-light, so theme colours would leave the code unreadable under a dark theme while still looking like a QR code. The SVG carries a `viewBox`, so `class: 'w-full h-auto'` overrides `size:`; `role="img"` plus an `aria-label` that defaults to the generic `bali_view.qr_code.label` ("QR code" / "Código QR") and takes a `label:` for the context the markup does not supply.
+
 ## [v3.1.0.beta.2] - 2026-08-06
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ end
 
 group :development, :test do
   gem "brakeman", require: false
+  # Deliberately not in the gemspec: Bali::QrCode::Component requires it lazily so
+  # an app that never renders a QR code does not carry the dependency. Here so the
+  # test suite and the Lookbook preview exercise the real thing.
+  gem "rqrcode", "~> 3.1"
   gem "bundler-audit", require: false
   gem "dotenv"
   gem "turbo-rails", "~> 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 2.4, < 4)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
@@ -287,6 +288,10 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rouge (4.7.0)
+    rqrcode (3.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.1.0)
     rubocop (1.86.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -397,6 +402,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   ransack
+  rqrcode (~> 3.1)
   rrule!
   rubocop-rails-omakase
   simple_command
@@ -431,6 +437,7 @@ CHECKSUMS
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   caxlsx (4.5.0) sha256=e3d98d859f148df05d5462086b5079b523f29c1766b569535f1d68629ce743ff
+  chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
@@ -503,6 +510,8 @@ CHECKSUMS
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  rqrcode (3.2.0) sha256=64c1494ca6bb67d731330f38b50e3fd09eeab4f5dcd04b608e21218d1d0b9542
+  rqrcode_core (2.1.0) sha256=f303b85df89c1b8fc5ee8dc19808c9dc4330e6329b660d99d4a8cbb36ca13051
   rrule (0.8.0)
   rubocop (1.86.0) sha256=4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ In your CSS entry point (e.g., `app/assets/tailwind/application.css`):
 `Breadcrumb`, `Command`, `Dropdown`, `Navbar`, `Pagination`, `PaginationFooter`, `SideMenu`, `Stepper`, `Tabs`, `ViewSwitch`
 
 ### Data Display
-`Avatar`, `BooleanIcon`, `Chart`, `DataTable`, `Heatmap`, `Icon`, `ImageGrid`, `InfoLevel`, `LabelValue`, `List`, `LocationsMap`, `Progress`, `PropertiesTable`, `Rate`, `Skeleton`, `StatCard`, `Table`, `Tag`, `Tags`, `Timeago`, `Timeline`, `TreeView`
+`Avatar`, `BooleanIcon`, `Chart`, `DataTable`, `Heatmap`, `Icon`, `ImageGrid`, `InfoLevel`, `LabelValue`, `List`, `LocationsMap`, `Progress`, `PropertiesTable`, `QrCode`, `Rate`, `Skeleton`, `StatCard`, `Table`, `Tag`, `Tags`, `Timeago`, `Timeline`, `TreeView`
 
 ### Interactive
 `ActionsDropdown`, `BulkActions`, `Button`, `Carousel`, `Clipboard`, `ConfirmDialog`, `DeleteLink`, `Filters`, `HoverCard`, `Kanban`, `Link`, `Reveal`, `SortableList`, `Tooltip`

--- a/app/components/bali/qr_code/component.rb
+++ b/app/components/bali/qr_code/component.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Bali
+  module QrCode
+    # A QR code rendered server-side as inline SVG.
+    #
+    # The gem it encodes with, `rqrcode`, is deliberately *not* a dependency of
+    # bali_view_components: three apps in the org render QR codes and the rest
+    # would carry the gem for nothing. It is required the first time a component
+    # actually builds a code, and its absence raises {MissingDependency} — a
+    # LoadError subclass whose message names the line to add to the Gemfile.
+    # Same contract as the optional npm peers in package.json.
+    #
+    # @example A URL
+    #   render Bali::QrCode::Component.new(payload: movie_url(@movie))
+    #
+    # @example A TOTP enrolment code, named for the screen reader
+    #   render Bali::QrCode::Component.new(
+    #     payload: @totp.provisioning_uri, size: 240, level: :q,
+    #     label: t('.scan_with_your_authenticator')
+    #   )
+    class Component < ApplicationViewComponent
+      class MissingDependency < LoadError; end
+
+      MISSING_DEPENDENCY_MESSAGE = <<~MSG.squish
+        Bali::QrCode::Component needs the rqrcode gem, which bali_view_components
+        does not depend on. Add `gem "rqrcode", "~> 3.1"` to your Gemfile and run
+        `bundle install`.
+      MSG
+
+      # Error correction, cheapest to most redundant. A denser level survives a
+      # dirtier or partially covered code by spending modules on redundancy, so
+      # it also makes the code bigger for the same payload.
+      LEVELS = %i[l m q h].freeze
+
+      # The QR spec's quiet zone: four modules of background on every side. A code
+      # rendered flush against its neighbours is a code some scanners will not
+      # find, so it is not an option.
+      QUIET_ZONE_MODULES = 4
+
+      # Black on white, always. A scanner reads dark-on-light, and the theme's own
+      # colours would leave the code unreadable the moment a host renders it under
+      # a dark theme — which is exactly when it looks most like it works.
+      FOREGROUND = "000"
+      BACKGROUND = "fff"
+
+      DEFAULT_SIZE = 200
+      DEFAULT_LEVEL = :m
+
+      # @param payload [String] What the code encodes — a URL, an otpauth: URI, plain text (required)
+      # @param size [Integer] Rendered edge length in pixels. The SVG carries a
+      #   viewBox, so a CSS class overrides it
+      # @param level [Symbol] Error correction: :l, :m, :q or :h
+      # @param label [String, nil] Accessible name. Defaults to the generic
+      #   "QR code", which says nothing about what scanning it does — pass one
+      #   whenever the surrounding markup does not
+      # @param options [Hash] Additional HTML attributes for the svg element
+      def initialize(payload:, size: DEFAULT_SIZE, level: DEFAULT_LEVEL, label: nil, **options)
+        @payload = payload.to_s
+        @size = size
+        @level = validated_level(level)
+        @label = label
+        @options = prepend_class_name(options, "qr-code-component")
+
+        raise ArgumentError, "Bali::QrCode::Component: payload is required" if @payload.empty?
+      end
+
+      def call
+        tag.svg(**svg_attributes) { modules.html_safe }
+      end
+
+      private
+
+      def validated_level(level)
+        key = level.to_sym
+        return key if LEVELS.include?(key)
+
+        raise ArgumentError,
+              "Bali::QrCode::Component: unknown level #{key.inspect}. " \
+              "Valid: #{LEVELS.map(&:inspect).join(', ')}."
+      end
+
+      # `standalone: false` gets us the modules alone — the standalone form opens
+      # with an XML declaration, which has no business inside an HTML document.
+      # One module per user unit, so the offset counts modules and the viewBox
+      # does the scaling.
+      def modules
+        qr_code.as_svg(
+          standalone: false,
+          use_path: true,
+          module_size: 1,
+          offset: QUIET_ZONE_MODULES,
+          color: FOREGROUND,
+          fill: BACKGROUND
+        )
+      end
+
+      def svg_attributes
+        {
+          xmlns: "http://www.w3.org/2000/svg",
+          viewBox: "0 0 #{extent} #{extent}",
+          width: @size,
+          height: @size,
+          "shape-rendering": "crispEdges",
+          role: "img",
+          "aria-label": @label || I18n.t("bali_view.qr_code.label")
+        }.merge(@options)
+      end
+
+      def extent
+        qr_code.modules.size + (2 * QUIET_ZONE_MODULES)
+      end
+
+      def qr_code
+        @qr_code ||= build_qr_code
+      end
+
+      def build_qr_code
+        require "rqrcode"
+        ::RQRCode::QRCode.new(@payload, level: @level)
+      rescue ::LoadError
+        raise MissingDependency, MISSING_DEPENDENCY_MESSAGE
+      end
+    end
+  end
+end

--- a/app/components/bali/qr_code/component.rb
+++ b/app/components/bali/qr_code/component.rb
@@ -56,13 +56,13 @@ module Bali
       #   whenever the surrounding markup does not
       # @param options [Hash] Additional HTML attributes for the svg element
       def initialize(payload:, size: DEFAULT_SIZE, level: DEFAULT_LEVEL, label: nil, **options)
+        raise ArgumentError, "Bali::QrCode::Component: payload is required" if payload.blank?
+
         @payload = payload.to_s
         @size = size
         @level = validated_level(level)
         @label = label
         @options = prepend_class_name(options, "qr-code-component")
-
-        raise ArgumentError, "Bali::QrCode::Component: payload is required" if @payload.empty?
       end
 
       def call

--- a/app/components/bali/qr_code/preview.rb
+++ b/app/components/bali/qr_code/preview.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Bali
+  module QrCode
+    class Preview < ApplicationViewComponentPreview
+      # @param payload text
+      # @param size number
+      # @param level select { choices: [l, m, q, h] }
+      # A QR code generated server-side and rendered as inline SVG — no
+      # JavaScript, no image request.
+      #
+      # It needs the `rqrcode` gem, which Bali does **not** depend on. Add
+      # `gem "rqrcode", "~> 3.1"` to the host's Gemfile; without it the component
+      # raises `Bali::QrCode::Component::MissingDependency` with that same line.
+      #
+      # The code is always black on white, quiet zone included: a scanner reads
+      # dark-on-light, and theme colours would break it under a dark theme.
+      def default(payload: 'https://github.com/Grupo-AFAL/bali', size: 200, level: :m)
+        render Bali::QrCode::Component.new(payload: payload, size: size, level: level.to_sym)
+      end
+
+      # @label Error Correction Levels
+      # The same payload at every level. A denser level spends modules on
+      # redundancy, so the code survives a dirtier or partly covered surface and
+      # grows for the same payload — `:h` is what you want behind a logo overlay
+      # or on something printed, `:m` for a screen.
+      def error_correction_levels
+        render_with_template
+      end
+
+      # @label With Label
+      # The default accessible name is the generic "QR code", which says nothing
+      # about what scanning it does. Pass `label:` whenever the surrounding
+      # markup does not supply that — the SVG is `role="img"` and the label is
+      # the only name it has.
+      def with_label
+        render Bali::QrCode::Component.new(
+          payload: 'otpauth://totp/Bali:ada@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Bali',
+          label: 'Scan with your authenticator app'
+        )
+      end
+    end
+  end
+end

--- a/app/components/bali/qr_code/previews/error_correction_levels.html.erb
+++ b/app/components/bali/qr_code/previews/error_correction_levels.html.erb
@@ -1,0 +1,19 @@
+<div class="flex flex-wrap items-start gap-6">
+  <% Bali::QrCode::Component::LEVELS.each do |level| %>
+    <div class="flex flex-col items-center gap-2">
+      <%= render Bali::QrCode::Component.new(
+            payload: 'https://github.com/Grupo-AFAL/bali',
+            size: 140,
+            level: level,
+            label: "QR code, error correction #{level.to_s.upcase}"
+          ) %>
+      <span class="text-sm font-medium">level: <%= level.inspect %></span>
+    </div>
+  <% end %>
+</div>
+
+<p class="text-sm text-base-content/70 mt-4">
+  Same payload every time. The denser levels spend modules on redundancy, so the
+  code grows — <code>:h</code> recovers from roughly 30% of the surface being
+  covered, <code>:l</code> from about 7%.
+</p>

--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -608,3 +608,5 @@ en:
       user_menu:
         trigger_label: "User menu for %{name}"
         sign_out: "Sign out"
+    qr_code:
+      label: "QR code"

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -610,3 +610,5 @@ es:
       user_menu:
         trigger_label: "Menú de usuario de %{name}"
         sign_out: "Cerrar sesión"
+    qr_code:
+      label: "Código QR"

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -1893,6 +1893,41 @@ Displays key-value pairs in a zebra-striped table — useful for showing object 
 
 Prefer this over `LabelValue` or `DescriptionList` when the pairs form one set read top to bottom — the comparison of the three lives under [DescriptionList](#descriptionlist).
 
+#### QrCode
+
+A QR code generated server-side and rendered as inline SVG — no JavaScript, no image request, nothing to serve.
+
+It needs the [`rqrcode`](https://github.com/whomwah/rqrcode) gem, which Bali deliberately does **not** depend on: most apps never render a QR code and would carry the gem for nothing. Add it to the host's Gemfile:
+
+```ruby
+gem 'rqrcode', '~> 3.1'
+```
+
+Without it the first render raises `Bali::QrCode::Component::MissingDependency` — a `LoadError` subclass whose message repeats that line, so an app that forgets is told what to add rather than left with `cannot load such file`.
+
+```erb
+<%= render Bali::QrCode::Component.new(payload: movie_url(@movie)) %>
+
+<%# TOTP enrolment: name it, or the screen reader announces only "QR code" %>
+<%= render Bali::QrCode::Component.new(
+      payload: @totp.provisioning_uri,
+      size: 240,
+      level: :q,
+      label: t('.scan_with_your_authenticator')
+    ) %>
+```
+
+**Options:**
+- `payload` - What the code encodes — a URL, an `otpauth:` URI, plain text (required)
+- `size` - Rendered edge length in pixels (default: 200)
+- `level` - Error correction: `:l`, `:m`, `:q`, `:h`. Denser levels survive a dirtier or partly covered surface and make the code bigger for the same payload (default: :m)
+- `label` - Accessible name. Defaults to `bali_view.qr_code.label` — "QR code", which says nothing about what scanning it does (default: nil)
+- `**options` - Additional HTML attributes for the `svg` element
+
+The code is always black on white and includes the spec's four-module quiet zone. Neither is configurable: a scanner reads dark-on-light, so theme colours would leave the code unreadable under a dark theme — while still looking like a QR code — and one rendered flush against its neighbours is one some scanners never find.
+
+The SVG carries a `viewBox`, so `class: 'w-full h-auto'` overrides `size` where a fluid code is wanted.
+
 #### Rate
 
 Star rating built on DaisyUI's rating classes, with Rails form integration, auto-submit, and readonly display modes.

--- a/test/bali/components/qr_code_test.rb
+++ b/test/bali/components/qr_code_test.rb
@@ -26,9 +26,13 @@ class BaliQrCodeComponentTest < ComponentTestCase
     refute_equal first, rendered_content
   end
 
+  # A code with nothing in it still scans — it just resolves to an empty string,
+  # which is a bug that ships looking like a feature.
   def test_payload_is_required
-    error = assert_raises(ArgumentError) { Bali::QrCode::Component.new(payload: "") }
-    assert_match(/payload is required/, error.message)
+    [ "", "   ", nil ].each do |blank|
+      error = assert_raises(ArgumentError) { Bali::QrCode::Component.new(payload: blank) }
+      assert_match(/payload is required/, error.message)
+    end
   end
 
   # A code flush against its neighbours is a code some scanners never find, so

--- a/test/bali/components/qr_code_test.rb
+++ b/test/bali/components/qr_code_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliQrCodeComponentTest < ComponentTestCase
+  PAYLOAD = "https://github.com/Grupo-AFAL/bali"
+
+  def test_renders_an_svg_with_the_component_class
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_selector("svg.qr-code-component")
+  end
+
+  def test_renders_the_modules_as_a_single_path
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_selector("svg path")
+  end
+
+  # Two payloads that encode differently have to render differently, or the
+  # component is drawing something other than what it was given.
+  def test_encodes_the_payload
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    first = rendered_content
+
+    render_inline(Bali::QrCode::Component.new(payload: "something else"))
+
+    refute_equal first, rendered_content
+  end
+
+  def test_payload_is_required
+    error = assert_raises(ArgumentError) { Bali::QrCode::Component.new(payload: "") }
+    assert_match(/payload is required/, error.message)
+  end
+
+  # A code flush against its neighbours is a code some scanners never find, so
+  # the four-module quiet zone is part of the viewBox rather than something the
+  # host is expected to add with padding.
+  def test_viewbox_includes_the_quiet_zone_on_both_sides
+    component = Bali::QrCode::Component.new(payload: PAYLOAD)
+    render_inline(component)
+
+    modules = RQRCode::QRCode.new(PAYLOAD, level: :m).modules.size
+    extent = modules + (2 * Bali::QrCode::Component::QUIET_ZONE_MODULES)
+
+    assert_includes rendered_content, %(viewBox="0 0 #{extent} #{extent}")
+  end
+
+  # Dark-on-light is what a scanner reads. Without an opaque white plate the
+  # code inherits whatever surface it lands on, and stops scanning under a dark
+  # theme — while still looking like a QR code.
+  def test_paints_an_opaque_white_background_behind_the_modules
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_includes rendered_content, %(fill="#fff")
+    assert_includes rendered_content, %(fill="#000")
+  end
+
+  def test_size_sets_the_rendered_dimensions
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, size: 320))
+    assert_selector('svg[width="320"][height="320"]')
+  end
+
+  def test_size_defaults_to_200
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_selector('svg[width="200"][height="200"]')
+  end
+
+  # The viewBox is what makes the width/height attributes a default rather than
+  # a cage: a host class scales the code without touching the component.
+  def test_size_can_be_overridden_by_a_class
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, class: "w-full h-auto"))
+    assert_selector("svg.qr-code-component.w-full")
+  end
+
+  def test_level_changes_the_generated_code
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, level: :l))
+    lightest = rendered_content
+
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, level: :h))
+
+    refute_equal lightest, rendered_content
+  end
+
+  def test_level_accepts_every_documented_value
+    Bali::QrCode::Component::LEVELS.each do |level|
+      render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, level: level))
+      assert_selector("svg.qr-code-component")
+    end
+  end
+
+  def test_unknown_level_raises_with_the_valid_ones
+    error = assert_raises(ArgumentError) do
+      Bali::QrCode::Component.new(payload: PAYLOAD, level: :x)
+    end
+
+    assert_match(/unknown level :x/, error.message)
+    assert_match(/:l, :m, :q, :h/, error.message)
+  end
+
+  def test_a11y_exposes_the_code_as_an_image
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_selector('svg[role="img"]')
+  end
+
+  def test_a11y_names_the_code_by_default
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+    assert_selector('svg[aria-label="QR code"]')
+  end
+
+  def test_a11y_accepts_a_label_for_context
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, label: "Scan to check in"))
+    assert_selector('svg[aria-label="Scan to check in"]')
+  end
+
+  def test_a11y_translates_the_default_name
+    I18n.with_locale(:es) do
+      render_inline(Bali::QrCode::Component.new(payload: PAYLOAD))
+      assert_selector('svg[aria-label="Código QR"]')
+    end
+  end
+
+  def test_options_passthrough_merges_custom_classes
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, class: "custom-class"))
+    assert_selector("svg.qr-code-component.custom-class")
+  end
+
+  def test_options_passthrough_passes_data_attributes
+    render_inline(Bali::QrCode::Component.new(payload: PAYLOAD, data: { testid: "qr" }))
+    assert_selector('[data-testid="qr"]')
+  end
+
+  # rqrcode is not in the gemspec on purpose, so the failure a host actually
+  # meets is a missing gem at render time. It has to name the line to add: a
+  # bare `cannot load such file -- rqrcode` from inside a view component says
+  # nothing about which Gemfile or which version.
+  def test_missing_rqrcode_raises_with_installation_instructions
+    component = Bali::QrCode::Component.new(payload: PAYLOAD)
+    # The gem is installed here, so an unloadable `require` is the only way to
+    # reach the path a host without it takes.
+    component.define_singleton_method(:require) { |_name| raise LoadError }
+
+    error = assert_raises(Bali::QrCode::Component::MissingDependency) do
+      render_inline(component)
+    end
+
+    assert_match(/rqrcode/, error.message)
+    assert_match(/Gemfile/, error.message)
+    assert_match(/bundle install/, error.message)
+  end
+
+  # ...and it stays a LoadError, so a host that wants to degrade instead of
+  # blowing up can rescue the ordinary thing.
+  def test_missing_rqrcode_is_still_a_load_error
+    assert_operator Bali::QrCode::Component::MissingDependency, :<, LoadError
+  end
+end


### PR DESCRIPTION
Implementa #926 (decisión 730-1): componente server-side de generación de QR, con `rqrcode` como dependencia **opcional**.

## Qué entra

`Bali::QrCode::Component` genera el código y lo emite como SVG inline: sin JavaScript, sin request de imagen, nada que servir.

```erb
<%= render Bali::QrCode::Component.new(payload: movie_url(@movie)) %>

<%# Alta de TOTP: nombrálo, o el lector de pantalla anuncia solo "QR code" %>
<%= render Bali::QrCode::Component.new(
      payload: @totp.provisioning_uri, size: 240, level: :q,
      label: t('.scan_with_your_authenticator')
    ) %>
```

API mínima, cuatro keywords y `**options`:

| Keyword | Qué es |
|---|---|
| `payload:` | Lo que codifica — una URL, un `otpauth:`, texto plano (obligatorio) |
| `size:` | Lado renderizado en píxeles (default 200) |
| `level:` | Corrección de errores `:l` / `:m` / `:q` / `:h` (default `:m`) |
| `label:` | Nombre accesible; default `bali_view.qr_code.label` |

## La gema es opcional, y el error lo dice

El gemspec **no** la exige: tres apps de la org renderizan QRs y el resto la cargaría para nada. Se requiere perezosamente y su ausencia levanta `Bali::QrCode::Component::MissingDependency` —subclase de `LoadError`, así que un host que quiera degradar en vez de reventar rescata lo de siempre— con el mensaje que dicta la línea a agregar:

> Bali::QrCode::Component needs the rqrcode gem, which bali_view_components does not depend on. Add `gem "rqrcode", "~> 3.1"` to your Gemfile and run `bundle install`.

Mismo contrato que los peers npm opcionales de `package.json`. La gema sí entra al Gemfile de desarrollo/test, para que la suite y la preview ejerciten lo real.

## Dos cosas que no son configurables, a propósito

- **Negro sobre blanco.** Un escáner lee oscuro-sobre-claro. Con los colores del tema, el código queda ilegible bajo un tema oscuro *mientras sigue pareciendo un QR* — el peor modo de fallo posible. La placa blanca va debajo de los módulos, no del fondo del host.
- **Zona tranquila de cuatro módulos**, la del spec. Un código pegado a sus vecinos es un código que algunos escáneres no encuentran, y no es algo que el host deba acordarse de agregar con padding.

El SVG lleva `viewBox`, así que `class: 'w-full h-auto'` pisa a `size:` cuando se quiere fluido. `role="img"` más un `aria-label` que cae en el genérico traducido (en/es) y toma `label:` para el contexto que el markup de alrededor no da.

## Verificación

- **Suite completa verde**: 4158 runs, 9974 assertions, 0 failures, 0 errors. 20 tests nuevos en `test/bali/components/qr_code_test.rb` (render, `size`, los cuatro `level`, zona tranquila en el viewBox, placa blanca, a11y en los dos idiomas, passthrough de opciones, y el `LoadError` con sus instrucciones).
- **Navegador** (Lookbook en el dummy, tres previews en 200, sin errores de consola): no me quedé con "se ve un QR" — dibujé el SVG renderizado en un canvas y muestreé el centro de cada módulo. Los **29×29 módulos pintados coinciden uno a uno con la matriz de rqrcode** para ese payload, con la zona tranquila blanca en las cuatro esquinas. También lo miré bajo tema oscuro: la placa blanca aguanta.
- Rubocop limpio. Sin JS, así que sin Cypress.

Refs #926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
