### PR TITLE
fix(cypress): el spec del gantt deja de degradar la DB del dummy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Gantt island's drag spec no longer degrades the dummy database it runs against** (#705).
+  `gantt-island.cy.js` dragged a bar forward and then dragged it back "the same distance" to
+  restore the seeded dates. The return drag is not the inverse of the outbound one — measured on
+  the seeded fixture, the outbound drag moves the item 5 days and the return drag moves it 0 — so
+  every local run left the item ~5 days later than it found it. Once the item drifted past the
+  start of the next one, the return drag landed on the date the item already had,
+  `onNodeDragStop` short-circuited before posting, and `cy.wait('@patch')` timed out waiting for a
+  second request that never came. CI never saw it because every CI run does
+  `db:schema:load db:seed` first; locally it surfaced after a handful of repetitions and looked
+  like a race in the island. The spec now waits for the reconcile to land in the table before
+  asserting, and restores the item through the contract's own PATCH endpoint instead of through a
+  second drag — deterministic, and it leaves the database exactly as it found it. Verified with 8
+  consecutive runs: 8/8 green with the seeded dates unchanged (before: 0/8 from a drifted
+  database).
+
 ### Added
 
 - **`Bali::WorkflowSteps` gets the horizontal "quick flow" and the decision-form pattern** (#716). `variant: :horizontal` renders the same steps as a row of cards with an N/M progress bar on top — the shape for a summary card or a table cell, where the whole chain has to fit in a glance. Same `with_step` API; the marker becomes a dot and there are no connectors, because the bar already says how far the flow got. **N counts the steps with a verdict** (`:success`, `:error`, `:warning`, `:skipped`): a skipped step is settled and it is still one of the dots on screen, so counting it keeps N/M matching what the reader can count; `:pending` and `:current` are the two that have not happened yet. **The bar takes the flow's verdict** — red if any step was rejected, amber if any came back with observations, neutral otherwise — so a broken chain reads as broken without reading it. `progress: false` drops the bar; asking for one on the vertical variant raises, since that shape has no header to hang it on. The cards wrap on their own (`auto-fit` from 11rem) instead of shrinking past reading width, and `:skipped` draws a **hollow** dot rather than the vertical variant's dash: with no number left to read, two greys at that size were the same dot.

--- a/cypress/e2e/gantt-island.cy.js
+++ b/cypress/e2e/gantt-island.cy.js
@@ -16,6 +16,9 @@ const instancias = (win) =>
 
 const anchoDe = ($el) => $el[0].getBoundingClientRect().width
 
+// Fila de la tabla de un item, por su nombre (el `title` de la fila).
+const filaDe = (nombre) => cy.get(`div[title="${nombre}"]`).filter('[class*="cursor-pointer"]')
+
 // Arrastra un nodo de React Flow `dx` px en horizontal. d3-drag escucha
 // mousedown en el nodo y sigue mousemove/mouseup en la window del AUT — los
 // eventos sinteticos necesitan `view: win` (d3 hace select(event.view)) o
@@ -119,22 +122,57 @@ describe('Gantt island', () => {
     // Editable: los handles de resize existen (aparecen en hover).
     cy.get('.cursor-ew-resize').should('exist')
 
-    // Ida: +10 dias en zoom week (8 px/dia).
-    arrastrarNodo('.react-flow__node', 80)
-    cy.wait('@patch').then(({ request, response }) => {
-      expect(request.body.item.id).to.be.a('number')
-      expect(request.body.item.starts_on).to.match(/^\d{4}-\d{2}-\d{2}$/)
-      expect(request.body.item.duration_days).to.be.greaterThan(0)
-      expect(response.statusCode).to.equal(200)
-      // Reconcile: el documento COMPLETO, no un parche.
-      expect(response.body).to.have.all.keys('groups', 'items', 'dependencies', 'critical_ids')
+    // Las ediciones PERSISTEN en la DB del dummy y este spec corre una y otra
+    // vez contra la misma. Se guarda el estado del item para devolverlo por el
+    // mismo endpoint del contrato al final.
+    //
+    // Antes la vuelta se hacia con un segundo drag de la misma distancia, y NO
+    // funciona: el arrastre de vuelta no es el inverso del de ida (medido: la
+    // ida mueve 5 dias, la vuelta 0), asi que la fecha derivaba ~5 dias por
+    // corrida hasta que el item pasaba al siguiente y el `cy.wait` del segundo
+    // PATCH moria por timeout. En CI nunca se vio porque cada corrida hace
+    // `db:schema:load db:seed`; en local aparecia a las pocas repeticiones.
+    cy.get('[data-controller="gantt"]').then(($isla) => {
+      const items = JSON.parse($isla.attr('data-gantt-data-value')).items
+      const id = Number(Cypress.$('.react-flow__node').first().attr('data-id'))
+      const item = items.find((i) => Number(i.id) === id)
+      cy.wrap({
+        // Absoluta: `cy.request` resuelve una relativa contra el baseUrl, que
+        // aqui apunta dentro de Lookbook y no al endpoint.
+        url: `${window.location.origin}${$isla.attr('data-gantt-patch-url-value')}`,
+        id,
+        nombre: item.name,
+        startsOn: item.starts_on,
+        dias: Math.round((Date.parse(item.ends_on) - Date.parse(item.starts_on)) / 86400000) + 1
+      }).as('itemArrastrado')
     })
-    cy.get('.react-flow__node').should('have.length.greaterThan', 0).and('be.visible')
-    cy.get('.alert-error').should('not.exist')
 
-    // Vuelta: restaura las fechas del seed (misma distancia, snap identico).
-    arrastrarNodo('.react-flow__node', -80)
-    cy.wait('@patch').its('response.statusCode').should('equal', 200)
-    cy.get('.alert-error').should('not.exist')
+    // La fila del item ARRASTRADO (por su nombre, no por posicion: el orden de
+    // las filas depende de las fechas) es el testigo del reconcile — tabla y
+    // barras salen del MISMO `rows`, y el 200 del PATCH llega antes de que
+    // React reposicione nada.
+    cy.get('@itemArrastrado').then(({ nombre }) => {
+      filaDe(nombre).invoke('text').then((textoInicial) => {
+        arrastrarNodo('.react-flow__node', 80)
+        cy.wait('@patch').then(({ request, response }) => {
+          expect(request.body.item.id).to.be.a('number')
+          expect(request.body.item.starts_on).to.match(/^\d{4}-\d{2}-\d{2}$/)
+          expect(request.body.item.duration_days).to.be.greaterThan(0)
+          expect(response.statusCode).to.equal(200)
+          // Reconcile: el documento COMPLETO, no un parche.
+          expect(response.body).to.have.all.keys('groups', 'items', 'dependencies', 'critical_ids')
+        })
+        filaDe(nombre).should('not.have.text', textoInicial)
+        cy.get('.react-flow__node').should('have.length.greaterThan', 0).and('be.visible')
+        cy.get('.alert-error').should('not.exist')
+      })
+    })
+
+    // Restaura por API: determinista, y deja la DB como la encontro.
+    cy.get('@itemArrastrado').then(({ url, id, startsOn, dias }) => {
+      cy.request('PATCH', url, { item: { id, starts_on: startsOn, duration_days: dias } })
+        .its('status')
+        .should('equal', 200)
+    })
   })
 })


### PR DESCRIPTION
## Qué pasaba

Reportado desde #707/#944: `gantt-island.cy.js` → "arrastrar una barra postea el PATCH del
contrato y reconcilia" quedó flaky (pasa/pasa/falla), siempre con

```
cy.wait() timed out waiting 5000ms for the 2nd request to the route: `patch`.
No request ever occurred.
```

La sospecha razonable era que lo había roto #942 (el PR de performance de la isla), porque toca
justo la superficie del drag. **No es eso.** Medido abajo: el flake es anterior y no depende del
render, sino de que **el spec degrada la base de datos del dummy en cada corrida**.

## La causa, medida

El test arrastra la barra +80px y luego −80px "la misma distancia" para restaurar las fechas del
seed. La vuelta **no es el inverso de la ida**:

- ida: +80px pedidos → el item se mueve **5 días** (el PATCH que sale lo confirma: `7 Jun` → `12 Jun`)
- vuelta: −80px pedidos → el item se mueve **0 días**

Como el dummy **persiste** las ediciones (lo dice el propio comentario del spec), cada corrida deja
el item ~5 días más tarde de como lo encontró. Medido corriendo el spec 8 veces seguidas, leyendo
la DB antes de cada una:

```
run 1: PASS | item 1 = 2026-06-07   (seed)
run 2: PASS | item 1 = 2026-06-12
run 3: PASS | item 1 = 2026-06-17
run 4: FAIL | item 1 = 2026-06-18   <-- alcanza el arranque del item 2 (18 Jun)
run 5: FAIL | item 1 = 2026-06-23
run 6: FAIL | item 1 = 2026-06-28
run 7: PASS | item 1 = 2026-07-03
run 8: FAIL | item 1 = 2026-07-03
```

El punto de quiebre no es casual: mientras el item arrastrado es el más temprano del documento, él
define el `windowStart`, así que tras el reconcile su barra vuelve a `x=0` y la vuelta espeja a la
ida. En cuanto la deriva lo lleva más allá del arranque del siguiente item, la ventana deja de
seguirlo, la geometría cambia y el drag de vuelta cae sobre la fecha que el item ya tenía →
`onNodeDragStop` corta antes de postear → no hay segundo PATCH → timeout.

**CI nunca lo vio** porque `.github/workflows/cypress.yml` hace `db:schema:load db:seed` antes de
cada corrida. En local, tras un puñado de repeticiones, aparece.

## Por qué no es de #942

Mismo árbol (`3.1` en `ffabd1ad`), misma DB seedeada de cero, 8 corridas seguidas, cambiando
**solo** el directorio `app/components/bali/gantt/`:

| Isla | Resultado |
|---|---|
| con #942 (lo que hay en `3.1`) | **3 PASS / 5 FAIL** — pasa mientras el item sigue siendo el más temprano |
| revertida a pre-#942 (`9081963a`) | **0 PASS / 8 FAIL** — falla ya en la primera, desde el seed intacto |

La deriva de +5 días por corrida es **idéntica en las dos**. Es decir: el flake es anterior a #942
y, en esta máquina, #942 lo hace fallar *menos*, no más. (Verifiqué que el bundle revertido era de
verdad el viejo: 0 ocurrencias de `useViewportFollow`, 3 de los `translateX(${…})` inline.)

## El arreglo

Solo toca el spec:

- **Espera a que el reconcile aterrice** en la tabla antes de seguir. El `200` del PATCH llega
  antes de que React reposicione la barra, y cualquier cosa que mida geometría en esa ventana mide
  la vieja.
- **Localiza la fila por el nombre del item**, no por su posición: el orden de las filas depende de
  las fechas, así que con la DB derivada el índice fijo apuntaba a otra fila (esto lo descubrí
  cuando mi primer intento de arreglo falló contra una DB muy derivada).
- **Restaura el item por el propio endpoint del contrato** (`cy.request` PATCH) en vez de con un
  segundo drag. Determinista, y deja la DB exactamente como la encontró. La URL va absoluta a
  propósito: `cy.request` resuelve una relativa contra el `baseUrl`, que aquí apunta dentro de
  Lookbook.

Se pierde la aserción "el segundo drag también postea", que era redundante (mismo camino de código
que el primero) y que además nunca hizo lo que su comentario decía.

## Verificación

- **8 corridas consecutivas sin reseed: 8/8 en verde**, y las fechas del seed intactas en las 8
  (`item 1 = 2026-06-07` antes de cada una). Antes, desde una DB derivada: 0/8.
- La suite completa la corre el CI de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
