### PR TITLE
perf(gantt): la isla sigue al viewport sin re-renderizar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Gantt island follows the viewport without re-rendering** (#705). Panning, dragging a bar,
+  selecting and typing in the search box each used to re-reconcile the island's entire React tree;
+  on a 300-item document (20 groups, 150 dependencies) a single pan frame rebuilt every row of the
+  left table, every tick of the axis and every bar of the minimap. No public API, markup, CSS or
+  data-contract change — only how the components subscribe to the canvas:
+  - The layers that shift as a block with the pan (time header, grid + weekend bands, row bands,
+    group summary bars, today line, left table, minimap viewport rectangle) no longer subscribe to
+    the React Flow transform with `useStore`. They take it from the store imperatively (new
+    `useViewportFollow` hook) and write `style.transform` on a ref, so a pan frame costs **zero**
+    React renders instead of one per layer plus all of its children. Measured over 20 pan frames:
+    horizontal 100 component renders → 0; vertical 20 renders + 6.400 table rows → 0.
+  - `React.memo` on the chrome (`GanttTable` and its `Row`, `Toolbar`, `TimeHeader`, `GridBands`,
+    `RowBands`, `SummaryBars`, `Minimap`, `GanttFooter`), with the toolbar's toggle callbacks
+    given stable identities so the memo actually holds. Dragging a bar re-rendered the whole
+    chrome once per pointer frame (3.200 row renders over 20 frames); it now re-renders only the
+    dragged bar. Same for the table splitter: 6.080 row renders → 0.
+  - Node decoration runs in two passes, so the `selected` bit no longer rebuilds every bar's `data`
+    object: React Flow keeps its internal node for the bars whose bit did not change and only the
+    affected ones re-render. A selection click went from 300 bar renders + 640 row renders to 1
+    and 1.
+  - `useDeferredValue` on search and status filter: the input echoes the keystroke immediately
+    while the model rebuild is deferred, so a burst of keystrokes rebuilds the filtered document
+    once instead of once per letter (9 letters: 5.760 row renders + 2.700 bar renders → 320 + 300).
+
 ## [v3.1.0.beta.2] - 2026-08-06
 
 ### Added

--- a/app/components/bali/gantt/GanttFlow.jsx
+++ b/app/components/bali/gantt/GanttFlow.jsx
@@ -16,7 +16,7 @@
 // Data arrives in the Bali::Gantt contract (see Bali::Gantt::Data):
 // { window, groups[], items[], dependencies[], critical_ids[] } — groups nest
 // one level via parent_id, items carry group_id/parent_id/name/milestone.
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -42,6 +42,7 @@ import {
   ZOOM_LEVELS
 } from './ZoomControls'
 import { useGanttModel, ROW_H, rowY, groupKey, itemKey, drawnEndsOn, DEP_PREFIX } from './useGanttModel'
+import { useViewportFollow } from './useViewportFollow'
 import { xToDate, daysBetween, durationDays, fmtDayMonth, weekendBands, timeTicks, addDaysIso, setDateLocale } from './timeScale'
 import { legendFor, normalizeCatalogs } from './ganttColors'
 import { translator } from './i18n'
@@ -103,11 +104,11 @@ function openItemDrawer (itemUrlTemplate, itemId) {
 // ---- Canvas overlays (siblings of <ReactFlow>, synced by transform) ----
 
 // Vertical grid + weekend bands. Reflect translateX (follow horizontal pans).
-function GridBands ({ ticks, weekend, height }) {
-  const translateX = useStore((s) => s.transform[0])
+const GridBands = memo(function GridBands ({ ticks, weekend, height }) {
+  const followRef = useViewportFollow('x')
   return (
     <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden'>
-      <div className='absolute inset-y-0 left-0' style={{ transform: `translateX(${translateX}px)`, willChange: 'transform' }}>
+      <div ref={followRef} className='absolute inset-y-0 left-0' style={{ willChange: 'transform' }}>
         {weekend.map((w) => (
           <div key={`we-${w.key}`} className='absolute top-0 bg-base-content/[0.035]' style={{ left: w.x, width: w.width, height }} />
         ))}
@@ -117,15 +118,15 @@ function GridBands ({ ticks, weekend, height }) {
       </div>
     </div>
   )
-}
+})
 
 // Row bands: background + label of each group, and tint of selected rows.
 // Reflect translateY (follow vertical scrolls).
-function RowBands ({ rows, selection }) {
-  const translateY = useStore((s) => s.transform[1])
+const RowBands = memo(function RowBands ({ rows, selection }) {
+  const followRef = useViewportFollow('y')
   return (
     <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden'>
-      <div className='absolute inset-x-0 top-0' style={{ transform: `translateY(${translateY}px)`, willChange: 'transform' }}>
+      <div ref={followRef} className='absolute inset-x-0 top-0' style={{ willChange: 'transform' }}>
         {rows.map((row) => {
           if (row.kind === 'group') {
             // Background band only; the group's name lives in the left table
@@ -152,16 +153,15 @@ function RowBands ({ rows, selection }) {
       </div>
     </div>
   )
-}
+})
 
 // Group summary bars (rollup with triangular caps). Reflect translateX+Y.
-function SummaryBars ({ bars, showCritical }) {
-  const tx = useStore((s) => s.transform[0])
-  const ty = useStore((s) => s.transform[1])
+const SummaryBars = memo(function SummaryBars ({ bars, showCritical }) {
+  const followRef = useViewportFollow('xy')
   if (!bars.length) return null
   return (
     <div className='pointer-events-none absolute inset-0 z-[1] overflow-hidden'>
-      <div className='absolute left-0 top-0' style={{ transform: `translate(${tx}px, ${ty}px)`, willChange: 'transform' }}>
+      <div ref={followRef} className='absolute left-0 top-0' style={{ willChange: 'transform' }}>
         {bars.map((b) => {
           const color =
             b.critical && showCritical
@@ -179,15 +179,15 @@ function SummaryBars ({ bars, showCritical }) {
       </div>
     </div>
   )
-}
+})
 
 // "Today" line + pill. Reflect translateX.
-function TodayOverlay ({ todayXValue, label }) {
-  const translateX = useStore((s) => s.transform[0])
+const TodayOverlay = memo(function TodayOverlay ({ todayXValue, label }) {
+  const followRef = useViewportFollow('x', todayXValue || 0)
   if (todayXValue == null) return null
   return (
     <div className='pointer-events-none absolute inset-0 z-20 overflow-hidden'>
-      <div className='absolute inset-y-0 left-0 w-0' style={{ transform: `translateX(${translateX + todayXValue}px)` }}>
+      <div ref={followRef} className='absolute inset-y-0 left-0 w-0'>
         <div className='absolute inset-y-0 left-0 w-0.5 bg-warning/85' />
         <div className='absolute left-0 top-0.5 grid h-4 -translate-x-1/2 place-items-center whitespace-nowrap rounded bg-warning px-1.5 text-[9px] font-bold text-warning-content'>
           {label}
@@ -195,7 +195,7 @@ function TodayOverlay ({ todayXValue, label }) {
       </div>
     </div>
   )
-}
+})
 
 // Floating buttons (bottom-left): zoom in / zoom out / fit / today.
 function FloatingControls ({ onZoomIn, onZoomOut, onFit, onToday, t }) {
@@ -242,6 +242,12 @@ function GanttCanvas (props) {
   const [collapsedIds, setCollapsedIds] = useState(() => new Set())
   const [search, setSearch] = useState('')
   const [filterStatus, setFilterStatus] = useState('all')
+  // The TOOLBAR reads the immediate values (the field echoes the keystroke at
+  // once); the MODEL reads the deferred ones, so rebuilding rows/nodes/edges
+  // for a 300-item document never blocks the keystroke. Same final result —
+  // only the priority differs.
+  const deferredSearch = useDeferredValue(search)
+  const deferredFilterStatus = useDeferredValue(filterStatus)
   const [colorBy, setColorBy] = useState('status')
   const [showCritical, setShowCritical] = useState(true)
   const [showDeps, setShowDeps] = useState(true)
@@ -392,8 +398,8 @@ function GanttCanvas (props) {
     pixelsPerDay: pxPerDay,
     criticalIds: schedule.critical_ids,
     collapsedIds,
-    search,
-    filterStatus
+    search: deferredSearch,
+    filterStatus: deferredFilterStatus
   })
 
   // X of "today" relative to windowStart (same origin as the bars). The axis
@@ -418,13 +424,15 @@ function GanttCanvas (props) {
     [t]
   )
 
-  const decoratedNodes = useMemo(
+  // Decoration in TWO passes, because they change at very different rates.
+  // (a) everything that belongs to the bar itself — rebuilt only when the
+  // schedule or a view option changes.
+  const baseNodes = useMemo(
     () =>
       model.nodes.map((n) => ({
         ...n,
         draggable: editable,
         selectable: false,
-        selected: selection.has(String(n.id)),
         data: {
           ...n.data,
           editable,
@@ -436,8 +444,28 @@ function GanttCanvas (props) {
           onResize: editable ? (side, deltaDays) => handleResize(n.data, side, deltaDays) : undefined
         }
       })),
-    [model.nodes, editable, pxPerDay, colorBy, catalogs, nodeLabels, showCritical, selection, handleResize]
+    [model.nodes, editable, pxPerDay, colorBy, catalogs, nodeLabels, showCritical, handleResize]
   )
+
+  // (b) the `selected` BIT, which changes on every click. Rebuilding `data`
+  // here too would hand React Flow a new object for all 300 bars per click
+  // and re-render every one of them; instead the previous node object is
+  // REUSED whenever its bit did not change (RF's `adoptUserNodes` keeps its
+  // internal node when the user node is identical, so those bars never
+  // re-render). When `baseNodes` itself changed there is nothing to reuse —
+  // every node object is new anyway.
+  const decoratedRef = useRef({ base: null, nodes: [] })
+  const decoratedNodes = useMemo(() => {
+    const previous = decoratedRef.current
+    const reusable = previous.base === baseNodes ? previous.nodes : null
+    const nodes = baseNodes.map((base, i) => {
+      const selected = selection.has(String(base.id))
+      const cached = reusable && reusable[i]
+      return cached && cached.selected === selected ? cached : { ...base, selected }
+    })
+    decoratedRef.current = { base: baseNodes, nodes }
+    return nodes
+  }, [baseNodes, selection])
 
   const displayEdges = useMemo(() => {
     if (!showDeps) return []
@@ -640,6 +668,11 @@ function GanttCanvas (props) {
     [effTableW]
   )
 
+  // Stable identities: an inline arrow here would give `Toolbar` a new prop on
+  // every canvas render and defeat its memo.
+  const toggleCritical = useCallback(() => setShowCritical((v) => !v), [])
+  const toggleDeps = useCallback(() => setShowDeps((v) => !v), [])
+
   const toggleCol = useCallback((key) => {
     setHiddenCols((prev) => {
       const next = new Set(prev)
@@ -759,9 +792,9 @@ function GanttCanvas (props) {
         zoom={zoom}
         onZoom={handleZoomChange}
         showCritical={showCritical}
-        onToggleCritical={() => setShowCritical((v) => !v)}
+        onToggleCritical={toggleCritical}
         showDeps={showDeps}
-        onToggleDeps={() => setShowDeps((v) => !v)}
+        onToggleDeps={toggleDeps}
         onToday={scrollToday}
         onFullscreen={onFullscreen}
         catalogs={catalogs}

--- a/app/components/bali/gantt/GanttFooter.jsx
+++ b/app/components/bali/gantt/GanttFooter.jsx
@@ -1,6 +1,7 @@
 // Bottom status bar of the Gantt: selection · counts · legend (per color-by)
 // · range · duration · critical path · progress. Purely presentational: the
 // metrics are computed in GanttFlow (already localized) and arrive as props.
+import { memo } from 'react'
 
 // Separator ("·") between metrics. At module level so React reconciles it
 // instead of remounting (defining it inside render creates a new type per
@@ -9,7 +10,7 @@ function Sep () {
   return <span className='text-base-content/30'>·</span>
 }
 
-export default function GanttFooter ({
+export default memo(function GanttFooter ({
   selectionLabel = '',
   countLabel = '',
   legend = [],
@@ -58,4 +59,4 @@ export default function GanttFooter ({
       )}
     </div>
   )
-}
+})

--- a/app/components/bali/gantt/GanttTable.jsx
+++ b/app/components/bali/gantt/GanttTable.jsx
@@ -6,10 +6,11 @@
 // the bar at y=rowY(N). It reflects the React Flow viewport's `translateY` to
 // scroll with the bars (scale pinned at zoom=1 → 1px=1px). Must render INSIDE
 // <ReactFlowProvider>.
-import { useStore } from '@xyflow/react'
+import { memo } from 'react'
 import { ROW_H } from './useGanttModel'
 import { statusColor, statusLabel, avatarColor } from './ganttColors'
 import { fmtDayMonth, durationDays } from './timeScale'
+import { useViewportFollow } from './useViewportFollow'
 
 function Caret ({ collapsed }) {
   return (
@@ -37,7 +38,7 @@ function HeaderCell ({ label, style, className = '' }) {
 
 const DEFAULT_COLS = { assignee: true, dates: true, days: true, status: true, progress: true }
 
-export default function GanttTable ({
+export default memo(function GanttTable ({
   rows,
   criticalIds,
   selectedIds,
@@ -50,7 +51,7 @@ export default function GanttTable ({
   width,
   cols = DEFAULT_COLS
 }) {
-  const translateY = useStore((s) => s.transform[1])
+  const followRef = useViewportFollow('y')
   const critical = criticalIds || new Set()
   const selected = selectedIds || new Set()
 
@@ -72,8 +73,9 @@ export default function GanttTable ({
       {/* Body shifted with the viewport (same translateY as the bars). */}
       <div className='relative min-h-0 flex-1 overflow-hidden'>
         <div
+          ref={followRef}
           className='absolute inset-x-0 top-0'
-          style={{ transform: `translateY(${translateY}px)`, willChange: 'transform' }}
+          style={{ willChange: 'transform' }}
         >
           {rows.map((row) => (
             <Row
@@ -93,9 +95,11 @@ export default function GanttTable ({
       </div>
     </div>
   )
-}
+})
 
-function Row ({ row, isCritical, isSelected, onToggle, onSelect, onOpen, catalogs, t, cols }) {
+// Memoized: the canvas re-renders on every drag/splitter/typing frame, and
+// without this each of those frames rebuilt one Row per visible row.
+const Row = memo(function Row ({ row, isCritical, isSelected, onToggle, onSelect, onOpen, catalogs, t, cols }) {
   const isGroup = row.kind === 'group'
   const item = row.item
   const label = isGroup ? row.name : item.name
@@ -210,4 +214,4 @@ function Row ({ row, isCritical, isSelected, onToggle, onSelect, onOpen, catalog
       )}
     </div>
   )
-}
+})

--- a/app/components/bali/gantt/Minimap.jsx
+++ b/app/components/bali/gantt/Minimap.jsx
@@ -1,21 +1,49 @@
 // Minimap of the Gantt: miniature bars + "today" mark + viewport rectangle;
 // click/drag to navigate. Syncs with the React Flow viewport by reading its
-// transform from the store and moving it with setViewport (scale pinned at
-// zoom=1). Must render INSIDE <ReactFlowProvider>.
-import { useCallback, useRef } from 'react'
-import { useStore, useReactFlow } from '@xyflow/react'
+// transform from the store (imperatively — see below) and moving it with
+// setViewport (scale pinned at zoom=1). Must render INSIDE
+// <ReactFlowProvider>.
+import { memo, useCallback, useLayoutEffect, useRef } from 'react'
+import { useStore, useStoreApi, useReactFlow } from '@xyflow/react'
 import { ROW_H } from './useGanttModel'
 
 const MINI_W = 204
 const MINI_H = 96
 
-export default function Minimap ({ nodes = [], canvasWidth, canvasMinX = 0, canvasHeight, todayXValue, hint }) {
+export default memo(function Minimap ({ nodes = [], canvasWidth, canvasMinX = 0, canvasHeight, todayXValue, hint }) {
   const { setViewport } = useReactFlow()
-  const tx = useStore((s) => s.transform[0])
-  const ty = useStore((s) => s.transform[1])
+  const store = useStoreApi()
+  // Pane size changes on RESIZE only, so it stays a render-time subscription;
+  // the transform does not (see the viewport rectangle effect below).
   const paneW = useStore((s) => s.width)
   const paneH = useStore((s) => s.height)
   const boxRef = useRef(null)
+  const viewportRef = useRef(null)
+
+  const sx = MINI_W / canvasWidth
+  const sy = MINI_H / Math.max(canvasHeight, 1)
+
+  // Only the viewport RECTANGLE follows the pan; the miniature bars do not.
+  // Writing its position imperatively keeps a pan frame from re-rendering the
+  // one mini bar per item this map draws. No dependency array on purpose: the
+  // map now renders so rarely that re-subscribing each time is cheaper than
+  // getting the dependency list wrong (the scales and the mount of the rect
+  // itself all have to re-place it).
+  useLayoutEffect(() => {
+    const place = ([tx, ty]) => {
+      const el = viewportRef.current
+      if (!el || !canvasWidth || !canvasHeight) return
+      el.style.left = `${Math.max(0, (-tx - canvasMinX) * sx)}px`
+      el.style.top = `${Math.max(0, -ty * sy)}px`
+    }
+    place(store.getState().transform)
+    let previous = store.getState().transform
+    return store.subscribe((state) => {
+      if (state.transform === previous) return
+      previous = state.transform
+      place(state.transform)
+    })
+  })
 
   const seek = useCallback(
     (clientX, clientY) => {
@@ -48,10 +76,6 @@ export default function Minimap ({ nodes = [], canvasWidth, canvasMinX = 0, canv
 
   if (!canvasWidth || !canvasHeight) return null
 
-  const sx = MINI_W / canvasWidth
-  const sy = MINI_H / Math.max(canvasHeight, 1)
-  const vpLeft = Math.max(0, (-tx - canvasMinX) * sx)
-  const vpTop = Math.max(0, -ty * sy)
   const vpW = Math.min(MINI_W, (paneW || 0) * sx)
   const vpH = Math.min(MINI_H, (paneH || 0) * sy)
 
@@ -88,9 +112,10 @@ export default function Minimap ({ nodes = [], canvasWidth, canvasMinX = 0, canv
         />
       )}
       <div
+        ref={viewportRef}
         className='absolute rounded-sm border-[1.5px] border-primary bg-primary/10'
-        style={{ left: vpLeft, top: vpTop, width: vpW, height: vpH }}
+        style={{ width: vpW, height: vpH }}
       />
     </div>
   )
-}
+})

--- a/app/components/bali/gantt/TimeHeader.jsx
+++ b/app/components/bali/gantt/TimeHeader.jsx
@@ -8,20 +8,19 @@
 // (minZoom=maxZoom=1) the zoom factor never enters: 1 canvas px = 1 header
 // px, and the bands (in window coords × pxPerDay) stay aligned with the bars
 // while panning. Must render INSIDE <ReactFlowProvider> for the store.
-import { useMemo } from 'react'
-import { useStore } from '@xyflow/react'
+import { memo, useMemo } from 'react'
 import { timeTicks, timeBands } from './timeScale'
+import { useViewportFollow } from './useViewportFollow'
 
 const BAND_H = 20 // upper tier (month/year context).
 const TICK_H = 28 // lower tier (day/week/month).
 export const HEADER_H = BAND_H + TICK_H // total two-tier header height (px).
 
-export default function TimeHeader ({ windowStart, windowEnd, pxPerDay, unit, origin = windowStart }) {
-  // transform = [translateX, translateY, zoom]. Only X matters (time axis).
-  const translateX = useStore((s) => s.transform[0])
-  // The translateX subscription re-renders every pan frame; ticks/bands only
-  // depend on window/scale (stable during pans), so they memoize to avoid
-  // being rebuilt per frame (same as gridTicks/weekend in GanttFlow).
+export default memo(function TimeHeader ({ windowStart, windowEnd, pxPerDay, unit, origin = windowStart }) {
+  // transform = [translateX, translateY, zoom]. Only X matters (time axis),
+  // and only the band WRAPPER uses it — `useViewportFollow` writes it
+  // imperatively so a pan frame does not re-render the ticks at all.
+  const followRef = useViewportFollow('x')
   const ticks = useMemo(
     () => timeTicks(windowStart, windowEnd, pxPerDay, unit, origin),
     [windowStart, windowEnd, pxPerDay, unit, origin]
@@ -39,8 +38,9 @@ export default function TimeHeader ({ windowStart, windowEnd, pxPerDay, unit, or
     >
       {/* Band shifted with the viewport (same translateX as the bars). */}
       <div
+        ref={followRef}
         className='absolute inset-y-0 left-0'
-        style={{ transform: `translateX(${translateX}px)`, willChange: 'transform' }}
+        style={{ willChange: 'transform' }}
       >
         {/* Upper tier: month/year context. */}
         {bands.map((band) => (
@@ -67,4 +67,4 @@ export default function TimeHeader ({ windowStart, windowEnd, pxPerDay, unit, or
       </div>
     </div>
   )
-}
+})

--- a/app/components/bali/gantt/Toolbar.jsx
+++ b/app/components/bali/gantt/Toolbar.jsx
@@ -5,7 +5,7 @@
 // (they never touch the server's schedule). Icons are inline SVG (no icon-set
 // dependency inside the React island). All texts come from the `t` translator
 // (decision D12) and the status vocabulary from `catalogs` (decision D11).
-import { useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import ZoomControls from './ZoomControls'
 import { statusColor } from './ganttColors'
 
@@ -61,7 +61,7 @@ function Segmented ({ options, value, onChange, ariaLabel }) {
   )
 }
 
-export default function Toolbar ({
+export default memo(function Toolbar ({
   search,
   onSearch,
   filterStatus,
@@ -281,4 +281,4 @@ export default function Toolbar ({
       )}
     </div>
   )
-}
+})

--- a/app/components/bali/gantt/useViewportFollow.js
+++ b/app/components/bali/gantt/useViewportFollow.js
@@ -1,0 +1,57 @@
+// Makes a chrome layer follow the React Flow pan WITHOUT re-rendering it.
+//
+// The layers that sit outside the pane (time header, grid + weekend bands,
+// row bands, group summary bars, today line, left table) are positioned in
+// canvas coordinates and shifted as a block by the viewport transform. Only
+// the WRAPPER div uses that transform — its hundreds of children (ticks,
+// rows, bars) do not depend on it at all. Subscribing with `useStore` made
+// every one of those layers re-render its whole child list once per pan
+// frame; subscribing to the store imperatively and writing `style.transform`
+// on a ref costs ZERO React renders per frame instead, which is the whole
+// point of this hook.
+//
+// The transform is deliberately absent from the element's `style` prop: React
+// only writes the style keys it knows about, so it never fights the value
+// written here.
+//
+// Must be used inside <ReactFlowProvider> (it reads the flow store).
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import { useStoreApi } from '@xyflow/react'
+
+// `axis` picks which translations the layer follows: 'x' (time axis), 'y'
+// (rows) or 'xy'. `offsetX` is a fixed canvas offset added to the horizontal
+// translation (the today line lives at a fixed x of the canvas).
+export function useViewportFollow (axis, offsetX = 0) {
+  const store = useStoreApi()
+  const ref = useRef(null)
+
+  const write = useCallback(
+    ([x, y]) => {
+      const el = ref.current
+      if (!el) return
+      if (axis === 'y') el.style.transform = `translateY(${y}px)`
+      else if (axis === 'x') el.style.transform = `translateX(${x + offsetX}px)`
+      else el.style.transform = `translate(${x}px, ${y}px)`
+    },
+    [axis, offsetX]
+  )
+
+  // On every render (mount included, and after a layer that returned null
+  // starts rendering) put the CURRENT transform on the element: the
+  // subscription below only fires on later changes.
+  useLayoutEffect(() => write(store.getState().transform))
+
+  useLayoutEffect(() => {
+    // The flow store is a plain zustand store: `subscribe` takes no selector,
+    // so the listener runs on every store change and compares the transform
+    // tuple by reference itself (React Flow replaces the array on each pan).
+    let previous = store.getState().transform
+    return store.subscribe((state) => {
+      if (state.transform === previous) return
+      previous = state.transform
+      write(state.transform)
+    })
+  }, [store, write])
+
+  return ref
+}


### PR DESCRIPTION
## Contexto

El reporte de performance de la isla Gantt del 06/08 (`docs/plans/v3.1/gantt-performance.md`)
midió que el costo no está en los datos ni en el reconcile servidor-autoritativo, sino en **cómo
la vista sigue al viewport**: siete componentes se suscriben al `transform` de React Flow con
`useStore` y re-renderizan sus hijos completos por frame, y ningún componente de chrome está
memoizado, así que cualquier `setState` del canvas (drag, tecleo, splitter) arrastra al árbol
entero.

Este PR implementa los cuatro hallazgos marcados como behavior-preserving (1, 2+5, 3 y 4), en
orden de ROI. **Cero cambios de API pública, de markup observable, de CSS y de contrato de datos**:
solo cambia cómo los componentes se suscriben al canvas.

Va **antes de #719** a propósito: la fase 3 va a medir el swap `:static` → isla (gate D16), y
medir ese swap contra una isla que janquea por su cuenta contamina la medición.

## Qué cambia

1. **Hallazgo 1 — el viewport se sigue sin re-renderizar** (nuevo hook `useViewportFollow`).
   Las capas que se desplazan en bloque con el paneo (cabecera de tiempo, grid + bandas de fin de
   semana, bandas de fila, barras resumen, línea de hoy, tabla izquierda, rectángulo del minimapa)
   ya no leen el transform con `useStore`: lo toman del store de forma imperativa y escriben
   `style.transform` sobre un ref. Elegí la **opción (b) del reporte para todas las capas**, no la
   (a): el `useMemo` de los hijos evita reconstruir el array pero igual commitea el componente por
   frame, y el presupuesto del reporte para el paneo es *cero*. El riesgo de la (b) —que el ref no
   esté montado— se resuelve con un `useLayoutEffect` sin deps que reaplica el transform actual en
   cada render, de modo que una capa que devuelve `null` (SummaryBars sin barras, TodayOverlay sin
   fecha) queda alineada en cuanto vuelve a pintarse.
   El minimapa lleva su propio efecto en vez del hook porque lo que sigue al paneo no es un
   `transform` sino el `left`/`top` del rectángulo de viewport, escalados por el tamaño del canvas.

2. **Hallazgos 2+5 — `React.memo` en el chrome** (`GanttTable` y su `Row`, `Toolbar`, `TimeHeader`,
   `GridBands`, `RowBands`, `SummaryBars`, `Minimap`, `GanttFooter`). Verifiqué que las props sean
   estables durante el drag: las únicas que no lo eran son los toggles Critical/Deps del toolbar,
   que eran arrows inline y ahora son `useCallback`. `FloatingControls` queda fuera a propósito
   (cuatro botones, y sus props son arrows inline por diseño).

3. **Hallazgo 3 — decoración de nodos en dos pasadas.** La pasada (a) arma la `data` de la barra
   (deps: `model.nodes`, `editable`, `pxPerDay`, `colorBy`, `catalogs`, `nodeLabels`,
   `showCritical`, `handleResize` — con `is_critical && showCritical` dentro, como pedía el
   reporte); la (b) solo aplica el bit `selected`, **reutilizando el objeto de nodo anterior**
   cuando el bit no cambió. Eso es lo que hace que rinda: `adoptUserNodes` de React Flow corre con
   `checkEquality: true` y conserva su nodo interno cuando el objeto de usuario es idéntico, así
   que el `NodeWrapper` memoizado de esas barras ni se re-renderiza. Reutilizar solo la referencia
   de `data` no habría bastado.

4. **Hallazgo 4 — `useDeferredValue`** en `search` y `filterStatus`. El toolbar sigue leyendo los
   valores inmediatos (el campo refleja la tecla al instante) y el modelo lee los diferidos.

## Mediciones (antes / después)

Dataset del reporte: **300 items / 20 grupos (321 filas de tabla) / 150 dependencias**, zoom
semana, sobre un preview Lookbook temporal (`island_stress`, borrado antes del commit). Método:
instrumentación temporal — un contador en el cuerpo de cada componente — medida sobre el código
original y sobre el nuevo, y retirada antes del commit final. Las cifras son **renders de React
por interacción**, no milisegundos: son deterministas y no dependen de la máquina.

| Interacción | Qué se mide | Antes | Después |
|---|---|---|---|
| **Paneo horizontal**, 20 frames | TimeHeader + GridBands + SummaryBars + TodayOverlay + Minimap | 100 (20 c/u) | **0** |
| **Paneo vertical**, 20 frames | GanttTable | 20 | **0** |
| | filas de la tabla | 6.400 | **0** |
| | RowBands + SummaryBars + Minimap | 60 (20 c/u) | **0** |
| **Drag de una barra**, 20 frames de puntero (10 commits) | chrome completo (9 componentes) | 90 (10 c/u) | **0** |
| | filas de la tabla | 3.200 | **0** |
| | TaskBarNode | 11 (solo la barra arrastrada) | 11 (igual) |
| | GanttCanvas | 10 | 10 (es el dueño del estado) |
| **Clic de selección** | barras | 300 | **1** |
| | filas de la tabla | 640 | **1** |
| | chrome | 2 renders de cada uno de los 9 | GanttTable 1, RowBands 1, GanttFooter 1, resto **0** |
| **Tecleo, 9 letras** (todas hacen match) | filas de la tabla | 5.760 | **320** |
| | barras | 2.700 | **300** |
| | Toolbar | 18 | 9 (una por tecla: es quien tiene el input) |
| **Splitter de la tabla**, 20 frames | filas de la tabla | 6.080 | **0** |
| | GanttTable | 19 | 19 (su `width` sí cambia) |

El presupuesto del reporte para el paneo era "0 commits de React por frame fuera del
viewport-follow interno de RF": se cumple en los dos ejes. El de selección era "re-render solo de
las barras cuyo `selected` cambió (+tabla)": 1 barra y 1 fila. El de drag era "por frame, solo el
nodo arrastrado; chrome 0 re-renders": exacto.

Sobre el tecleo: el modelo filtrado se reconstruye **una vez** al final de la ráfaga en lugar de
una vez por letra, porque React descarta los valores diferidos intermedios cuando llega otra tecla
antes de que el render de baja prioridad commitee. El resultado final es idéntico; tecleando lento
se reconstruiría más de una vez, que es exactamente lo que se busca.

## Qué NO se tocó, y por qué

- **El clamp de `onMove` (hallazgo 8).** Fuera de alcance por instrucción, y con razón: el clamp
  permite `x` hasta `+leftRoom` y `translateExtent` no cubre ese caso de forma obviamente
  equivalente. Cambiarlo pide una comprobación de paridad propia, no un PR de performance.
- **El `ResizeObserver` sobre `document.body` (hallazgo 9).** Fuera de alcance. Su costo real es
  casi nulo (el `setState` con valores iguales hace bail-out); es un acoplamiento feo, no un
  problema de rendimiento.
- El payload/serializer (hallazgo 7) y el doble costo del `:static` (hallazgo 6) son decisiones de
  #719 y #720, no de este PR.

## Verificación

- **Cypress**: `gantt-island.cy.js` 5/5 en verde, y la suite completa también.
- **Minitest**: 4.138 runs, 9.934 asserts, 0 failures, 0 errors, 0 skips.
- **Browser** (obligatorio por CLAUDE.md), sobre el dummy de este worktree: se ejercitaron a mano
  paneo en ambos ejes, drag con PATCH real contra el endpoint del dummy (`200`, el servidor
  reconcilia y la tabla muestra las fechas nuevas), resize por el handle derecho (11 → 14 días,
  `200`) y su vuelta, selección (tinte de fila + anillo en la barra + "1 selected" en el footer),
  búsqueda (321 → 22 filas y de vuelta a 321), colapso de grupo (321 → 306), zoom
  (semana 48px → día 144px, con el param `gantt_zoom` reescrito sin navegar), color-by, minimapa
  (clic que navega) y botón Today. Sin toasts de error en ningún paso.
- **Alineación tabla ↔ barras tras el paneo** — el riesgo real del enfoque imperativo: con el
  viewport en `(-40, -24)`, las cinco capas llevaban exactamente `translateY(-24px)`,
  `translateX(-40px)`, `translateX(-40px)`, `translateY(-24px)` y `translate(-40px, -24px)`, y la
  barra de un item quedó 6px por debajo del top de su fila, que es justo el centrado vertical de la
  barra dentro de la fila (`(ROW_H - BAR_H) / 2`).

Screenshot de la isla editable con el build final (12 items, aristas de dependencia con el camino
crítico en rojo, hito en diamante, barras resumen, línea de hoy, minimapa y footer) adjunto en el
reporte de la sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
