### PR TITLE
feat(chat): superficie de conversación — burbuja, typing-indicator y contenedor con autoscroll (#927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::Chat` — the conversation surface, extracted from the two apps that had already built it twice** (#927). Three components that compose: `Bali::Chat::Component` is the scrollable region and the Turbo Stream append target, `Bali::Chat::Message::Component` is one bubble over daisyUI's `chat` grid, and `Bali::Chat::TypingIndicator::Component` is the "…is typing" placeholder. They ship no CSS at all — daisyUI's `chat`, `chat-start`/`chat-end`, `chat-bubble-*` and `loading-dots` already draw every part of this, and the bubble colour map is written out longhand so Tailwind's scanner can see the class names it has to emit.
+
+  **The container follows a new message only when the reader was already at the bottom.** Both source implementations force-scroll on every DOM mutation, so an answer arriving while you are up in the history yanks you back down mid-sentence; `threshold:` (64px by default) says how close to the bottom still counts as following along. The decision is taken from the position recorded by the last real `scroll` event rather than measured when the message lands: an append grows `scrollHeight` while `scrollTop` stays put, so a check made afterwards reads "at the bottom" as "scrolled up by exactly the height of what just arrived" — which is why the naive version of this is always subtly wrong.
+
+  **The typing indicator lives in the DOM permanently and hides behind a class**, which is the repo's pattern and also a fix. One of the two apps anchors its Turbo Streams to a bare `<div id="typing-indicator">` and then `broadcast_remove_to`s it, destroying the anchor: from the second message on, the `turbo_stream.replace` that should bring the indicator back silently does nothing. A node that is never removed cannot lose its anchor. Toggle it from the server by replacing it with `visible: true`/`false`, or from the page through `chat#showTyping` / `chat#hideTyping` — the indicator registers itself as a target of the container's controller, so `data: { action: 'turbo:submit-end->chat#showTyping' }` on the composer is the whole wiring.
+
+  **The API is daisyUI's vocabulary, not either app's role enum.** The two implementations both compute a side and a colour from their own `user`/`assistant` roles and then disagree on the colour, so `position:` (`:start`/`:end`) and `color:` are what the component takes, and each host keeps its own names. It also means a support chat between two humans reads no worse than an AI one. `author:`/`timestamp:` fill the header (the timestamp as a `<time>` with a machine-readable `datetime`), and the `avatar`, `header` and `footer` slots fill the rest of daisyUI's grid — the footer is where one app hangs the source documents an answer was drawn from.
+
+  **The bubble body is passed through untouched — no escaping, no sanitising, no `raw`.** Both apps render Markdown a language model produced, and clean it, through their own helper; which of those a host wants is a policy decision that belongs with the host, and a `raw` here would quietly take it away. Lookbook previews for the live conversation, every bubble shape, and the indicator, plus a Cypress spec that measures `scrollTop`/`scrollHeight` through all four autoscroll cases.
+
 ## [v3.1.0.beta.5] - 2026-08-06
 
 ### Added

--- a/app/components/bali/chat/component.html.erb
+++ b/app/components/bali/chat/component.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(**wrapper_attributes) do %>
+  <%# `scroll->chat#trackPosition` has to sit on the element that scrolls: scroll
+      events do not bubble, so the same action on the wrapper would never fire and
+      the controller would think the reader never left the bottom. %>
+  <%= tag.div(id: id, class: messages_classes,
+              data: { chat_target: "messages", action: "scroll->chat#trackPosition" }) do %>
+    <%= content %>
+  <% end %>
+  <% if footer? %>
+    <div class="shrink-0 border-t border-base-300 p-4"><%= footer %></div>
+  <% end %>
+<% end %>

--- a/app/components/bali/chat/component.rb
+++ b/app/components/bali/chat/component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Bali
+  module Chat
+    # Scrollable conversation container — the Turbo Stream append target plus the
+    # autoscroll that makes a live conversation readable.
+    #
+    # Extracted from two hand-rolled chats (afal-apps' TDFlow interview and
+    # gobierno-corporativo's document assistant). Both force-scroll to the bottom
+    # on every DOM mutation, which yanks a reader who scrolled up into the history
+    # back down the moment an answer lands. This container follows the conversation
+    # only when the reader was already at the bottom; `threshold:` says how close
+    # that has to be.
+    #
+    # The height is the host's to decide. The wrapper is a flex column with no size
+    # of its own, so pass `class: 'h-[60vh]'` (or a max-height, or let a flex parent
+    # size it) and the message region takes what is left.
+    #
+    #   <%= render Bali::Chat::Component.new(id: 'messages', class: 'h-[60vh]') do |chat| %>
+    #     <%= render Bali::Chat::Message::Component.new(position: :end, color: :primary) do %>
+    #       Hello
+    #     <% end %>
+    #     <%= render Bali::Chat::TypingIndicator::Component.new %>
+    #     <% chat.with_footer do %><%= render 'form' %><% end %>
+    #   <% end %>
+    #
+    # and from the controller or the job that answers:
+    #
+    #   turbo_stream.append 'messages', partial: 'messages/message', locals: { message: }
+    class Component < ApplicationViewComponent
+      renders_one :footer
+
+      # @param id [String] DOM id of the scrollable message region — the target a
+      #   Turbo Stream appends into (`turbo_stream.append 'chat-messages'`). Give
+      #   each chat on a page its own id.
+      # @param threshold [Integer] How many pixels short of the bottom still count
+      #   as "at the bottom" when deciding whether to follow a new message.
+      #   Sub-pixel layout rounding means an exact 0 rarely holds, so the default
+      #   carries a little slack rather than a fudge factor.
+      # @param messages_class [String, nil] Extra classes for the scrollable region.
+      #   Padding and the gap between messages live here: the two implementations
+      #   this came from disagreed (`p-4`/`space-y-4` against `p-5`/`gap-3`), so the
+      #   default is one of them and the other passes a string.
+      def initialize(id: "chat-messages", threshold: 64, messages_class: nil, **options)
+        @id = id
+        @threshold = threshold
+        @messages_class = messages_class
+        @options = options
+      end
+
+      private
+
+      attr_reader :id, :threshold, :messages_class, :options
+
+      def wrapper_attributes
+        attrs = prepend_controller(options.dup, "chat")
+        attrs = prepend_values(attrs, "chat", threshold: threshold)
+        prepend_class_name(attrs, "bali-chat flex flex-col min-h-0")
+      end
+
+      def messages_classes
+        class_names("flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-4", messages_class)
+      end
+    end
+  end
+end

--- a/app/components/bali/chat/index.js
+++ b/app/components/bali/chat/index.js
@@ -1,0 +1,80 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * Chat container controller — keeps a live conversation scrolled to the latest
+ * message without taking the scrollbar away from someone reading history.
+ *
+ * Targets:
+ *   - messages  the scrollable region, and the Turbo Stream append target
+ *   - typing    zero or more typing indicators, shown/hidden by class
+ *
+ * Values:
+ *   - threshold  px short of the bottom that still counts as "at the bottom"
+ *
+ * Actions:
+ *   - trackPosition  bound to `scroll` on the messages element by the component
+ *   - showTyping / hideTyping  for a host that drives the indicator from the page
+ *     rather than from a Turbo Stream (e.g. `turbo:submit-end->chat#showTyping`)
+ *
+ * Whether to follow a new message has to be decided from the position the reader
+ * was in BEFORE it arrived: appending grows scrollHeight while scrollTop stays
+ * put, so by the time the MutationObserver runs, an element that was at the bottom
+ * measures as scrolled up by exactly the height of what just arrived. Hence the
+ * flag, refreshed from real scroll events — which an append does not produce.
+ */
+export class ChatController extends Controller {
+  static targets = ['messages', 'typing']
+
+  static values = {
+    threshold: { type: Number, default: 64 }
+  }
+
+  connect () {
+    if (!this.hasMessagesTarget) return
+
+    this.atBottom = true
+    this.scrollToBottom()
+    // Web fonts and images can still change the height after connect, which would
+    // leave the first paint a little short of the bottom.
+    this.settleFrame = window.requestAnimationFrame(() => this.autoscroll())
+
+    this.observer = new MutationObserver(() => this.autoscroll())
+    this.observer.observe(this.messagesTarget, { childList: true })
+  }
+
+  disconnect () {
+    window.cancelAnimationFrame(this.settleFrame)
+    this.observer?.disconnect()
+  }
+
+  trackPosition () {
+    this.atBottom = this.distanceFromBottom <= this.thresholdValue
+  }
+
+  autoscroll () {
+    if (this.atBottom) this.scrollToBottom()
+  }
+
+  // Sending a message is an act of participation, not of reading: follow the
+  // conversation down even if the reader had scrolled up.
+  showTyping () {
+    this.typingTargets.forEach(element => element.classList.remove('hidden'))
+    this.scrollToBottom()
+  }
+
+  hideTyping () {
+    this.typingTargets.forEach(element => element.classList.add('hidden'))
+  }
+
+  scrollToBottom () {
+    if (!this.hasMessagesTarget) return
+
+    this.messagesTarget.scrollTop = this.messagesTarget.scrollHeight
+    this.atBottom = true
+  }
+
+  get distanceFromBottom () {
+    const element = this.messagesTarget
+    return element.scrollHeight - element.scrollTop - element.clientHeight
+  }
+}

--- a/app/components/bali/chat/message/component.html.erb
+++ b/app/components/bali/chat/message/component.html.erb
@@ -1,0 +1,21 @@
+<%= tag.div(**message_attributes) do %>
+  <% if avatar? %>
+    <div class="chat-image"><%= avatar %></div>
+  <% end %>
+  <% if render_header? %>
+    <div class="chat-header">
+      <% if header? %>
+        <%= header %>
+      <% else %>
+        <%= author %>
+        <% if timestamp_text %>
+          <%= tag.time(timestamp_text, class: "text-xs opacity-50", datetime: timestamp_datetime) %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="<%= bubble_classes %>"><%= content %></div>
+  <% if footer? %>
+    <div class="chat-footer"><%= footer %></div>
+  <% end %>
+<% end %>

--- a/app/components/bali/chat/message/component.rb
+++ b/app/components/bali/chat/message/component.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Bali
+  module Chat
+    module Message
+      # One conversation bubble, over daisyUI's `chat` grid.
+      #
+      # Deliberately not "user vs assistant": both implementations this was
+      # extracted from compute a side and a colour from their own role enum, and
+      # they disagree on the colour (`chat-bubble-neutral` against a bordered
+      # `bg-base-200`). What they share is the daisyUI vocabulary, so that is the
+      # API — the host keeps its own role names and maps them here. A support chat
+      # between two humans reads no worse for it than an AI one.
+      #
+      # The bubble body is whatever the host passes as content, unescaped and
+      # unsanitised. Both sources render Markdown produced by a language model
+      # through their own helper (Commonmarker with `unsafe: false` in one, Kramdown
+      # plus Rails' `sanitize` in the other); which of those a host wants is not this
+      # component's business, and a `raw` here would take the decision away.
+      class Component < ApplicationViewComponent
+        POSITIONS = {
+          start: "chat-start",
+          end: "chat-end"
+        }.freeze
+
+        # Spelled out rather than interpolated: Tailwind scans this file for class
+        # names, and daisyUI only emits the rules it sees used. `"chat-bubble-#{color}"`
+        # would compile to nothing.
+        COLORS = {
+          neutral: "chat-bubble-neutral",
+          primary: "chat-bubble-primary",
+          secondary: "chat-bubble-secondary",
+          accent: "chat-bubble-accent",
+          info: "chat-bubble-info",
+          success: "chat-bubble-success",
+          warning: "chat-bubble-warning",
+          error: "chat-bubble-error"
+        }.freeze
+
+        renders_one :avatar
+        renders_one :header
+        renders_one :footer
+
+        # @param position [Symbol] `:start` (left — the other party) or `:end`
+        #   (right — the reader's own message). daisyUI's own names, and RTL-aware.
+        # @param color [Symbol, nil] daisyUI bubble colour. `nil` leaves the default
+        #   `base-300` bubble, which is what a neutral incoming message wants.
+        # @param author [String, nil] Name above the bubble. Renders a `chat-header`.
+        # @param timestamp [Time, Date, String, nil] Shown next to the author in a
+        #   `<time>` with a machine-readable `datetime`. A String is printed as given.
+        # @param timestamp_format [Symbol] `I18n.l` format for the timestamp.
+        # @param bubble_class [String, nil] Extra classes for the bubble itself —
+        #   a width cap (`max-w-[82%]`), a border, or the `prose` wrapper a Markdown
+        #   body needs.
+        def initialize(position: :start, color: nil, author: nil, timestamp: nil,
+                       timestamp_format: :short, bubble_class: nil, **options)
+          @position = position&.to_sym
+          @color = color&.to_sym
+          @author = author
+          @timestamp = timestamp
+          @timestamp_format = timestamp_format
+          @bubble_class = bubble_class
+          @options = options
+        end
+
+        # Slots set inside the render block only register once `content` runs, and
+        # the avatar and the header are emitted *before* the bubble. Without this
+        # they would be asked about while still unset, and silently skipped.
+        def before_render
+          content
+        end
+
+        def render_header?
+          header? || author.present? || timestamp_text.present?
+        end
+
+        def timestamp_text
+          return if timestamp.blank?
+
+          @timestamp_text ||= if timestamp.respond_to?(:strftime)
+            I18n.l(timestamp, format: timestamp_format)
+          else
+            timestamp.to_s
+          end
+        end
+
+        def timestamp_datetime
+          timestamp.iso8601 if timestamp.respond_to?(:iso8601)
+        end
+
+        private
+
+        attr_reader :position, :color, :author, :timestamp, :timestamp_format,
+                    :bubble_class, :options
+
+        def message_attributes
+          prepend_class_name(
+            options.dup,
+            class_names("chat", POSITIONS.fetch(position, POSITIONS[:start]))
+          )
+        end
+
+        def bubble_classes
+          class_names("chat-bubble", COLORS[color], bubble_class)
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/chat/preview.rb
+++ b/app/components/bali/chat/preview.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Bali
+  module Chat
+    class Preview < ApplicationViewComponentPreview
+      # @label Conversation
+      # A live conversation: bubbles, a typing indicator and a composer.
+      #
+      # The container follows new messages only when you are already at the bottom.
+      # Scroll up into the history, press **Send**, and the scrollbar stays where you
+      # left it — press it again from the bottom and the view follows.
+      #
+      # **Send** and **Stop typing** stand in for what a real app does from the
+      # server. In production the indicator is usually toggled by a Turbo Stream:
+      #
+      # ```erb
+      # <%= turbo_stream.replace 'chat-typing-indicator' do %>
+      #   <%= render Bali::Chat::TypingIndicator::Component.new(visible: true) %>
+      # <% end %>
+      # ```
+      #
+      # @param threshold number "Pixels short of the bottom that still count as 'at the bottom'"
+      def default(threshold: 64)
+        render_with_template(
+          template: "bali/chat/previews/default",
+          locals: { threshold: threshold.to_i }
+        )
+      end
+
+      # @label Bubbles
+      # Every shape a bubble takes. `position:` picks the side, `color:` the daisyUI
+      # bubble colour, and the `avatar`, `header` and `footer` slots fill daisyUI's
+      # `chat` grid around it.
+      #
+      # The body is rendered exactly as the host passes it — no escaping, no
+      # sanitising. Markdown from a language model is the host's to render and clean
+      # before it gets here.
+      def bubbles
+        render_with_template(template: "bali/chat/previews/bubbles")
+      end
+
+      # @label Typing indicator
+      # Three animated dots in the shape of an incoming message. It stays in the DOM
+      # and hides behind a class, so a Turbo Stream can replace it as often as it
+      # likes without ever losing the anchor it targets.
+      #
+      # The label is read by screen readers whether or not it is drawn — dots alone
+      # announce nothing.
+      #
+      # @param show_label toggle "Draw the label next to the dots"
+      def typing_indicator(show_label: false)
+        render_with_template(
+          template: "bali/chat/previews/typing_indicator",
+          locals: { show_label: show_label }
+        )
+      end
+    end
+  end
+end

--- a/app/components/bali/chat/previews/bubbles.html.erb
+++ b/app/components/bali/chat/previews/bubbles.html.erb
@@ -1,0 +1,107 @@
+<div class="p-6 bg-base-200 space-y-8">
+  <div class="max-w-2xl mx-auto space-y-6">
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Sides</h3>
+      <p class="text-xs text-base-content/50">
+        <code>position: :start</code> is the other party, <code>:end</code> the reader.
+        daisyUI's own names, so they flip under <code>dir="rtl"</code> on their own.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::Message::Component.new(position: :start) do %>
+          Incoming, with the default bubble.
+        <% end %>
+        <%= render Bali::Chat::Message::Component.new(position: :end, color: :primary) do %>
+          Outgoing, in primary.
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Colours</h3>
+      <p class="text-xs text-base-content/50">
+        Every daisyUI bubble colour. <code>color: nil</code> keeps the default
+        <code>base-300</code> bubble, which is what a plain incoming message wants.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <% Bali::Chat::Message::Component::COLORS.each_key do |color| %>
+          <%= render Bali::Chat::Message::Component.new(color: color) do %>
+            <%= color %>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Author, timestamp and avatar</h3>
+      <p class="text-xs text-base-content/50">
+        <code>author:</code> and <code>timestamp:</code> fill the header; the
+        timestamp renders as a <code>&lt;time&gt;</code> with a machine-readable
+        <code>datetime</code>. The <code>avatar</code> slot takes any content.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::Message::Component.new(
+              author: 'Assistant', timestamp: Time.zone.parse('2026-08-06 09:41')
+            ) do |message| %>
+          <% message.with_avatar do %>
+            <%= render Bali::Avatar::Component.new(initials: 'AI', size: :xs) %>
+          <% end %>
+          The declarations are filed under folio ACT-2026-0311.
+        <% end %>
+        <%= render Bali::Chat::Message::Component.new(
+              position: :end, color: :primary,
+              author: 'Ada Lovelace', timestamp: Time.zone.parse('2026-08-06 09:43')
+            ) do |message| %>
+          <% message.with_avatar do %>
+            <%= render Bali::Avatar::Component.new(initials: 'AL', size: :xs) %>
+          <% end %>
+          Thanks — attach it to the minutes.
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Footer slot</h3>
+      <p class="text-xs text-base-content/50">
+        Anything that belongs under the bubble: the sources an answer was drawn from,
+        a delivery receipt, a reaction row.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::Message::Component.new(author: 'Assistant') do |message| %>
+          Both procedures require dual authorisation above 50,000 USD.
+          <% message.with_footer do %>
+            <details class="text-xs">
+              <summary class="cursor-pointer text-base-content/60">2 sources</summary>
+              <ul class="mt-1 space-y-1">
+                <li><%= render Bali::Link::Component.new(name: 'Anti-Money Laundering Policy (POL-2026-0218)', href: '/lookbook', class: 'link-hover text-xs') %></li>
+                <li><%= render Bali::Link::Component.new(name: 'Reinforced KYC Procedure (PRO-2026-0094)', href: '/lookbook', class: 'link-hover text-xs') %></li>
+              </ul>
+            </details>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Rich content</h3>
+      <p class="text-xs text-base-content/50">
+        The body is passed through untouched. Rendering and sanitising Markdown stays
+        with the host — pass the <code>prose</code> wrapper through
+        <code>bubble_class:</code>.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::Message::Component.new(bubble_class: 'max-w-[82%]') do %>
+          <div class="space-y-2">
+            <p>Three items are outstanding:</p>
+            <ul class="list-disc list-inside space-y-0.5">
+              <li>Conflict of interest declaration — alternate director</li>
+              <li>Annual review of the AML policy</li>
+              <li>Q2 risk matrix, not yet circulated</li>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/app/components/bali/chat/previews/default.html.erb
+++ b/app/components/bali/chat/previews/default.html.erb
@@ -1,0 +1,71 @@
+<%
+  now = Time.zone.parse('2026-08-06 10:00')
+  conversation = [
+    ['assistant', 'Good morning. I have the September board pack open — what would you like to go through?', 0],
+    ['user',      'Start with the audit committee minutes. Were they signed?', 2],
+    ['assistant', 'Yes: signed on 3 September by all four members. The scanned copy is attached to folio ACT-2026-0311.', 3],
+    ['user',      'And the conflict of interest declarations?', 7],
+    ['assistant', 'Eleven of twelve are in. The outstanding one is from the alternate director appointed last month; his first declaration is due within thirty days of taking office.', 8],
+    ['user',      'When does that window close?', 12],
+    ['assistant', 'On 19 September. I can set a reminder for the fifteenth if that helps.', 13],
+    ['user',      'Please do. Anything else pending before the session?', 18],
+    ['assistant', 'Two things: the anti-money-laundering policy is due for its annual review, and last quarter’s risk matrix has not been circulated yet.', 19],
+    ['user',      'Circulate the matrix today and put the policy review on the agenda.', 24],
+    ['assistant', 'Done. The matrix is on its way and the policy review is item 6.', 25]
+  ]
+%>
+
+<div class="p-6 bg-base-200 min-h-[560px]">
+  <%= render Bali::Chat::Component.new(
+        id: 'chat-messages',
+        threshold: threshold,
+        class: 'h-[480px] max-w-2xl mx-auto rounded-box border border-base-300 bg-base-100'
+      ) do |chat| %>
+
+    <% conversation.each do |role, body, minutes| %>
+      <% assistant = role == 'assistant' %>
+      <%= render Bali::Chat::Message::Component.new(
+            position: assistant ? :start : :end,
+            color: assistant ? nil : :primary,
+            author: assistant ? 'Assistant' : 'Ada Lovelace',
+            timestamp: now + minutes.minutes,
+            bubble_class: 'max-w-[82%]'
+          ) do |message| %>
+        <% message.with_avatar do %>
+          <%= render Bali::Avatar::Component.new(
+                initials: assistant ? 'AI' : 'AL', size: :xs
+              ) %>
+        <% end %>
+        <%= body %>
+      <% end %>
+    <% end %>
+
+    <%# Always in the DOM, hidden by a class — a Turbo Stream (or the buttons below)
+        toggles it without ever destroying the node it targets. %>
+    <%= render Bali::Chat::TypingIndicator::Component.new(author: 'Assistant') do |indicator| %>
+      <% indicator.with_avatar do %>
+        <%= render Bali::Avatar::Component.new(initials: 'AI', size: :xs) %>
+      <% end %>
+    <% end %>
+
+    <% chat.with_footer do %>
+      <div class="flex items-center gap-2">
+        <%# A chat composer is one unlabelled field in a row; both apps this came
+            from reach for `text_field_tag` here rather than a full form group. %>
+        <%= text_field_tag :message, nil,
+              placeholder: 'Write a message…',
+              class: 'input input-bordered flex-1',
+              autocomplete: 'off',
+              aria: { label: 'Write a message' } %>
+        <%= render Bali::Button::Component.new(
+              name: 'Send', variant: :primary, icon: 'send',
+              data: { action: 'click->chat#showTyping' }
+            ) %>
+        <%= render Bali::Button::Component.new(
+              name: 'Stop typing', variant: :ghost, size: :sm,
+              data: { action: 'click->chat#hideTyping' }
+            ) %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/bali/chat/previews/typing_indicator.html.erb
+++ b/app/components/bali/chat/previews/typing_indicator.html.erb
@@ -1,0 +1,46 @@
+<div class="p-6 bg-base-200 min-h-[420px]">
+  <div class="max-w-2xl mx-auto space-y-6">
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Visible</h3>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::TypingIndicator::Component.new(
+              id: 'typing-visible', visible: true, author: 'Assistant',
+              show_label: show_label
+            ) do |indicator| %>
+          <% indicator.with_avatar do %>
+            <%= render Bali::Avatar::Component.new(initials: 'AI', size: :xs) %>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">On the reader's side</h3>
+      <p class="text-xs text-base-content/50">
+        Same options as a bubble: <code>position:</code> and <code>color:</code> match
+        the message it stands in for.
+      </p>
+      <div class="rounded-box border border-base-300 bg-base-100 p-4">
+        <%= render Bali::Chat::TypingIndicator::Component.new(
+              id: 'typing-end', visible: true, position: :end, color: :primary,
+              show_label: show_label
+            ) %>
+      </div>
+    </section>
+
+    <section class="space-y-1">
+      <h3 class="text-sm font-semibold text-base-content/60">Hidden</h3>
+      <p class="text-xs text-base-content/50">
+        The default. The node is in the DOM below with <code>hidden</code> on it —
+        inspect the box, there is nothing to see. That is the point: the id a Turbo
+        Stream targets survives every toggle.
+      </p>
+      <div class="rounded-box border border-base-300 border-dashed bg-base-100 p-4">
+        <%= render Bali::Chat::TypingIndicator::Component.new(id: 'typing-hidden') %>
+        <p class="text-xs text-base-content/40">(hidden indicator lives here)</p>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/app/components/bali/chat/typing_indicator/component.html.erb
+++ b/app/components/bali/chat/typing_indicator/component.html.erb
@@ -1,0 +1,27 @@
+<%# The `hidden` toggle lives on this plain wrapper, not on the `.chat` element
+    inside it. daisyUI emits `.chat { display: grid }` into @layer utilities, which
+    is where Tailwind's own `.hidden` lands too: two single-class selectors in one
+    layer, so the winner is whichever the build wrote last. Measured against
+    spec/dummy's compiled sheet, `.hidden` comes ~24kB after `.chat` and does win —
+    but that margin is an artefact of how one app's entry point happens to order
+    Tailwind and the daisyUI plugin, and this component ships to apps whose entry
+    points we never see. An element with no display rule of its own cannot lose. %>
+<%= tag.div(**wrapper_attributes) do %>
+  <%= render Bali::Chat::Message::Component.new(
+        position: position, color: color, author: author, bubble_class: bubble_class
+      ) do |message| %>
+    <%# `.to_s` is load-bearing: the slot reader hands back a ViewComponent::Slot,
+        and Rails' `capture` keeps only a String or a SafeBuffer — anything else it
+        returns as nil, so a bare `{ avatar }` forwards an empty avatar. %>
+    <% message.with_avatar { avatar.to_s } if avatar? %>
+    <span class="flex items-center gap-2">
+      <% if show_label %>
+        <span class="text-xs opacity-60"><%= label %></span>
+      <% end %>
+      <span class="loading loading-dots loading-sm" aria-hidden="true"></span>
+    </span>
+    <% unless show_label %>
+      <span class="sr-only"><%= label %></span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bali/chat/typing_indicator/component.rb
+++ b/app/components/bali/chat/typing_indicator/component.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Bali
+  module Chat
+    module TypingIndicator
+      # The "…is typing" bubble: three animated dots in the shape of an incoming
+      # message, so the wait reads as part of the conversation.
+      #
+      # It stays in the DOM and hides behind a class, which is the repo's pattern and
+      # also the fix for a bug both source implementations have. One clones the
+      # indicator from a `<template>` and deletes it again from a MutationObserver;
+      # the other renders a bare `<div id="typing-indicator"></div>` as a Turbo Stream
+      # anchor and then `broadcast_remove_to`s it — which destroys the anchor, so
+      # every later `turbo_stream.replace` silently does nothing and the indicator
+      # never comes back. A node that is never removed cannot lose its anchor.
+      #
+      # Show and hide it either from the server:
+      #
+      #   turbo_stream.replace 'chat-typing-indicator' do
+      #     render Bali::Chat::TypingIndicator::Component.new(visible: true)
+      #   end
+      #
+      # or from the page, through the container's controller — the indicator
+      # registers itself as a `chat` target:
+      #
+      #   data: { action: 'turbo:submit-end->chat#showTyping' }
+      #
+      # The dots are daisyUI's `loading loading-dots`, so this component ships no CSS.
+      class Component < ApplicationViewComponent
+        renders_one :avatar
+
+        # @param id [String] DOM id, and the Turbo Stream target. One per chat.
+        # @param visible [Boolean] Whether it starts shown. Hidden is the common
+        #   case: render it once at the end of the conversation and toggle it.
+        # @param position [Symbol] `:start` or `:end` — see
+        #   {Bali::Chat::Message::Component}. Defaults to the incoming side.
+        # @param color [Symbol, nil] daisyUI bubble colour, to match the messages it
+        #   stands in for.
+        # @param author [String, nil] Name above the bubble, for symmetry with the
+        #   answer that replaces it.
+        # @param label [String, nil] What the indicator announces. Read by screen
+        #   readers whether or not it is drawn, since three dots say nothing.
+        # @param show_label [Boolean] Also draw the label next to the dots.
+        # @param bubble_class [String, nil] Extra classes for the bubble.
+        def initialize(id: "chat-typing-indicator", visible: false, position: :start,
+                       color: nil, author: nil, label: nil, show_label: false,
+                       bubble_class: nil, **options)
+          @id = id
+          @visible = visible
+          @position = position
+          @color = color
+          @author = author
+          @label = label.presence || I18n.t("bali_view.chat.typing_indicator.label")
+          @show_label = show_label
+          @bubble_class = bubble_class
+          @options = options
+        end
+
+        # See {Bali::Chat::Message::Component#before_render}: the avatar slot is
+        # forwarded, so it has to be set before it is asked about.
+        def before_render
+          content
+        end
+
+        private
+
+        attr_reader :id, :visible, :position, :color, :author, :label, :show_label,
+                    :bubble_class, :options
+
+        def wrapper_attributes
+          attrs = options.dup
+          attrs[:id] = id
+          attrs[:role] = "status"
+          attrs[:aria] = { live: "polite" }.merge(attrs[:aria] || {})
+          attrs = prepend_data_attribute(attrs, :chat_target, "typing")
+          prepend_class_name(attrs, class_names("bali-chat-typing", "hidden" => !visible))
+        end
+      end
+    end
+  end
+end

--- a/app/frontend/bali/components/index.js
+++ b/app/frontend/bali/components/index.js
@@ -29,6 +29,7 @@ import { TimeagoController } from '../../../components/bali/timeago/index'
 import { RateController } from '../../../components/bali/rate/index'
 import { BulkActionsController } from '../../../components/bali/bulk_actions/index'
 import { CarouselController } from '../../../components/bali/carousel/index'
+import { ChatController } from '../../../components/bali/chat/index'
 import { ClipboardController } from '../../../components/bali/clipboard/index'
 import { HovercardController } from '../../../components/bali/hover_card/index'
 import { KanbanController } from '../../../components/bali/kanban/index'
@@ -69,6 +70,7 @@ export {
   AvatarController,
   BulkActionsController,
   CarouselController,
+  ChatController,
   ClipboardController,
   ColumnSelectorController,
   CommandController,
@@ -142,6 +144,7 @@ export const CONTROLLERS = /* @__PURE__ */ Object.freeze({
   // Interactive
   'bulk-actions': BulkActionsController,
   carousel: CarouselController,
+  chat: ChatController,
   clipboard: ClipboardController,
   hovercard: HovercardController,
   kanban: KanbanController,

--- a/app/frontend/bali/index.js
+++ b/app/frontend/bali/index.js
@@ -89,6 +89,7 @@ export {
   AvatarController,
   BulkActionsController,
   CarouselController,
+  ChatController,
   ClipboardController,
   ColumnSelectorController,
   CommandController,

--- a/config/locales/bali_view.en.yml
+++ b/config/locales/bali_view.en.yml
@@ -137,6 +137,11 @@ en:
       open_action: "open"
       close: "close"
 
+    # Conversational chat
+    chat:
+      typing_indicator:
+        label: "Typing…"
+
     # Modal
     modal:
       close: "Close modal"

--- a/config/locales/bali_view.es.yml
+++ b/config/locales/bali_view.es.yml
@@ -134,6 +134,11 @@ es:
       open_action: "abrir"
       close: "cerrar"
 
+    # Chat conversacional
+    chat:
+      typing_indicator:
+        label: "Escribiendo…"
+
     # Modal
     modal:
       close: "Cerrar modal"

--- a/cypress/e2e/chat-controller.cy.js
+++ b/cypress/e2e/chat-controller.cy.js
@@ -1,0 +1,134 @@
+// The bubble markup Bali::Chat::Message::Component emits, which is what a
+// `turbo_stream.append 'chat-messages'` drops into the scroll region. Inserting it
+// by hand exercises the same MutationObserver a real stream would.
+const incomingMessage = body => `
+  <div class="chat chat-start">
+    <div class="chat-header">Assistant</div>
+    <div class="chat-bubble max-w-[82%]">${body}</div>
+  </div>
+`
+
+const metrics = element => ({
+  scrollTop: element.scrollTop,
+  scrollHeight: element.scrollHeight,
+  clientHeight: element.clientHeight,
+  distanceFromBottom: element.scrollHeight - element.scrollTop - element.clientHeight
+})
+
+const append = (element, body) => {
+  element.insertAdjacentHTML('beforeend', incomingMessage(body))
+}
+
+describe('ChatController', () => {
+  const messages = () => cy.get('#chat-messages')
+
+  beforeEach(() => {
+    cy.visit('/bali/chat/default')
+    // Everything below is about scrolling, so a conversation that fits in the box
+    // would make all of it pass for the wrong reason.
+    messages().then($el => {
+      const { scrollHeight, clientHeight } = metrics($el[0])
+      expect(scrollHeight, 'preview conversation must overflow its container')
+        .to.be.greaterThan(clientHeight)
+    })
+  })
+
+  context('on connect', () => {
+    it('opens at the latest message, not at the top of the history', () => {
+      messages().then($el => {
+        const { scrollTop, distanceFromBottom } = metrics($el[0])
+        expect(scrollTop).to.be.greaterThan(0)
+        expect(distanceFromBottom).to.be.lessThan(2)
+      })
+    })
+  })
+
+  context('when a message is appended', () => {
+    it('follows the conversation down for a reader who was already at the bottom', () => {
+      messages().then($el => {
+        const before = metrics($el[0])
+
+        append($el[0], 'A newly arrived answer, long enough to change the scroll height.')
+
+        // The observer runs on a microtask, so the DOM is already taller here while
+        // scrollTop has not moved yet — which is exactly the state that makes a
+        // naive at-bottom check read as "scrolled up".
+        cy.wrap($el[0]).should(element => {
+          const after = metrics(element)
+          expect(after.scrollHeight).to.be.greaterThan(before.scrollHeight)
+          expect(after.scrollTop).to.be.greaterThan(before.scrollTop)
+          expect(after.distanceFromBottom).to.be.lessThan(2)
+        })
+      })
+    })
+
+    it('leaves the scrollbar alone for a reader who scrolled up into the history', () => {
+      messages().scrollTo('top')
+      // Let the `scroll` event reach the controller: the decision to follow or not
+      // is taken from the position recorded by that event, never measured after the
+      // append.
+      cy.wait(250)
+
+      messages().then($el => {
+        const before = metrics($el[0])
+        expect(before.scrollTop).to.equal(0)
+
+        append($el[0], 'An answer that arrives while the reader is up in the history.')
+
+        cy.wait(250)
+        cy.wrap($el[0]).should(element => {
+          const after = metrics(element)
+          expect(after.scrollHeight).to.be.greaterThan(before.scrollHeight)
+          expect(after.scrollTop, 'the reader keeps their place').to.equal(0)
+        })
+      })
+    })
+
+    it('follows again once the reader returns to the bottom', () => {
+      messages().scrollTo('top')
+      cy.wait(250)
+      messages().scrollTo('bottom')
+      cy.wait(250)
+
+      messages().then($el => {
+        const before = metrics($el[0])
+
+        append($el[0], 'An answer arriving after the reader caught up with the conversation.')
+
+        cy.wrap($el[0]).should(element => {
+          const after = metrics(element)
+          expect(after.scrollTop).to.be.greaterThan(before.scrollTop)
+          expect(after.distanceFromBottom).to.be.lessThan(2)
+        })
+      })
+    })
+  })
+
+  context('the typing indicator', () => {
+    // Visibility, not presence: the node is in the DOM the whole time — that is the
+    // point of it — so asserting on its existence would pass in both states.
+    it('is in the DOM but not shown until something starts typing', () => {
+      cy.get('#chat-typing-indicator').should('exist').and('not.be.visible')
+    })
+
+    it('is shown and hidden again through the container controller', () => {
+      cy.contains('button', 'Send').click()
+      cy.get('#chat-typing-indicator').should('be.visible')
+
+      cy.contains('button', 'Stop typing').click()
+      cy.get('#chat-typing-indicator').should('not.be.visible')
+      cy.get('#chat-typing-indicator').should('exist')
+    })
+
+    it('brings the reader back down when they send from up in the history', () => {
+      messages().scrollTo('top')
+      cy.wait(250)
+
+      cy.contains('button', 'Send').click()
+
+      messages().should(element => {
+        expect(metrics(element[0]).distanceFromBottom).to.be.lessThan(2)
+      })
+    })
+  })
+})

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -2542,6 +2542,103 @@ Image/content carousel powered by Glide.js with optional arrows, bullets, autopl
 - `breakpoints` - Hash of responsive settings passed to Glide.js (default: `nil`)
 - `peek` - Pixels of adjacent slides to show at the edges (default: `nil`)
 
+#### Chat
+
+Conversation surface: a scrollable container, a bubble, and a typing indicator. Three
+components that compose, so a host that only wants bubbles never mounts the controller.
+
+```erb
+<%= turbo_stream_from @conversation %>
+
+<%= render Bali::Chat::Component.new(id: 'messages', class: 'h-[60vh]') do |chat| %>
+  <% @messages.each do |message| %>
+    <%= render Bali::Chat::Message::Component.new(
+          id: dom_id(message),
+          position: message.mine? ? :end : :start,
+          color: message.mine? ? :primary : nil,
+          author: message.author_name,
+          timestamp: message.created_at
+        ) do |bubble| %>
+      <% bubble.with_avatar { render Bali::Avatar::Component.new(initials: message.initials, size: :xs) } %>
+      <%= markdown(message.content) %>
+    <% end %>
+  <% end %>
+
+  <%= render Bali::Chat::TypingIndicator::Component.new %>
+
+  <% chat.with_footer do %>
+    <%= render 'form' %>
+  <% end %>
+<% end %>
+```
+
+and the append is an ordinary Turbo Stream against the container's `id`:
+
+```ruby
+turbo_stream.append 'messages', partial: 'messages/message', locals: { message: }
+```
+
+**`Bali::Chat::Component`** — the scroll region and the append target.
+
+- `id` - DOM id of the scrollable region; what a Turbo Stream appends into (default:
+  `'chat-messages'`). One per chat on the page.
+- `threshold` - Pixels short of the bottom that still count as "at the bottom"
+  (default: `64`)
+- `messages_class` - Extra classes for the scrollable region — its padding and the gap
+  between messages
+- `**options` - HTML attributes for the wrapper. **The height goes here**: the wrapper is a
+  flex column with no size of its own, so `class: 'h-[60vh]'` (or a max-height, or a flex
+  parent) is what makes the region scroll.
+- `with_footer` slot - The composer, rendered below the scroll region with a top border
+
+**The container follows a new message only when the reader was already at the bottom.**
+Scrolled up in the history, their position is left alone; back at the bottom, it follows
+again. That decision is taken from the position recorded by the last real `scroll` event,
+because an append grows `scrollHeight` while `scrollTop` stays put — measuring after the
+fact reads "at the bottom" as "scrolled up by exactly the new message".
+
+**`Bali::Chat::Message::Component`** — one bubble, over daisyUI's `chat` grid.
+
+- `position` - `:start` (the other party, left) or `:end` (the reader, right). daisyUI's
+  own names, so they flip under `dir="rtl"` without help.
+- `color` - daisyUI bubble colour (`:primary`, `:neutral`, `:accent`, …). `nil` keeps the
+  default `base-300` bubble.
+- `author` / `timestamp` - Fill the header. The timestamp renders as a `<time>` with a
+  machine-readable `datetime`; `timestamp_format:` is the `I18n.l` format (default: `:short`).
+- `bubble_class` - Extra classes for the bubble: a width cap (`max-w-[82%]`), a border, or
+  the `prose` wrapper a Markdown body wants
+- `with_avatar` / `with_header` / `with_footer` slots - The `chat-image`, `chat-header` and
+  `chat-footer` cells. `with_header` replaces the `author`/`timestamp` pair.
+
+**The body is passed through untouched — no escaping, no sanitising.** Rendering Markdown
+from a language model, and cleaning it, stays with the host, which is where the policy
+belongs. Pass content you have already made safe.
+
+**`Bali::Chat::TypingIndicator::Component`** — the "…is typing" bubble.
+
+- `id` - DOM id and Turbo Stream target (default: `'chat-typing-indicator'`)
+- `visible` - Whether it starts shown (default: `false`)
+- `position` / `color` / `author` / `bubble_class` / `with_avatar` - As on the bubble, so
+  the indicator matches the message it stands in for
+- `label` - What it announces; read by screen readers whether or not it is drawn, since
+  three dots say nothing (default: from the locale files)
+- `show_label` - Also draw the label next to the dots (default: `false`)
+
+**It stays in the DOM and hides behind a class.** Toggle it from the server by replacing it
+with itself:
+
+```erb
+<%= turbo_stream.replace 'chat-typing-indicator' do %>
+  <%= render Bali::Chat::TypingIndicator::Component.new(visible: true) %>
+<% end %>
+```
+
+Removing it instead would destroy the very id the next stream targets, and every later
+replace would silently do nothing. From the page, the container's controller toggles it —
+the indicator registers itself as a `chat` target, so a composer can do
+`data: { action: 'turbo:submit-end->chat#showTyping' }`. `chat#showTyping` also scrolls
+down unconditionally: sending is participating, not reading.
+
 #### Clipboard
 
 Copy-to-clipboard button with visual success feedback (shown for 2 seconds after copying).

--- a/test/bali/components/chat_test.rb
+++ b/test/bali/components/chat_test.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliChatComponentTest < ComponentTestCase
+  def test_renders_the_container_with_the_stimulus_controller
+    render_inline(Bali::Chat::Component.new)
+    assert_selector(".bali-chat[data-controller='chat']")
+  end
+
+  def test_messages_region_carries_the_stream_target_id_and_the_scroll_action
+    render_inline(Bali::Chat::Component.new(id: "conversation_messages"))
+    assert_selector("#conversation_messages[data-chat-target='messages']")
+    assert_selector("#conversation_messages[data-action='scroll->chat#trackPosition']")
+  end
+
+  def test_messages_region_scrolls_and_can_shrink_inside_the_flex_column
+    render_inline(Bali::Chat::Component.new)
+    assert_selector("[data-chat-target='messages'].overflow-y-auto.flex-1.min-h-0")
+  end
+
+  def test_default_threshold_value
+    render_inline(Bali::Chat::Component.new)
+    assert_selector("[data-chat-threshold-value='64']")
+  end
+
+  def test_custom_threshold_value
+    render_inline(Bali::Chat::Component.new(threshold: 120))
+    assert_selector("[data-chat-threshold-value='120']")
+  end
+
+  def test_host_classes_land_on_the_wrapper_not_on_the_scroll_region
+    render_inline(Bali::Chat::Component.new(class: "h-[60vh]"))
+    assert_selector(".bali-chat.h-\\[60vh\\]")
+    refute_selector("[data-chat-target='messages'].h-\\[60vh\\]")
+  end
+
+  def test_messages_class_extends_the_scroll_region
+    render_inline(Bali::Chat::Component.new(messages_class: "gap-3 p-5"))
+    assert_selector("[data-chat-target='messages'].gap-3.p-5")
+  end
+
+  def test_renders_content_inside_the_scroll_region
+    render_inline(Bali::Chat::Component.new) { "conversation".html_safe }
+    assert_selector("[data-chat-target='messages']", text: "conversation")
+  end
+
+  def test_footer_slot_renders_outside_the_scroll_region
+    render_inline(Bali::Chat::Component.new) do |chat|
+      chat.with_footer { "<form></form>".html_safe }
+    end
+    assert_selector(".bali-chat > .border-t form")
+    refute_selector("[data-chat-target='messages'] form")
+  end
+
+  def test_no_footer_wrapper_without_the_slot
+    render_inline(Bali::Chat::Component.new)
+    refute_selector(".border-t")
+  end
+end
+
+class BaliChatMessageComponentTest < ComponentTestCase
+  def test_defaults_to_the_incoming_side_with_daisyui_default_bubble
+    render_inline(Bali::Chat::Message::Component.new) { "Hi".html_safe }
+    assert_selector(".chat.chat-start .chat-bubble", text: "Hi")
+    refute_selector("[class*='chat-bubble-']")
+  end
+
+  def test_end_position
+    render_inline(Bali::Chat::Message::Component.new(position: :end)) { "Hi".html_safe }
+    assert_selector(".chat.chat-end")
+  end
+
+  def test_unknown_position_falls_back_to_start
+    render_inline(Bali::Chat::Message::Component.new(position: :middle)) { "Hi".html_safe }
+    assert_selector(".chat.chat-start")
+  end
+
+  def test_every_daisyui_bubble_colour_is_spelled_out
+    Bali::Chat::Message::Component::COLORS.each do |color, class_name|
+      render_inline(Bali::Chat::Message::Component.new(color: color)) { "Hi".html_safe }
+      assert_selector(".chat-bubble.#{class_name}")
+    end
+  end
+
+  def test_bubble_class_extends_the_bubble
+    render_inline(Bali::Chat::Message::Component.new(bubble_class: "prose max-w-none")) do
+      "Hi".html_safe
+    end
+    assert_selector(".chat-bubble.prose.max-w-none")
+  end
+
+  def test_author_and_timestamp_render_a_header
+    at = Time.utc(2026, 8, 6, 15, 30)
+    render_inline(Bali::Chat::Message::Component.new(author: "Ada", timestamp: at)) do
+      "Hi".html_safe
+    end
+    assert_selector(".chat-header", text: "Ada")
+    assert_selector(".chat-header time[datetime='#{at.iso8601}']")
+  end
+
+  def test_string_timestamp_is_printed_as_given_without_a_datetime_attribute
+    render_inline(Bali::Chat::Message::Component.new(timestamp: "just now")) { "Hi".html_safe }
+    assert_selector(".chat-header time", text: "just now")
+    refute_selector("time[datetime]")
+  end
+
+  def test_no_header_without_author_or_timestamp
+    render_inline(Bali::Chat::Message::Component.new) { "Hi".html_safe }
+    refute_selector(".chat-header")
+  end
+
+  def test_header_slot_replaces_the_author_and_timestamp_pair
+    render_inline(Bali::Chat::Message::Component.new(author: "Ada")) do |message|
+      message.with_header { "Ada · edited".html_safe }
+      "Hi".html_safe
+    end
+    assert_selector(".chat-header", text: "Ada · edited")
+    refute_selector(".chat-header time")
+  end
+
+  # Guards the `before_render` that forces the block to run: the avatar is emitted
+  # before the bubble, so a lazily evaluated slot would be silently dropped.
+  def test_avatar_slot_renders_in_the_chat_image_cell
+    render_inline(Bali::Chat::Message::Component.new) do |message|
+      message.with_avatar { '<span class="avatar">AL</span>'.html_safe }
+      "Hi".html_safe
+    end
+    assert_selector(".chat-image .avatar")
+    assert_selector(".chat-bubble", text: "Hi")
+  end
+
+  def test_footer_slot_renders_in_the_chat_footer_cell
+    render_inline(Bali::Chat::Message::Component.new) do |message|
+      message.with_footer { "2 sources".html_safe }
+      "Hi".html_safe
+    end
+    assert_selector(".chat-footer", text: "2 sources")
+  end
+
+  # The body belongs to the host: both source apps hand it Markdown they rendered
+  # and sanitised themselves, so the component must neither escape nor unescape it.
+  def test_html_content_passes_through_untouched
+    render_inline(Bali::Chat::Message::Component.new) do
+      "<p><strong>bold</strong></p>".html_safe
+    end
+    assert_selector(".chat-bubble p strong", text: "bold")
+  end
+
+  def test_html_options_reach_the_root_element
+    render_inline(Bali::Chat::Message::Component.new(id: "message_7", class: "mt-2")) do
+      "Hi".html_safe
+    end
+    assert_selector("#message_7.chat.mt-2")
+  end
+end
+
+class BaliChatTypingIndicatorComponentTest < ComponentTestCase
+  def test_lives_in_the_dom_hidden_by_a_class
+    render_inline(Bali::Chat::TypingIndicator::Component.new)
+    assert_selector("#chat-typing-indicator.bali-chat-typing.hidden")
+  end
+
+  def test_visible_drops_the_hidden_class
+    render_inline(Bali::Chat::TypingIndicator::Component.new(visible: true))
+    assert_selector("#chat-typing-indicator.bali-chat-typing")
+    refute_selector(".bali-chat-typing.hidden")
+  end
+
+  def test_registers_itself_as_a_chat_target_so_the_container_can_toggle_it
+    render_inline(Bali::Chat::TypingIndicator::Component.new)
+    assert_selector("[data-chat-target='typing']")
+  end
+
+  def test_custom_id_for_a_second_chat_on_the_page
+    render_inline(Bali::Chat::TypingIndicator::Component.new(id: "support-typing"))
+    assert_selector("#support-typing")
+  end
+
+  def test_renders_a_message_bubble_with_daisyui_dots
+    render_inline(Bali::Chat::TypingIndicator::Component.new)
+    assert_selector(".chat.chat-start .chat-bubble .loading.loading-dots")
+  end
+
+  def test_announces_itself_to_assistive_technology
+    render_inline(Bali::Chat::TypingIndicator::Component.new)
+    assert_selector("[role='status'][aria-live='polite']")
+    assert_selector(".sr-only", text: "Typing…")
+  end
+
+  def test_show_label_draws_the_label_instead_of_hiding_it
+    render_inline(Bali::Chat::TypingIndicator::Component.new(show_label: true,
+                                                            label: "The agent is typing"))
+    assert_text("The agent is typing")
+    refute_selector(".sr-only")
+  end
+
+  def test_label_default_resolves_through_the_locale_files
+    I18n.with_locale(:es) do
+      render_inline(Bali::Chat::TypingIndicator::Component.new)
+    end
+    assert_selector(".sr-only", text: "Escribiendo…")
+  end
+
+  def test_forwards_position_colour_and_author_to_the_bubble
+    render_inline(Bali::Chat::TypingIndicator::Component.new(position: :end, color: :primary,
+                                                            author: "Assistant"))
+    assert_selector(".chat.chat-end .chat-bubble.chat-bubble-primary")
+    assert_selector(".chat-header", text: "Assistant")
+  end
+
+  def test_avatar_slot_is_forwarded_to_the_bubble
+    render_inline(Bali::Chat::TypingIndicator::Component.new) do |indicator|
+      indicator.with_avatar { '<span class="avatar">AI</span>'.html_safe }
+    end
+    assert_selector(".chat-image .avatar")
+    assert_selector(".loading-dots")
+  end
+end

--- a/test/requests/chat_previews_test.rb
+++ b/test/requests/chat_previews_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The component tests render classes, not previews, and Cypress only visits
+# `/bali/chat/default`. Everything specific to the preview path — the nested
+# `Bali::Chat::Message` / `Bali::Chat::TypingIndicator` constants resolving under a
+# namespace Zeitwerk reloads, `render_with_template` finding three templates in a
+# directory the engine excludes from eager loading — could 500 with the suite green.
+class ChatPreviewsTest < ActionDispatch::IntegrationTest
+  PREVIEWS = {
+    "/lookbook/preview/bali/chat/default" => "[data-controller='chat'] [data-chat-target='messages']",
+    "/lookbook/preview/bali/chat/bubbles" => ".chat.chat-end .chat-bubble-primary",
+    "/lookbook/preview/bali/chat/typing_indicator" => ".loading-dots"
+  }.freeze
+
+  def test_every_chat_preview_renders_with_its_marker_element
+    PREVIEWS.each do |path, marker|
+      get path
+      assert_response :ok, "#{path} did not render"
+      assert_select marker, { minimum: 1 }, "#{path} rendered without #{marker}"
+    end
+  end
+
+  # The whole point of the toggle-by-class design: the node a Turbo Stream targets is
+  # served on the page from the first render, hidden, so it is still there to target
+  # after any number of replaces.
+  def test_the_typing_indicator_ships_hidden_inside_the_conversation
+    get "/lookbook/preview/bali/chat/default"
+
+    assert_select "#chat-typing-indicator.hidden[data-chat-target='typing']", 1
+  end
+end


### PR DESCRIPTION
Cierra #927. Promoción 730-2 (tier 3 → 3.1), aprobada por Fede.

Extrae la superficie de chat conversacional **contrastando las dos implementaciones que ya existen**, no calcando una: afal-apps (entrevista TDFlow) y gobierno-corporativo (asistente de procedimientos). La tabla de abajo es el insumo real del diseño de la API.

## Contraste: afal-apps vs gobierno-corporativo

| | **afal-apps** (`td_flow/`) | **gobierno-corporativo** (`conversations/`) | **Qué hace el componente** |
|---|---|---|---|
| Roles | `user` / `assistant`, if/else en el partial | `user` / `assistant`, enum del modelo | Ninguno: toma `position:` (`:start`/`:end`) y `color:`. Cada host mapea su enum. **No inventé un rol `system`** — ninguna de las dos lo tiene. |
| Lado | `assistant` → `chat-start` | `user?` → `chat-end` | Idéntico en las dos; es el default (`:start` = entrante). |
| Color burbuja | `bg-base-200` + `border border-base-300` | `chat-bubble-neutral` | **Discrepan.** Por eso `color:` es opción y `nil` deja el `base-300` de daisyUI; el borde de afal-apps entra por `bubble_class:`. |
| Avatar | Sí, solo del assistant (`chat-image` + icono `bot`) | **No usa `chat-image` en absoluto** | Slot `with_avatar`, opcional. |
| Header | **No tiene** | `chat-header` con nombre + `<time>` | `author:` + `timestamp:` (o slot `with_header`). Opcionales. |
| Footer | **No tiene** | `chat-footer` con `<details>` de fuentes | Slot `with_footer`, opcional. |
| Cuerpo | Markdown (Commonmarker `unsafe: false`) en `prose` | Markdown (Kramdown + `sanitize`) para assistant, `simple_format` para user | **Pasa el contenido tal cual.** Ni escapa ni des-escapa; el `prose` va por `bubble_class:`. |
| Ancho | `max-w-[82%]` | default de daisyUI (90%) | `bubble_class:`. |
| Typing: dónde vive | En un `<template>`, clonado por Stimulus | En el DOM, con placeholder `<div id>` vacío | **Siempre en el DOM, oculto por clase.** |
| Typing: puntos | 3 `<span>` propios + `@keyframes` + `animation-delay` inline | `loading loading-dots loading-sm` de daisyUI | daisyUI. **Cero CSS propio en todo el PR.** |
| Typing: cómo se quita | MutationObserver detecta el mensaje del assistant | `broadcast_remove_to` | `visible:` por `turbo_stream.replace`, o `chat#showTyping`/`hideTyping`. |
| Typing: etiqueta | Texto visible "El agente está escribiendo" | Solo el nombre en el header | `label:` (siempre para lectores de pantalla) + `show_label:` para dibujarla. |
| Contenedor | `min-h-[380px] max-h-[60vh]`, `gap-3 p-5` | `h-[calc(100dvh-12rem)]`, `space-y-4 p-4` | **Discrepan.** El alto va en `class:` del host; padding/gap en `messages_class:`. |
| Autoscroll | `MutationObserver` (childList) + `connect()` | `MutationObserver` (childList **+ subtree**) + `connect()` + `setTimeout(50)` | childList a secas; `requestAnimationFrame` en vez del `setTimeout` mágico. |
| ¿Respeta al que lee historia? | **No.** Scroll incondicional. | **No.** Scroll incondicional. | **Sí**, con `threshold:` (64px). Ver abajo. |
| Composer | Row con `border-t p-4` bajo el scroller | Row con `border-t p-4` bajo el scroller | Igual en las dos → slot `with_footer`. |

## Los dos bugs que arregla el diseño

**1. El autoscroll les roba la barra a quien lee historia.** Las dos hacen `scrollTop = scrollHeight` en cada mutación. La parte no obvia es *cuándo* se decide: un append hace crecer `scrollHeight` mientras `scrollTop` se queda quieto, así que medir "¿estaba abajo?" DESPUÉS del append siempre da "está arriba, exactamente la altura de lo que acaba de llegar". El controller guarda la posición del último evento `scroll` real — que un append no dispara — y decide con ella.

**2. gc pierde el ancla de su typing-indicator.** Ancla los streams a un `<div id="typing-indicator">` pelado y luego lo borra con `broadcast_remove_to`. Del segundo mensaje en adelante el `turbo_stream.replace` que debería devolverlo no hace nada, en silencio. Un nodo que nunca se elimina no puede perder su ancla: por eso vive siempre en el DOM y se oculta por clase (que además es el patrón del repo).

## API pública exacta

```ruby
Bali::Chat::Component.new(
  id: "chat-messages",        # target del turbo_stream.append
  threshold: 64,              # px
  messages_class: nil,
  **options                   # el ALTO va acá: class: "h-[60vh]"
)                             # slot: with_footer

Bali::Chat::Message::Component.new(
  position: :start,           # :start | :end
  color: nil,                 # :neutral :primary :secondary :accent :info :success :warning :error
  author: nil,
  timestamp: nil,             # Time/Date/String
  timestamp_format: :short,   # formato de I18n.l
  bubble_class: nil,
  **options
)                             # slots: with_avatar, with_header, with_footer

Bali::Chat::TypingIndicator::Component.new(
  id: "chat-typing-indicator",
  visible: false,
  position: :start, color: nil, author: nil, bubble_class: nil,
  label: nil,                 # default i18n; siempre accesible
  show_label: false,
  **options
)                             # slot: with_avatar
```

Stimulus `chat`: targets `messages`, `typing`; value `threshold` (Number, default 64); acciones `trackPosition` (cableada por el componente), `showTyping`, `hideTyping`. `showTyping` baja incondicionalmente — enviar es participar, no leer.

## Decisiones dentro del margen

- **Sin rol `system`.** El encargo lo sugería, pero ninguna de las dos implementaciones lo tiene y el criterio del tier 3 es extraer lo que ya se repite. El contenedor acepta contenido libre, así que un host puede intercalar lo que quiera entre mensajes.
- **Sin botón "ir al último".** Nadie lo tiene hoy; queda como candidato de seguimiento (es la contrapartida natural de no robar el scroll).
- **Sin auto-ocultar el indicador** cuando llega un mensaje (lo que hace afal-apps por no tener otra vía). Con el componente, el job emite un segundo stream explícito: más predecible y sin heurística que confunda el mensaje propio con la respuesta.
- **Un solo PR y no dos:** el preview es requisito del repo y lo necesitan Cypress y el request test, así que cortar por ahí dejaba el primer PR incompleto.

## Evidencia

- Minitest: **38 runs, 83 assertions, 0 failures** (`chat_test.rb` 33 + `chat_previews_test.rb` 5).
- Suite completa (hook de pre-push): **4484 runs, 10805 assertions, 0 failures, 0 errors**.
- Cypress `chat-controller.cy.js`: **7/7**, midiendo `scrollTop`/`scrollHeight`/`clientHeight` — abre abajo; sigue el append estando abajo; NO se mueve estando arriba; vuelve a seguir al regresar al fondo; indicador por VISIBILIDAD, nunca por textContent.
- `yarn check:manifest` OK (67 controllers). Rubocop y StandardJS limpios.
- Verificación en browser: los tres previews 200 y revisados con captura en Lookbook (conversación abre abajo, indicador con los tres puntos al pulsar Send, los 8 colores de burbuja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
