### PR TITLE
feat(split-view): master-detail estilo inbox (#728, PR 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::SplitView` — the inbox shape, as a component** (#728). A master list on the left, the
+  detail of the selected row on the right inside a Turbo Frame, so a row click swaps only the
+  right column and the list keeps its scroll position and its highlight. `frame_id:` names the
+  frame, `master_width:` sets the left column from `lg` up (default `420px`; below `lg` the panes
+  stack, master on top, with no extra JavaScript), and `advance: true` puts
+  `data-turbo-action="advance"` on the frame so the selection is deep-linkable. Three slots:
+  `master`, `detail`, and `empty_detail` for when nothing is selected.
+
+  **It is deliberately thin.** The component owns the responsive grid, the frame and the
+  highlight controller — the three things that are identical in every master-detail screen — and
+  claims nothing else. Tabs, filter chips, pagination and the rows themselves go inside `master`
+  in whatever shape the screen needs, because the app this was extracted from puts all four there
+  and no two screens agree on their arrangement. The grouped "InboxList" the issue also asks for
+  is **not** in this release: one app has one, and one anatomy is not enough to triangulate an API.
+
+  **The selection is an attribute, not a class list.** The `split-view` Stimulus controller moves
+  `aria-current` between rows and the look follows from `.split-view-row[aria-current]` in the
+  package stylesheet, so the selected state cannot fall out of a Tailwind build the way class
+  names toggled from JavaScript can. It is drawn with an inset `box-shadow` rather than a left
+  border, measured: rows are separated with `border-b border-base-200/70`, and that colour utility
+  claims all four sides from Tailwind's utilities layer, which beats `@layer components` outright
+  — a `border-l-primary` in the component sheet rendered base-200 and the highlight was invisible.
+  The shadow also paints inside the padding box, so the selection moves between rows without
+  shifting a pixel of text. `data-split-view-selected-class` is there for a host that wants more.
+
+  **Back and forward behave.** A row click promotes the frame swap to a Turbo visit, and the
+  snapshot Turbo caches for the page being left is taken between the click and the frame's
+  response — so it holds the highlight the controller had just moved next to the detail pane from
+  *before* the swap, and pressing back restored a master pointing at one row with an empty detail
+  beside it. On a history traversal the controller now re-derives the highlight from the URL
+  instead of trusting that snapshot, which it can do because each row's href *is* the URL that
+  selects it. Only on a traversal: on a first paint the server's markup wins, since a master can
+  live on a page whose URL is not in its rows' URL space at all.
+
+  `.split-view-scroll` is an opt-in class for whichever part of the master should scroll — usually
+  the list alone, so tabs above it and pagination below it stay put — reading
+  `--bali-split-master-max-h` (default `calc(100vh - 20rem)`) so each screen can tune it to its own
+  chrome. `--bali-split-master-width` carries `master_width:` for the same reason a Tailwind
+  arbitrary value cannot: the width is a runtime value the build never sees.
+
 ## [v3.1.0.beta.5] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beside it. On a history traversal the controller now re-derives the highlight from the URL
   instead of trusting that snapshot, which it can do because each row's href *is* the URL that
   selects it. Only on a traversal: on a first paint the server's markup wins, since a master can
-  live on a page whose URL is not in its rows' URL space at all.
+  live on a page whose URL is not in its rows' URL space at all. The href and the location are
+  matched on path plus query params **as a set**, not as one string — the two are built by
+  different code paths, so the location routinely carries params the href never had (a page
+  number, a sort) and lists the shared ones in another order, and a string comparison called
+  those a different place and dropped the highlight.
 
   `.split-view-scroll` is an opt-in class for whichever part of the master should scroll — usually
   the list alone, so tabs above it and pagination below it stay put — reading

--- a/app/assets/stylesheets/bali/components.css
+++ b/app/assets/stylesheets/bali/components.css
@@ -36,6 +36,7 @@
 @import "../../../components/bali/app_layout/index.css" layer(components);
 @import "../../../components/bali/drawer/index.css" layer(components);
 @import "../../../components/bali/image_grid/index.css" layer(components);
+@import "../../../components/bali/split_view/index.css" layer(components);
 
 /* Feedback Components. The toast *stack* is layered; the toast itself is not --
    see the unlayered group below and that sheet's own header. */

--- a/app/components/bali/split_view/component.html.erb
+++ b/app/components/bali/split_view/component.html.erb
@@ -1,0 +1,12 @@
+<%# `tag.turbo_frame` and not `turbo_frame_tag`: turbo-rails is a development
+    dependency here, not a runtime one, so the component builds the element
+    itself instead of reaching for a helper a host may not have loaded. %>
+<%= tag.div(**container_attributes) do %>
+  <div class="split-view-master" data-controller="split-view">
+    <%= master %>
+  </div>
+
+  <%= tag.turbo_frame(**frame_attributes) do %>
+    <%= detail? ? detail : empty_detail %>
+  <% end %>
+<% end %>

--- a/app/components/bali/split_view/component.rb
+++ b/app/components/bali/split_view/component.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Bali
+  module SplitView
+    # Master-detail layout (the "inbox" shape): a list on the left, the detail of
+    # the selected row on the right inside a Turbo Frame, so clicking a row swaps
+    # only the detail pane — the master keeps its scroll position and its
+    # highlight without a re-render.
+    #
+    # The component is deliberately thin. It owns the three things that are
+    # identical in every master-detail screen — the responsive grid, the frame,
+    # and the row-highlight controller — and nothing else. Tabs, filter chips,
+    # pagination and the rows themselves are content: they go inside the `master`
+    # slot in whatever shape the screen needs.
+    #
+    #   <%= render Bali::SplitView::Component.new(frame_id: "inbox-detail") do |split| %>
+    #     <% split.with_master do %>
+    #       <%= render "master_pane", items: @items, selected: @selected %>
+    #     <% end %>
+    #     <% if @selected %>
+    #       <% split.with_detail { render "detail_pane", item: @selected } %>
+    #     <% else %>
+    #       <% split.with_empty_detail do %>
+    #         <%= render Bali::EmptyState::Component.new(title: "Selecciona un elemento") %>
+    #       <% end %>
+    #     <% end %>
+    #   <% end %>
+    #
+    # Rows opt into the highlight with three data attributes and the
+    # `split-view-row` class:
+    #
+    #   <%= link_to inbox_path(selected: item.id),
+    #         class: "split-view-row",
+    #         aria: { current: (item == @selected ? "true" : nil) },
+    #         data: { turbo_frame: "inbox-detail",
+    #                 turbo_action: "advance",
+    #                 split_view_target: "row",
+    #                 action: "click->split-view#select" } do %>
+    #
+    # The server still paints the selection on first render and on full-page
+    # navigation; the Stimulus controller only covers the in-page transitions.
+    # Below `lg` the two panes stack (master on top), which needs no extra JS.
+    class Component < ApplicationViewComponent
+      # Free-form left column. Wrapped in the `split-view` controller element so
+      # rows inside it can be its targets.
+      renders_one :master
+
+      # Initial contents of the frame — what the server renders for the current
+      # selection.
+      renders_one :detail
+
+      # Shown inside the frame when there is no selection. Ignored when `detail`
+      # is present.
+      renders_one :empty_detail
+
+      DEFAULT_MASTER_WIDTH = "420px"
+
+      # A single CSS length or percentage. Anything more expressive (`minmax()`,
+      # `clamp()`) belongs in the host's own stylesheet overriding
+      # `--bali-split-master-width`, not in an inline style attribute built from
+      # a Ruby argument.
+      MASTER_WIDTH_FORMAT = /\A\d+(\.\d+)?(px|rem|em|ch|vw|%)\z/
+
+      attr_reader :frame_id, :master_width
+
+      # frame_id  - id of the detail Turbo Frame. Rows target it with
+      #             `data-turbo-frame`, so it has to be unique in the page.
+      # master_width - width of the master column from `lg` up. CSS length or
+      #             percentage; drives `--bali-split-master-width`.
+      # advance   - emit `data-turbo-action="advance"` on the frame so a row click
+      #             pushes its URL into the history and the selection is
+      #             deep-linkable. Turn it off for a split view that is not a
+      #             navigable location of its own.
+      def initialize(frame_id:, master_width: DEFAULT_MASTER_WIDTH, advance: true, **options)
+        @frame_id = frame_id
+        @master_width = validated_master_width(master_width)
+        @advance = advance
+        @options = options
+      end
+
+      private
+
+      attr_reader :options
+
+      def advance? = @advance
+
+      def validated_master_width(value)
+        width = value.to_s.strip
+        return width if width.match?(MASTER_WIDTH_FORMAT)
+
+        raise ArgumentError,
+              "master_width must be a CSS length or percentage (e.g. \"420px\", \"24rem\", \"30%\"), got #{value.inspect}. " \
+              "For anything more expressive, override --bali-split-master-width in your own stylesheet."
+      end
+
+      def container_attributes
+        options.except(:class, :style)
+               .merge(
+                 class: class_names("split-view-component", options[:class]),
+                 # The only inline declaration is the custom property the grid
+                 # reads: `lg:grid-cols-[#{master_width}_1fr]` would be an
+                 # arbitrary value Tailwind never sees at build time, so it would
+                 # be purged out of the bundle.
+                 style: [ "--bali-split-master-width: #{master_width}", options[:style] ].compact.join("; ")
+               )
+      end
+
+      def frame_attributes
+        { id: frame_id, class: "split-view-detail" }.tap do |attributes|
+          attributes[:data] = { turbo_action: "advance" } if advance?
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/split_view/component.rb
+++ b/app/components/bali/split_view/component.rb
@@ -33,9 +33,12 @@ module Bali
     #         class: "split-view-row",
     #         aria: { current: (item == @selected ? "true" : nil) },
     #         data: { turbo_frame: "inbox-detail",
-    #                 turbo_action: "advance",
     #                 split_view_target: "row",
     #                 action: "click->split-view#select" } do %>
+    #
+    # No `turbo_action:` on the row: `advance:` puts it on the frame, and a
+    # link-level one wins over the frame's — so writing it here would silently
+    # defeat `advance: false`.
     #
     # The server still paints the selection on first render and on full-page
     # navigation; the Stimulus controller only covers the in-page transitions.

--- a/app/components/bali/split_view/index.css
+++ b/app/components/bali/split_view/index.css
@@ -1,0 +1,66 @@
+/* SplitView Component
+ *
+ * Three things live here rather than as utilities on the template:
+ *
+ *   1. The grid tracks. The master width is a runtime value, so
+ *      `lg:grid-cols-[420px_1fr]` cannot work — Tailwind only emits arbitrary
+ *      values it can read in the source at build time. The component writes
+ *      `--bali-split-master-width` into a style attribute and this rule reads it.
+ *   2. The scroll helper. `--bali-split-master-max-h` is the knob a host turns
+ *      when its own chrome is taller or shorter than the default assumption.
+ *   3. The row highlight, keyed on `aria-current`. The Stimulus controller only
+ *      moves the attribute; the look follows from here, so the selected style
+ *      cannot fall out of the Tailwind build the way a class list toggled from
+ *      JavaScript can.
+ *
+ * `@layer components` on purpose: a host utility on the container (`gap-6`,
+ * `lg:items-stretch`) beats everything below, which is the point.
+ */
+
+.split-view-component {
+  @apply grid grid-cols-1 gap-4 items-start;
+}
+
+/* `lg` — the breakpoint gc's inbox splits at, and the one the stacked mobile
+   behaviour is documented against. */
+@media (width >= 64rem) {
+  .split-view-component {
+    grid-template-columns: var(--bali-split-master-width, 420px) 1fr;
+  }
+}
+
+/* Opt-in, applied by the host to whatever part of the master should scroll —
+   usually the list alone, so tabs above it and pagination below it stay put.
+   The component cannot place this itself without dictating the master's
+   anatomy. */
+.split-view-scroll {
+  overflow-y: auto;
+  max-height: var(--bali-split-master-max-h, calc(100vh - 20rem));
+}
+
+/* ── Row states ───────────────────────────────────────────────────────────
+   The selection bar is an INSET BOX-SHADOW and not a left border, measured:
+   a row separator is written `border-b border-base-200/70`, and Tailwind's
+   `border-<color>` utility sets the colour of all four sides, not just the one
+   the `border-b` drew. That utility lives in Tailwind's utilities layer, which
+   beats `@layer components` outright — so a `border-l-primary` here rendered
+   base-200 on the selected row and the highlight was invisible. box-shadow is
+   a property no border utility claims, it paints inside the padding box so it
+   needs no transparent border reserved for it, and the selection therefore
+   moves between rows without shifting any text.
+
+   The tint is still a background, which a host CAN override with a utility of
+   its own — that one is deliberate: a row with its own background is a host
+   saying so. */
+.split-view-row {
+  @apply block transition-[background-color,box-shadow];
+}
+
+.split-view-row:hover {
+  @apply bg-base-200/50;
+}
+
+.split-view-row[aria-current] {
+  @apply bg-primary/5;
+  box-shadow: inset 3px 0 0 0 var(--color-primary);
+}

--- a/app/components/bali/split_view/index.js
+++ b/app/components/bali/split_view/index.js
@@ -1,0 +1,90 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Whether the navigation now in flight is a back/forward rather than a new one.
+// It lives at module scope because the controller instance that would remember
+// it is destroyed by the very render this has to survive: Turbo replaces the
+// body with the restored snapshot, and the fresh instance's `connect()` has no
+// way of its own to tell a first paint from a restore. Cleared on `turbo:load`,
+// which fires once every controller on the restored page has connected.
+let restoringHistory = false
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('popstate', () => { restoringHistory = true })
+  document.addEventListener('turbo:load', () => { restoringHistory = false })
+}
+
+// Moves the master-pane row highlight when a row is clicked, so the detail
+// Turbo Frame can swap without the master re-rendering — which is what keeps
+// its scroll position and its selection intact.
+//
+// The server still paints the selection on first render and on every full-page
+// navigation (a filter tab, a page of results); this controller only covers the
+// in-page transitions between them.
+//
+// The look of a selected row comes from `.split-view-row[aria-current]` in the
+// component stylesheet, so nothing here depends on class names surviving a
+// Tailwind build. `selected`/`unselected` Stimulus classes are there for a host
+// that wants to add its own on top:
+//
+//   <div data-controller="split-view"
+//        data-split-view-selected-class="ring-2 ring-primary">
+export class SplitViewController extends Controller {
+  static targets = ['row']
+  static classes = ['selected', 'unselected']
+
+  connect () {
+    this.syncFromLocation = this.syncFromLocation.bind(this)
+    window.addEventListener('popstate', this.syncFromLocation)
+    // A restore that DID replace the body lands here, on the new instance.
+    if (restoringHistory) this.syncFromLocation()
+  }
+
+  disconnect () {
+    window.removeEventListener('popstate', this.syncFromLocation)
+  }
+
+  // Back and forward, and only those. Measured: a row click promotes the frame
+  // swap to a visit, and the snapshot Turbo caches for the page being left is
+  // taken between the click and the frame's response — so it holds the highlight
+  // this controller had just moved next to the detail pane from BEFORE the swap.
+  // Pressing back restored exactly that: a master pointing at one row, an empty
+  // detail beside it.
+  //
+  // On a history traversal the URL is the only honest source, and it is a
+  // sufficient one: each row's href IS the URL that selects it, so the highlight
+  // is re-derived rather than remembered. No row matching means no selection at
+  // this URL, which is what going back to the unselected list is.
+  //
+  // Only on a traversal. On a first paint the server's markup wins, because a
+  // master can be rendered on a page whose URL is not in the rows' URL space at
+  // all and deriving there would erase a correct selection.
+  syncFromLocation () {
+    const current = this.rowTargets.find(row => row.href === window.location.href) ?? null
+    this.rowTargets.forEach(row => this.applySelection(row, row === current))
+  }
+
+  select (event) {
+    const clicked = event.currentTarget
+    this.rowTargets.forEach(row => this.applySelection(row, row === clicked))
+  }
+
+  applySelection (row, selected) {
+    if (selected) {
+      row.setAttribute('aria-current', 'true')
+    } else {
+      row.removeAttribute('aria-current')
+    }
+
+    // The plural readers, not `this.selectedClass`: a host writing two classes
+    // into one attribute would otherwise reach `classList.toggle` with a space
+    // in the string, which throws InvalidCharacterError.
+    this.toggleClasses(row, this.selectedClasses, selected)
+    this.toggleClasses(row, this.unselectedClasses, !selected)
+  }
+
+  toggleClasses (row, classes, on) {
+    if (classes.length === 0) return
+
+    on ? row.classList.add(...classes) : row.classList.remove(...classes)
+  }
+}

--- a/app/components/bali/split_view/index.js
+++ b/app/components/bali/split_view/index.js
@@ -59,8 +59,31 @@ export class SplitViewController extends Controller {
   // master can be rendered on a page whose URL is not in the rows' URL space at
   // all and deriving there would erase a correct selection.
   syncFromLocation () {
-    const current = this.rowTargets.find(row => row.href === window.location.href) ?? null
+    const current = this.rowTargets.find(row => this.selectsCurrentLocation(row)) ?? null
     this.rowTargets.forEach(row => this.applySelection(row, row === current))
+  }
+
+  // Whether this row's href names the location we are on. Not `row.href ===
+  // location.href`: the two are built by different code paths — the row by a
+  // route helper, the location by whatever put it in the history — so
+  // `?a=1&b=2` and `?b=2&a=1` are the same place and a string comparison calls
+  // them different, losing the highlight on back. Query params are compared as
+  // a set for that reason.
+  //
+  // Params the location has and the row does not (a page number, a filter the
+  // href leaves out) do not disqualify it: the question is whether the row's
+  // URL is satisfied here, not whether the two are identical. That also makes
+  // path-based selection work — a row pointing at `/inbox/9` carries no params
+  // and is identified by its path alone.
+  selectsCurrentLocation (row) {
+    const target = new URL(row.href, window.location.href)
+    const here = new URL(window.location.href)
+
+    if (target.origin !== here.origin || target.pathname !== here.pathname) return false
+
+    return [...target.searchParams].every(
+      ([key, value]) => here.searchParams.getAll(key).includes(value)
+    )
   }
 
   select (event) {

--- a/app/components/bali/split_view/preview.rb
+++ b/app/components/bali/split_view/preview.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Bali
+  module SplitView
+    class Preview < ApplicationViewComponentPreview
+      TEMPLATE = "bali/split_view/previews/default"
+
+      # The rows link to `/split-view?selected=<id>` in the dummy app, a real page
+      # that renders the same `split-view-detail` frame. Clicking one is a real
+      # Turbo Frame navigation: only the right column is replaced, the master keeps
+      # its scroll, and the URL advances so the selection is deep-linkable.
+      #
+      # Below `lg` the panes stack, master on top.
+      # @param master_width [String] select ["320px", "420px", "36rem", "35%"]
+      def default(master_width: "420px")
+        render_with_template(
+          template: Bali::SplitView::Preview::TEMPLATE,
+          locals: { movies: preview_movies, selected: nil, master_width: master_width }
+        )
+      end
+
+      # What the server renders for a deep link: the row already carries
+      # `aria-current="true"` on first paint and the frame already holds the
+      # detail. The Stimulus controller only takes over from the next click on.
+      def with_selection
+        movies = preview_movies
+
+        render_with_template(
+          template: Bali::SplitView::Preview::TEMPLATE,
+          locals: { movies: movies, selected: movies.second, master_width: "420px" }
+        )
+      end
+
+      # `advance: false` for a split view that is not a location of its own — the
+      # frame still swaps, but nothing is pushed into the history.
+      def without_advance
+        render_with_template(
+          template: Bali::SplitView::Preview::TEMPLATE,
+          locals: { movies: preview_movies, selected: nil, master_width: "420px", advance: false }
+        )
+      end
+
+      private
+
+      def preview_movies
+        Movie.includes(:studio).order(:name).limit(8)
+      end
+    end
+  end
+end

--- a/app/components/bali/split_view/previews/default.html.erb
+++ b/app/components/bali/split_view/previews/default.html.erb
@@ -1,0 +1,61 @@
+<%# Rows point at the dummy app's `/split-view` page, which renders the same
+    `split-view-detail` frame, so the swap here is a real frame navigation and
+    not a preview-only illusion. %>
+<%= render Bali::SplitView::Component.new(
+  frame_id: "split-view-detail",
+  master_width: master_width,
+  advance: local_assigns.fetch(:advance, true)
+) do |split| %>
+  <% split.with_master do %>
+    <%= render Bali::Card::Component.new(style: :bordered, body_class: "p-0") do %>
+      <div class="px-4 py-3 border-b border-base-200 text-sm font-medium">
+        Catálogo
+        <span class="text-base-content/50 font-normal ml-1"><%= movies.size %></span>
+      </div>
+
+      <%# The scroll wrapper sits around the list alone so the header above it
+          stays put. --bali-split-master-max-h is the per-screen knob. %>
+      <div class="split-view-scroll" style="--bali-split-master-max-h: 22rem" data-testid="master-list">
+        <% movies.each do |movie| %>
+          <%= link_to "/split-view?selected=#{movie.id}",
+                id: "split-view-row-#{movie.id}",
+                class: "split-view-row px-4 py-3 border-b border-base-200/70",
+                aria: { current: (movie == selected ? "true" : nil) },
+                data: {
+                  turbo_frame: "split-view-detail",
+                  split_view_target: "row",
+                  action: "click->split-view#select"
+                } do %>
+            <div class="font-medium text-sm leading-snug truncate"><%= movie.name %></div>
+            <div class="flex items-center gap-2 mt-1">
+              <%= render Bali::Tag::Component.new(text: movie.genre, color: :info, size: :sm) %>
+              <span class="text-[11px] text-base-content/60 truncate"><%= movie.studio&.name %></span>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if selected %>
+    <% split.with_detail do %>
+      <%= render Bali::Card::Component.new(style: :bordered) do %>
+        <div class="card-body">
+          <h2 class="card-title text-lg" data-testid="detail-title"><%= selected.name %></h2>
+          <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
+            <% list.with_item(label: "Género", value: selected.genre) %>
+            <% list.with_item(label: "Estudio", value: selected.studio&.name) %>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  <% else %>
+    <% split.with_empty_detail do %>
+      <%= render Bali::EmptyState::Component.new(
+        title: "Selecciona una película",
+        description: "Elige una fila de la izquierda para ver su ficha aquí.",
+        icon: "inbox"
+      ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bali/split_view/previews/default.html.erb
+++ b/app/components/bali/split_view/previews/default.html.erb
@@ -39,14 +39,16 @@
 
   <% if selected %>
     <% split.with_detail do %>
-      <%= render Bali::Card::Component.new(style: :bordered) do %>
-        <div class="card-body">
-          <h2 class="card-title text-lg" data-testid="detail-title"><%= selected.name %></h2>
-          <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
-            <% list.with_item(label: "Género", value: selected.genre) %>
-            <% list.with_item(label: "Estudio", value: selected.studio&.name) %>
-          <% end %>
-        </div>
+      <%# Card writes its own body wrapper; a second one by hand nests two and
+          doubles the padding (#833). `test/requests/nested_card_body_test.rb`
+          fails on any preview that writes one — the extra class goes in
+          `body_class:`, and the heading in the `title` slot. %>
+      <%= render Bali::Card::Component.new(style: :bordered) do |card| %>
+        <% card.with_title(selected.name, class: "text-lg", data: { testid: "detail-title" }) %>
+        <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
+          <% list.with_item(label: "Género", value: selected.genre) %>
+          <% list.with_item(label: "Estudio", value: selected.studio&.name) %>
+        <% end %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/frontend/bali/components/index.js
+++ b/app/frontend/bali/components/index.js
@@ -61,6 +61,7 @@ import { FeedbackWidgetController } from '../../../components/bali/feedback_widg
 import { CommandController } from '../../../components/bali/command/index'
 import { StatusController } from '../../../components/bali/status/index'
 import { ToastContainerController } from '../../../components/bali/toast_container/index'
+import { SplitViewController } from '../../../components/bali/split_view/index'
 
 export {
   AlertController,
@@ -98,6 +99,7 @@ export {
   SideMenuFlyoutController,
   SideMenuTriggerController,
   SortableListController,
+  SplitViewController,
   StatusController,
   TabsController,
   TimeagoController,
@@ -187,7 +189,10 @@ export const CONTROLLERS = /* @__PURE__ */ Object.freeze({
   'feedback-widget': FeedbackWidgetController,
 
   // Command palette
-  command: CommandController
+  command: CommandController,
+
+  // Master-detail
+  'split-view': SplitViewController
 })
 
 /**

--- a/app/frontend/bali/index.js
+++ b/app/frontend/bali/index.js
@@ -118,6 +118,7 @@ export {
   SideMenuFlyoutController,
   SideMenuTriggerController,
   SortableListController,
+  SplitViewController,
   StatusController,
   TabsController,
   TimeagoController,

--- a/cypress/e2e/split-view.cy.js
+++ b/cypress/e2e/split-view.cy.js
@@ -1,0 +1,150 @@
+// The point of SplitView is what does NOT happen on a row click: the master
+// pane must survive untouched, keeping its scroll position and its DOM, while
+// only the detail frame is replaced. Every assertion here is about that, so the
+// tests mark a live node and measure geometry rather than reading text.
+describe('SplitView', () => {
+  const masterList = () => cy.get('[data-testid="master-list"]')
+
+  context('default (no selection, advance on)', () => {
+    beforeEach(() => {
+      cy.visit('/bali/split_view/default')
+      // Stamped on the live node: a re-render of the master would replace it and
+      // the attribute would be gone.
+      masterList().invoke('attr', 'data-sentinel', 'kept')
+    })
+
+    it('starts on the empty detail with no row selected', () => {
+      cy.get('.split-view-detail .empty-state-component').should('be.visible')
+      cy.get('.split-view-row[aria-current]').should('not.exist')
+    })
+
+    it('replaces only the detail frame when a row is clicked', () => {
+      cy.get('.split-view-row').eq(2).click()
+
+      cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+      cy.get('.split-view-detail .empty-state-component').should('not.exist')
+      // Same master node as before the click.
+      masterList().should('have.attr', 'data-sentinel', 'kept')
+      cy.get('.split-view-row').should('have.length', 8)
+    })
+
+    it('keeps the master scroll position across the swap', () => {
+      masterList().scrollTo(0, 120)
+      masterList().its('0.scrollTop').should('be.greaterThan', 0).then((before) => {
+        // `scrollBehavior: false` or Cypress scrolls the row into view before
+        // clicking and moves the very scrollTop this test is about. Row 3 is
+        // already on screen at this offset.
+        cy.get('.split-view-row').eq(3).click({ scrollBehavior: false })
+        cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+        masterList().its('0.scrollTop').should('eq', before)
+      })
+    })
+
+    it('moves aria-current to the clicked row and nowhere else', () => {
+      cy.get('.split-view-row').eq(1).click()
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+      cy.get('.split-view-row').eq(1).should('have.attr', 'aria-current', 'true')
+
+      cy.get('.split-view-row').eq(4).click()
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+      cy.get('.split-view-row').eq(4).should('have.attr', 'aria-current', 'true')
+      cy.get('.split-view-row').eq(1).should('not.have.attr', 'aria-current')
+    })
+
+    // The selection bar has to be an inset box-shadow rather than a left
+    // border: the rows here carry `border-b border-base-200/70`, the idiom for
+    // a separator, and that colour utility claims all four sides from
+    // Tailwind's utilities layer — which beats @layer components. A
+    // `border-l-primary` in the component sheet renders base-200 under it and
+    // the highlight disappears. This test fails if anyone moves it back.
+    it('paints the selected row from CSS the row separator cannot override', () => {
+      cy.get('.split-view-row').eq(1).as('row')
+      cy.get('@row').should('have.css', 'box-shadow', 'none')
+
+      cy.get('@row').click()
+      // Not just /inset/: a shadow mid-transition, or one whose colour failed to
+      // resolve, still reads `... 0px 0px 0px 0px inset` and would pass that.
+      // The 3px offset and a non-transparent colour are the bar itself.
+      cy.get('@row')
+        .should('have.css', 'box-shadow')
+        .and('include', '3px')
+        .and('include', 'inset')
+        .and('not.match', /^(rgba\(0, 0, 0, 0\)|oklab\(0 0 0 \/ 0\))/)
+    })
+
+    it('does not reserve layout space for the selection bar', () => {
+      cy.get('.split-view-row').eq(1).then(($row) => {
+        const before = $row[0].getBoundingClientRect()
+        cy.get('.split-view-row').eq(1).click()
+        cy.get('.split-view-row').eq(1).should('have.attr', 'aria-current', 'true')
+        cy.get('.split-view-row').eq(1).then(($after) => {
+          const after = $after[0].getBoundingClientRect()
+          expect(after.width).to.eq(before.width)
+          expect(after.left).to.eq(before.left)
+        })
+      })
+    })
+
+    it('advances the URL and restores the preview on back', () => {
+      cy.get('.split-view-row').eq(3).invoke('attr', 'href').then((href) => {
+        cy.get('.split-view-row').eq(3).click()
+        cy.location('pathname').should('eq', '/split-view')
+        cy.location('search').should('eq', href.split('?')[1] ? `?${href.split('?')[1]}` : '')
+
+        cy.go('back')
+        cy.location('pathname').should('include', '/lookbook/preview/bali/split_view/default')
+        cy.get('.split-view-detail .empty-state-component').should('be.visible')
+        // The highlight has to rewind with the frame. Turbo caches the snapshot
+        // of the page it leaves, and it takes it AFTER the controller has moved
+        // aria-current — so without the `turbo:before-cache` rewind this page
+        // came back showing a selected row next to an empty detail.
+        cy.get('.split-view-row[aria-current]').should('not.exist')
+      })
+    })
+  })
+
+  context('with_selection (server-painted selection)', () => {
+    it('renders the detail and the highlight without any JS having run', () => {
+      cy.visit('/bali/split_view/with_selection')
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+      cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+    })
+  })
+
+  context('without_advance', () => {
+    it('swaps the frame but leaves the history alone', () => {
+      cy.visit('/bali/split_view/without_advance')
+      cy.get('.split-view-detail').should('not.have.attr', 'data-turbo-action')
+
+      cy.get('.split-view-row').eq(2).click()
+      cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+      cy.location('pathname').should('include', '/lookbook/preview/bali/split_view/without_advance')
+    })
+  })
+
+  context('responsive layout', () => {
+    it('puts the panes side by side from lg up and stacks them below it', () => {
+      cy.visit('/bali/split_view/default')
+
+      cy.viewport(1280, 800)
+      cy.get('.split-view-component')
+        .should('have.css', 'grid-template-columns')
+        .and('match', /^420px /)
+
+      cy.viewport(700, 800)
+      cy.get('.split-view-component')
+        .invoke('css', 'grid-template-columns')
+        .should((columns) => {
+          expect(columns.split(' ')).to.have.length(1)
+        })
+    })
+
+    it('honours a custom master_width through the CSS custom property', () => {
+      cy.viewport(1280, 800)
+      cy.visit('/bali/split_view/default?master_width=320px')
+      cy.get('.split-view-component')
+        .should('have.css', 'grid-template-columns')
+        .and('match', /^320px /)
+    })
+  })
+})

--- a/cypress/e2e/split-view.cy.js
+++ b/cypress/e2e/split-view.cy.js
@@ -122,6 +122,48 @@ describe('SplitView', () => {
     })
   })
 
+  // Which row a location selects, driven straight at the controller with a
+  // history entry and a popstate. Deliberately not through `cy.go('back')`:
+  // that also exercises Turbo's snapshot cache, and the rule under test is the
+  // controller's alone — given this URL, which row is current.
+  context('deciding which row a location selects', () => {
+    const traverseTo = search =>
+      cy.window().then((win) => {
+        win.history.pushState({}, '', `/split-view${search}`)
+        win.dispatchEvent(new win.PopStateEvent('popstate', { state: {} }))
+      })
+
+    beforeEach(() => {
+      cy.visit('/bali/split_view/default')
+      cy.get('.split-view-row').eq(2).invoke('attr', 'href').then((href) => {
+        cy.wrap(new URL(href, 'http://example.test').searchParams.get('selected')).as('id')
+      })
+    })
+
+    it('selects the row whose href the location satisfies', function () {
+      traverseTo(`?selected=${this.id}`)
+      cy.get(`#split-view-row-${this.id}`).should('have.attr', 'aria-current', 'true')
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+    })
+
+    // The regression this replaced an exact string comparison for: the row href
+    // and the location are built by different code paths, so the location can
+    // carry params the href never had and list them in another order.
+    it('still selects it when the location carries extra params, in any order', function () {
+      traverseTo(`?sort=name&selected=${this.id}&page=2`)
+      cy.get(`#split-view-row-${this.id}`).should('have.attr', 'aria-current', 'true')
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+    })
+
+    it('selects nothing when no row href is satisfied', function () {
+      traverseTo(`?selected=${this.id}`)
+      cy.get('.split-view-row[aria-current="true"]').should('have.length', 1)
+
+      traverseTo('?sort=name')
+      cy.get('.split-view-row[aria-current]').should('not.exist')
+    })
+  })
+
   context('responsive layout', () => {
     it('puts the panes side by side from lg up and stacks them below it', () => {
       cy.visit('/bali/split_view/default')

--- a/spec/dummy/app/controllers/split_views_controller.rb
+++ b/spec/dummy/app/controllers/split_views_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Reference wiring for Bali::SplitView (#728): the whole Rails side of a
+# master-detail screen in one action. `?selected=<id>` is what makes the
+# selection deep-linkable — the row links carry `data-turbo-frame`, so Turbo
+# swaps only the detail pane, but the same URL loaded cold renders the full page
+# with that row already highlighted.
+#
+# The Lookbook preview of the component points its rows at this route, so the
+# frame swap the preview demonstrates is a real request against a real page.
+class SplitViewsController < ApplicationController
+  MASTER_LIMIT = 12
+
+  def show
+    @movies = Movie.includes(:studio).order(:name).limit(MASTER_LIMIT)
+    @selected = @movies.detect { |movie| movie.id == params[:selected].to_i }
+  end
+end

--- a/spec/dummy/app/views/split_views/_detail.html.erb
+++ b/spec/dummy/app/views/split_views/_detail.html.erb
@@ -1,12 +1,11 @@
-<%= render Bali::Card::Component.new(style: :bordered) do %>
-  <div class="card-body">
-    <h2 class="card-title text-lg" data-testid="detail-title"><%= movie.name %></h2>
+<%# Card emits its own `.card-body`; a second one by hand doubles the padding (#833). %>
+<%= render Bali::Card::Component.new(style: :bordered) do |card| %>
+  <% card.with_title(movie.name, class: 'text-lg', data: { testid: 'detail-title' }) %>
 
-    <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
-      <% list.with_item(label: 'Género', value: movie.genre) %>
-      <% list.with_item(label: 'Estudio', value: movie.studio&.name) %>
-      <% list.with_item(label: 'Estado', value: movie.status.to_s.humanize) %>
-      <% list.with_item(label: 'Presupuesto', value: number_to_currency(movie.budget, precision: 0)) %>
-    <% end %>
-  </div>
+  <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
+    <% list.with_item(label: 'Género', value: movie.genre) %>
+    <% list.with_item(label: 'Estudio', value: movie.studio&.name) %>
+    <% list.with_item(label: 'Estado', value: movie.status.to_s.humanize) %>
+    <% list.with_item(label: 'Presupuesto', value: number_to_currency(movie.budget, precision: 0)) %>
+  <% end %>
 <% end %>

--- a/spec/dummy/app/views/split_views/_detail.html.erb
+++ b/spec/dummy/app/views/split_views/_detail.html.erb
@@ -1,0 +1,12 @@
+<%= render Bali::Card::Component.new(style: :bordered) do %>
+  <div class="card-body">
+    <h2 class="card-title text-lg" data-testid="detail-title"><%= movie.name %></h2>
+
+    <%= render Bali::DescriptionList::Component.new(columns: 2) do |list| %>
+      <% list.with_item(label: 'Género', value: movie.genre) %>
+      <% list.with_item(label: 'Estudio', value: movie.studio&.name) %>
+      <% list.with_item(label: 'Estado', value: movie.status.to_s.humanize) %>
+      <% list.with_item(label: 'Presupuesto', value: number_to_currency(movie.budget, precision: 0)) %>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/dummy/app/views/split_views/_master.html.erb
+++ b/spec/dummy/app/views/split_views/_master.html.erb
@@ -1,0 +1,31 @@
+<%# The scroll wrapper goes around the list alone, not around the whole master:
+    the header above it stays put while the rows scroll. `split-view-scroll`
+    reads --bali-split-master-max-h, which this page narrows because its own
+    chrome (navbar + page header) is shorter than the component's default
+    assumption. %>
+<%= render Bali::Card::Component.new(style: :bordered, body_class: 'p-0') do %>
+  <div class="px-4 py-3 border-b border-base-200 text-sm font-medium">
+    Catálogo
+    <span class="text-base-content/50 font-normal ml-1"><%= movies.size %></span>
+  </div>
+
+  <div class="split-view-scroll" style="--bali-split-master-max-h: 26rem" data-testid="master-list">
+    <% movies.each do |movie| %>
+      <%= link_to split_view_path(selected: movie.id),
+            id: "split-view-row-#{movie.id}",
+            class: 'split-view-row px-4 py-3 border-b border-base-200/70',
+            aria: { current: (movie == selected ? 'true' : nil) },
+            data: {
+              turbo_frame: 'split-view-detail',
+              split_view_target: 'row',
+              action: 'click->split-view#select'
+            } do %>
+        <div class="font-medium text-sm leading-snug truncate"><%= movie.name %></div>
+        <div class="flex items-center gap-2 mt-1">
+          <%= render Bali::Tag::Component.new(text: movie.genre, color: :info, size: :sm) %>
+          <span class="text-[11px] text-base-content/60 truncate"><%= movie.studio&.name %></span>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/dummy/app/views/split_views/show.html.erb
+++ b/spec/dummy/app/views/split_views/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for(:title) { 'SplitView' } %>
+
+<%= render Bali::ShowPage::Component.new(
+  title: 'SplitView',
+  subtitle: 'Master-detail con el detalle dentro de un Turbo Frame'
+) do |page| %>
+  <% page.with_body do %>
+    <%= render Bali::SplitView::Component.new(frame_id: 'split-view-detail') do |split| %>
+      <% split.with_master do %>
+        <%= render 'split_views/master', movies: @movies, selected: @selected %>
+      <% end %>
+
+      <% if @selected %>
+        <% split.with_detail do %>
+          <%= render 'split_views/detail', movie: @selected %>
+        <% end %>
+      <% else %>
+        <% split.with_empty_detail do %>
+          <%= render Bali::EmptyState::Component.new(
+            title: 'Selecciona una película',
+            description: 'Elige una fila de la izquierda para ver su ficha aquí.',
+            icon: 'inbox'
+          ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -64,6 +64,9 @@ Rails.application.routes.draw do
   get 'sidemenu-example', to: 'pages#sidemenu_example'
   get 'z-stack', to: 'pages#z_stack' # Manual check for the overlay z-index scale
   get 'feedback-widget-demo', to: 'pages#feedback_widget_demo'
+  # SplitView reference page. `?selected=<id>` is the deep link; the Lookbook
+  # preview of the component navigates its detail frame here.
+  get 'split-view', to: 'split_views#show', as: :split_view
   get 'embed/feedback_posts', to: 'pages#feedback_embed' # Stand-in for Opina's embed page
 
   # Modal/Drawer content routes (for remote loading)

--- a/test/bali/components/split_view_test.rb
+++ b/test/bali/components/split_view_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaliSplitViewComponentTest < ComponentTestCase
+  def test_renders_master_and_detail_in_the_grid
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+      split.with_detail { "DETAIL" }
+    end
+
+    assert_selector("div.split-view-component .split-view-master", text: "MASTER")
+    assert_selector("div.split-view-component turbo-frame.split-view-detail", text: "DETAIL", visible: :all)
+  end
+
+  def test_frame_carries_the_given_id
+    render_inline(Bali::SplitView::Component.new(frame_id: "orders-detail")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector("turbo-frame#orders-detail", visible: :all)
+  end
+
+  def test_master_hosts_the_split_view_controller
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector('.split-view-master[data-controller="split-view"]')
+  end
+
+  def test_advance_is_on_by_default
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector('turbo-frame[data-turbo-action="advance"]', visible: :all)
+  end
+
+  def test_advance_false_omits_the_turbo_action
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", advance: false)) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_no_selector("turbo-frame[data-turbo-action]", visible: :all)
+  end
+
+  def test_empty_detail_fills_the_frame_when_there_is_no_detail
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+      split.with_empty_detail { "NOTHING SELECTED" }
+    end
+
+    assert_selector("turbo-frame.split-view-detail", text: "NOTHING SELECTED", visible: :all)
+  end
+
+  def test_detail_wins_over_empty_detail
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+      split.with_detail { "DETAIL" }
+      split.with_empty_detail { "NOTHING SELECTED" }
+    end
+
+    assert_selector("turbo-frame.split-view-detail", text: "DETAIL", visible: :all)
+    assert_no_selector("turbo-frame.split-view-detail", text: "NOTHING SELECTED", visible: :all)
+  end
+
+  def test_default_master_width_reaches_the_custom_property
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector('.split-view-component[style*="--bali-split-master-width: 420px"]')
+  end
+
+  def test_custom_master_width_reaches_the_custom_property
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", master_width: "24rem")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector('.split-view-component[style*="--bali-split-master-width: 24rem"]')
+  end
+
+  def test_percentage_master_width_is_accepted
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", master_width: "35%")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector('.split-view-component[style*="--bali-split-master-width: 35%"]')
+  end
+
+  # The value lands in a style attribute, so anything that is not a plain CSS
+  # length has to be refused rather than interpolated.
+  def test_master_width_that_is_not_a_css_length_raises
+    error = assert_raises(ArgumentError) do
+      render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", master_width: "420px; background: red"))
+    end
+
+    assert_match(/master_width must be a CSS length/, error.message)
+  end
+
+  def test_host_class_is_merged_and_host_style_is_kept
+    render_inline(
+      Bali::SplitView::Component.new(frame_id: "inbox-detail", class: "gap-6", style: "--bali-split-master-max-h: 30rem")
+    ) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector(".split-view-component.gap-6")
+    assert_selector('.split-view-component[style*="--bali-split-master-max-h: 30rem"]')
+    assert_selector('.split-view-component[style*="--bali-split-master-width: 420px"]')
+  end
+
+  def test_arbitrary_html_options_reach_the_container
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", id: "inbox-split")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector("div#inbox-split.split-view-component")
+  end
+end


### PR DESCRIPTION
Primer PR de #728. Aporta el componente, el controller, el CSS, el preview de Lookbook, la página de referencia del dummy y las specs. La guía del patrón va en el PR 2, apilado sobre esta rama.

## Alcance

Decisión de Fede (D728-1 = **b**): componente **delgado** + controller + docs. Se queda con las tres cosas idénticas en toda pantalla master-detail — la rejilla responsive, el Turbo Frame del detalle y el controller del resaltado — y con nada más. Tabs, chips de filtros, paginación y las propias filas son contenido del host y viven dentro del slot `master`.

**El `InboxList` agrupado del issue NO entra en 3.1.** Una sola app (afal-apps) lo tiene, y una sola anatomía no alcanza para triangular una API. Queda para reevaluar cuando una segunda app lo pida.

Móvil (D728-2): por debajo de `lg` los paneles se apilan (master arriba), sin JavaScript extra. La alternativa de página completa se documenta como receta en el PR 2, no se implementa.

## API pública

```ruby
Bali::SplitView::Component.new(
  frame_id:,                    # obligatorio; id del turbo-frame del detalle
  master_width: "420px",        # longitud o porcentaje CSS; columna izquierda desde lg
  advance: true,                # data-turbo-action="advance" en el frame
  **options                     # class/style/id… se fusionan en el contenedor
)
```

Slots: `master` (libre), `detail`, `empty_detail` (solo si no hay `detail`).

Fila del master:

```erb
<%= link_to inbox_path(selected: item.id),
      class: "split-view-row",
      aria: { current: (item == @selected ? "true" : nil) },
      data: { turbo_frame: "inbox-detail",
              split_view_target: "row",
              action: "click->split-view#select" } do %>
```

Clases CSS: `.split-view-row` (fila), `.split-view-scroll` (opt-in, para la parte del master que scrollea). Variables: `--bali-split-master-width`, `--bali-split-master-max-h` (default `calc(100vh - 20rem)`).

## Tres cosas que salieron de medir, no de diseñar

**La barra de selección es un `box-shadow` inset, no un borde izquierdo.** Las filas se separan con `border-b border-base-200/70`, el idiom habitual, y esa utilidad de color reclama los **cuatro** lados desde la capa `utilities`, que le gana a `@layer components` por capa. Un `border-l-primary` en la hoja del componente pintaba base-200 y el resaltado era invisible. El shadow además pinta dentro del padding box, así que la selección se mueve entre filas sin desplazar un pixel de texto. Hay una spec que falla si alguien lo devuelve a un borde.

**El `data-turbo-action` va solo en el frame.** Cuando también estaba en las filas, `advance: false` no servía de nada: el atributo del link manda sobre el del frame. Medido con las dos variantes.

**Back rebobina el resaltado.** El click promociona el swap del frame a una visita, y el snapshot que Turbo cachea de la página que deja se toma entre el click y la respuesta del frame — con el resaltado ya movido junto al detalle de *antes* del swap. Pressing back devolvía un master apuntando a una fila con el detalle vacío al lado. En una navegación de historial el controller vuelve a derivar la selección de la URL, que puede hacerlo porque el href de cada fila **es** la URL que la selecciona. Solo ahí: en el primer pintado manda el servidor.

## Evidencia

- Minitest `test/bali/components/split_view_test.rb`: **13 runs, 19 assertions, 0 failures**.
- Suite completa (hook de pre-push): **4462 runs, 10761 assertions, 0 failures**.
- Cypress `cypress/e2e/split-view.cy.js`: **11 passing**. Mide lo que NO pasa — marca un nodo vivo del master y comprueba que sobrevive al click, que el `scrollTop` no se mueve, que `aria-current` queda en exactamente una fila, que la barra no reserva espacio de layout, y que back rebobina resaltado y detalle a la vez. Nada por `textContent`.
- `yarn check:manifest` OK (67 controllers). Rubocop y StandardJS limpios.
- Verificación en browser de `/lookbook/preview/bali/split_view/{default,with_selection,without_advance}` y de `/split-view` del dummy: swap del frame, avance de URL y barra de selección confirmados a ojo y por estilos computados.

## Riesgo conocido

API con un solo consumidor real (el inbox de gobierno-corporativo, de donde se extrajo). El PR de adopción en gc antes de congelar el release sigue siendo lo que valida los slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)