### PR TITLE
docs(split-view): guía del patrón master-detail (#728, PR 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   way out of them), and the full-page-detail-on-a-phone variant. That last one hinges on a
   measured Turbo fallback: a frame in the DOM is swapped **even under `display: none`**, and
   only a frame that is absent turns the row click into a full visit — so whether a phone gets
-  the split view at all is a server-side decision, and `lg:hidden` will not make it.
+  the split view at all is a server-side decision, and `lg:hidden` will not make it. The guide
+  also covers what happens when the detail request **fails**, which splits two ways and is the
+  one corner that looks fine on screen: a response carrying
+  `<meta name="turbo-visit-control" content="reload">` (Rails' own exception page does) becomes
+  a full-page visit, while any other response without a matching frame is *ignored* — the pane
+  keeps its previous detail while the optimistic highlight has already moved, and the two
+  disagree silently until the next click.
 
 ## [v3.1.0.beta.5] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chrome. `--bali-split-master-width` carries `master_width:` for the same reason a Tailwind
   arbitrary value cannot: the width is a runtime value the build never sees.
 
+  The component is half the screen and the other half is the host's, so
+  **`docs/guides/master-detail.md`** carries the rest of the pattern: the whole Rails side in
+  one action, why the row's href has to hold the current filters, the two different empty
+  states a filtered list needs (composed from `Bali::EmptyState`'s `cta` slot, not added as an
+  option — "no results" beside filters the reader set is a dead end, and the useful thing is a
+  way out of them), and the full-page-detail-on-a-phone variant. That last one hinges on a
+  measured Turbo fallback: a frame in the DOM is swapped **even under `display: none`**, and
+  only a frame that is absent turns the row click into a full visit — so whether a phone gets
+  the split view at all is a server-side decision, and `lg:hidden` will not make it.
+
 ## [v3.1.0.beta.5] - 2026-08-06
 
 ### Added

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -599,6 +599,67 @@ Responsive site footer (DaisyUI `footer`) with brand, link sections, and bottom 
 - `color` - Background color preset: `:neutral`, `:base`, `:primary`, `:secondary` (default: `:neutral`)
 - `center` - Center-align footer content (default: `false`)
 
+#### SplitView
+
+The inbox shape: a list on the left, the detail of the selected row on the right
+inside a Turbo Frame, so a row click swaps only the right column and the list
+keeps its scroll position and its highlight.
+
+```erb
+<%= render Bali::SplitView::Component.new(frame_id: "inbox-detail") do |split| %>
+  <% split.with_master do %>
+    <%= render "master_pane", items: @items, selected: @selected %>
+  <% end %>
+
+  <% if @selected %>
+    <% split.with_detail { render "detail_pane", item: @selected } %>
+  <% else %>
+    <% split.with_empty_detail do %>
+      <%= render Bali::EmptyState::Component.new(title: 'Select an item', icon: 'inbox') %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options:**
+- `frame_id` - **Required.** Id of the detail Turbo Frame; rows point at it with `data-turbo-frame`, so it must be unique in the page
+- `master_width` - Width of the left column from `lg` up. A CSS length or percentage (default: `"420px"`); anything more expressive overrides `--bali-split-master-width` in your own stylesheet
+- `advance` - Emit `data-turbo-action="advance"` on the frame, so a row click pushes its URL into the history and the selection is deep-linkable (default: `true`)
+
+**Slots:**
+- `with_master` - The left column, free-form. Wrapped in the `split-view` controller element so rows inside can be its targets
+- `with_detail` - What the server renders for the current selection
+- `with_empty_detail` - Shown inside the frame when there is no selection; ignored when `detail` is present
+
+**Rows are yours**, and they opt in with four attributes:
+
+```erb
+<%= link_to inbox_path(selected: item.id),
+      class: "split-view-row px-4 py-3 border-b border-base-200/70",
+      aria: { current: (item == @selected ? "true" : nil) },
+      data: { turbo_frame: "inbox-detail",
+              split_view_target: "row",
+              action: "click->split-view#select" } do %>
+```
+
+The server paints `aria-current` on the first render and after every full-page
+navigation; the `split-view` controller only moves it between clicks. The look
+follows from `.split-view-row[aria-current]`, so the selected state cannot fall
+out of a Tailwind build. Do **not** add `data-turbo-action` to the row — the
+frame carries it, and a link-level one wins, silently defeating `advance: false`.
+
+`.split-view-scroll` is an opt-in class for whichever part of the master should
+scroll (usually the list alone, so tabs above and pagination below stay put); its
+height is `var(--bali-split-master-max-h, calc(100vh - 20rem))`.
+
+Below `lg` the panes stack, master on top, with no extra JavaScript.
+
+**The component is deliberately thin.** Tabs, filter chips, pagination and the
+rows go inside `master` as content — the screens that need them do not agree on
+where they sit. The full pattern, including the Rails wiring, deep-linking, the
+two empty states a filtered list needs, and the full-page-on-a-phone variant,
+lives in the [master-detail guide](master-detail.md).
+
 ---
 
 ### Navigation Components

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -1,0 +1,320 @@
+# Master-Detail Screens
+
+The inbox shape: a list of items on the left, the detail of the selected one on
+the right. Clicking a row swaps only the right column, so the list keeps its
+scroll position and its highlight — which is the whole reason to build the
+screen this way instead of navigating to a detail page.
+
+`Bali::SplitView::Component` gives you the three parts that are identical in
+every such screen — the responsive grid, the Turbo Frame around the detail, and
+the Stimulus controller that moves the highlight. **Everything else is yours.**
+Tabs, filter chips, pagination and the rows themselves go inside the `master`
+slot in whatever shape the screen needs; no two master-detail screens agree on
+that arrangement, so the component does not try to own it.
+
+- Live example: `/lookbook/preview/bali/split_view/default`
+- Working reference in the dummy app: `spec/dummy/app/controllers/split_views_controller.rb`
+  and `spec/dummy/app/views/split_views/` — the whole Rails side in one action.
+
+---
+
+## The shape
+
+```erb
+<%= render Bali::SplitView::Component.new(frame_id: "inbox-detail") do |split| %>
+  <% split.with_master do %>
+    <%= render "master_pane", items: @items, selected: @selected %>
+  <% end %>
+
+  <% if @selected %>
+    <% split.with_detail do %>
+      <%= render "detail_pane", item: @selected %>
+    <% end %>
+  <% else %>
+    <% split.with_empty_detail do %>
+      <%= render Bali::EmptyState::Component.new(
+        title: t("inbox.detail.none.title"),
+        description: t("inbox.detail.none.description"),
+        icon: "inbox"
+      ) %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Options**
+
+- `frame_id` (required) — id of the detail Turbo Frame. Rows point at it with
+  `data-turbo-frame`, so it has to be unique in the page.
+- `master_width` — width of the left column from `lg` up. A CSS length or
+  percentage (`"420px"` default, `"24rem"`, `"30%"`). Anything more expressive
+  goes in your own stylesheet, overriding `--bali-split-master-width`.
+- `advance` — emit `data-turbo-action="advance"` on the frame so a row click
+  pushes its URL into the history and the selection is deep-linkable
+  (default: `true`).
+
+**Slots**
+
+- `master` — the left column, free-form. Wrapped in the `split-view` controller
+  element, so rows inside it can be its targets.
+- `detail` — what the server renders for the current selection.
+- `empty_detail` — shown inside the frame when there is no selection. Ignored
+  when `detail` is present.
+
+Below `lg` the two panes stack, master on top. That needs no JavaScript and no
+option; see [Full-page detail on a phone](#full-page-detail-on-a-phone) if you
+want the other mobile behaviour.
+
+---
+
+## The Rails side
+
+One action renders both the full page and the frame response. There is no
+second controller and no `respond_to` block: Turbo asks for the same URL and
+extracts the matching frame from the reply.
+
+```ruby
+class InboxController < ApplicationController
+  def show
+    @items    = current_user.inbox_items.then { |scope| filter(scope) }
+    @selected = @items.find_by(id: params[:selected])
+  end
+end
+```
+
+`params[:selected]` is the entire deep-linking mechanism:
+
+- Loaded cold, `/inbox?selected=42` renders the whole page with row 42 already
+  highlighted and its detail in the frame.
+- Reached by a row click, Turbo fetches the same URL, takes only
+  `<turbo-frame id="inbox-detail">` out of the response, and puts it in the
+  page. The master is never touched.
+
+**Order the list deterministically.** The master is not re-rendered on a row
+click, so a list whose order depends on `updated_at` will disagree with itself
+after the detail pane writes to a record.
+
+### The row
+
+```erb
+<%= link_to inbox_path(selected: item.id, **@filters),
+      id: dom_id(item, :inbox_row),
+      class: "split-view-row px-4 py-3 border-b border-base-200/70",
+      aria: { current: (item == @selected ? "true" : nil) },
+      data: {
+        turbo_frame: "inbox-detail",
+        split_view_target: "row",
+        action: "click->split-view#select"
+      } do %>
+  <div class="font-medium text-sm truncate"><%= item.title %></div>
+  <div class="text-xs text-base-content/60 truncate"><%= item.subtitle %></div>
+<% end %>
+```
+
+Four things are load-bearing:
+
+- **`class: "split-view-row"`** — the look of a row, including its selected
+  state, comes from this class. Add your own padding and separators next to it.
+- **`aria-current` from the server** — this is what paints the selection on the
+  first render and after any full-page navigation (a filter tab, another page
+  of results). The controller only covers the clicks in between.
+- **`data-turbo-frame`** — what makes the click swap the frame instead of the
+  page.
+- **`data-split-view-target` + `data-action`** — what lets the controller move
+  the highlight without a round trip.
+
+**Carry the current filters in the row's href.** The href is the URL the
+selection deep-links to; drop the filters and reloading that URL gives an
+unfiltered list with a mysteriously selected row.
+
+**Do not put `data-turbo-action="advance"` on the row.** The frame already
+carries it, and a link-level one wins over the frame — so it silently defeats
+`advance: false`.
+
+---
+
+## Making the list scroll
+
+`.split-view-scroll` is opt-in and goes around **the part of the master that
+should scroll**, usually the list alone, so tabs above it and pagination below
+it stay put:
+
+```erb
+<%= render Bali::Card::Component.new(style: :bordered, body_class: "p-0") do %>
+  <%= render "bucket_tabs" %>
+
+  <div class="split-view-scroll">
+    <%= render partial: "row", collection: @items %>
+  </div>
+
+  <%= render Bali::PaginationFooter::Component.new(pagy: @pagy) %>
+<% end %>
+```
+
+Its height is `var(--bali-split-master-max-h, calc(100vh - 20rem))`. The default
+is a guess about your chrome; when it is wrong, say so on the element rather
+than writing a new `max-height`:
+
+```erb
+<div class="split-view-scroll" style="--bali-split-master-max-h: 26rem">
+```
+
+---
+
+## Two empty states, not one
+
+A list with nothing in it means one of two things, and they need different
+words and different offers. "No results" next to filters the user set is a dead
+end; the useful thing is a way out of them.
+
+`Bali::EmptyState::Component` already has the `cta` slot for exactly this, so
+this is composition, not a component option:
+
+```erb
+<% if @items.none? %>
+  <% if @filters.none? %>
+    <%= render Bali::EmptyState::Component.new(
+      title: t("inbox.empty.zero.title"),
+      description: t("inbox.empty.zero.description"),
+      icon: "inbox",
+      size: :sm
+    ) %>
+  <% else %>
+    <%= render Bali::EmptyState::Component.new(
+      title: t("inbox.empty.filtered.title"),
+      description: t("inbox.empty.filtered.description"),
+      icon: "filter-x",
+      size: :sm
+    ) do |state| %>
+      <% state.with_cta do %>
+        <%= render Bali::Link::Component.new(
+          name: t("inbox.filters.clear"),
+          href: inbox_path,
+          variant: :ghost,
+          size: :sm
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+`@filters.none?` stands for whatever "the user narrowed this" means on your
+screen — an active tab, a search term, a set of chips. Compute it once in the
+controller; the condition is easy to get subtly wrong in two places.
+
+The detail pane's empty state is a third, different one, and it belongs in
+`empty_detail`: nothing is wrong, the user simply has not picked anything yet.
+
+---
+
+## Full-page detail on a phone
+
+The default below `lg` is stacked: master on top, detail underneath. That is one
+scroll for both, which is right when the rows are short.
+
+When the detail is long, the alternative is master-only, with a row click
+navigating to a detail page of its own. There is no option for this because it
+is not a layout change — it is a different route, and the component cannot
+invent one.
+
+The mechanism is Turbo's own fallback, measured both ways:
+
+| The frame `data-turbo-frame` names is… | What a row click does |
+|---|---|
+| in the DOM | swaps the frame — **even with `display: none` on it** |
+| not in the DOM at all | an ordinary full-page visit to the row's href |
+
+So the row markup never changes. What changes is whether the page renders the
+split view, and **that has to be a server-side decision** — hiding it with
+`lg:hidden` leaves the frame in the DOM, and Turbo swaps a frame nobody can see.
+
+Rails variants are the tool for that:
+
+```ruby
+class InboxController < ApplicationController
+  before_action { request.variant = :phone if browser.device.mobile? }
+
+  def show
+    @items    = filter(current_user.inbox_items)
+    @selected = @items.find_by(id: params[:selected])
+  end
+end
+```
+
+`show.html+phone.erb` renders the master alone — no `SplitView`, no frame — and
+`show.html.erb` renders the split view as above. On a phone the same row click
+becomes a real visit to `/inbox?selected=42`, which the same action already
+answers with a whole page. One route, one response, and a real back button.
+
+If you would rather not sniff the User-Agent, the same split works off anything
+the server can see: a `?view=` param, a user preference, a cookie your layout
+sets from a media query on first load.
+
+---
+
+## Back and forward
+
+With `advance: true` the URL is the selection, and the browser buttons work.
+One thing is worth knowing because it explains a line in the controller:
+
+Turbo promotes the frame swap to a visit, and the snapshot it caches for the
+page being left is taken **between** the click and the frame's response. That
+snapshot therefore holds the highlight the controller has just moved, next to
+the detail pane from before the swap. Restoring it would show a master pointing
+at one row with an unrelated detail beside it.
+
+So on a history traversal the controller re-derives the highlight from the URL
+rather than trusting the snapshot. It can, because each row's href *is* the URL
+that selects it. **This is also why the href matters**: rows whose href is not
+the URL that selects them lose their highlight on back. If your rows link
+somewhere else entirely, use `advance: false` — the frame still swaps, nothing
+is pushed into the history, and none of this applies.
+
+On a first render the server's markup always wins, since a master can perfectly
+well live on a page whose URL is not in its rows' URL space.
+
+---
+
+## Styling the rows
+
+The selected row is `.split-view-row[aria-current]`, drawn as a tinted
+background plus an inset `box-shadow` bar down the left edge.
+
+**It is a shadow and not a left border on purpose.** Rows are usually separated
+with `border-b border-base-200/70`, and Tailwind's `border-<color>` utility sets
+the colour of all four sides, not just the one `border-b` drew. Utilities beat
+`@layer components`, so a `border-l-primary` in Bali's stylesheet renders
+base-200 under it and the highlight disappears. The shadow also paints inside
+the padding box, so the selection moves between rows without shifting any text.
+
+To add to the selected look rather than replace it, use the Stimulus classes on
+the master element:
+
+```erb
+<div data-controller="split-view" data-split-view-selected-class="ring-2 ring-primary">
+```
+
+Those are applied on top of `aria-current`, so they only need to cover what the
+attribute-driven CSS does not. Remember that a class only present in a JS
+attribute has to appear somewhere Tailwind scans — which your row partial does,
+if the server renders the same selected state.
+
+---
+
+## What this is not
+
+- **Not a list component.** The rows are yours. If they all look the same across
+  your app, that is a partial in your app, not an option here.
+- **Not a filter or pagination host.** Those go in `master` as content, because
+  the screens that need them do not agree on where they sit.
+- **Not a re-render.** Never answer a row click by re-rendering the master — it
+  loses the scroll position, which is the one thing this pattern exists to keep.
+
+---
+
+## See also
+
+- [Components guide](components.md#splitview) — the API reference.
+- `Bali::EmptyState` — the empty states above.
+- `Bali::PaginationFooter` — pagination inside the master.

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -274,6 +274,47 @@ is pushed into the history, and none of this applies.
 On a first render the server's markup always wins, since a master can perfectly
 well live on a page whose URL is not in its rows' URL space.
 
+The href and the location are matched on path plus query params **as a set**.
+The location routinely carries params a row's href never had — a page number, a
+sort — and lists the shared ones in another order, and comparing the two as
+strings would call that a different place and drop the highlight.
+
+---
+
+## When the detail request fails
+
+Two different things happen, and the error response decides which. Both are
+measured against the dummy app:
+
+- **A response that says to reload** — Rails' own exception page, or any page
+  carrying `<meta name="turbo-visit-control" content="reload">` — makes Turbo
+  abandon the frame and visit the URL as a whole page. The user lands on the
+  error page. Loud, and usually what you want for a bug.
+- **Anything else with no matching frame** — a bare 500 body, a JSON error, a
+  custom error page that does not contain `<turbo-frame id="inbox-detail">` — is
+  **ignored**. Turbo rejects with *"The response (500) did not contain the
+  expected `<turbo-frame id="inbox-detail">` and will be ignored"*, and the pane
+  keeps the detail it already had.
+
+The second one is the case to decide about, because the screen does not look
+broken: the highlight has already moved optimistically to the row that failed,
+so the master says "you are on row 7" beside row 3's detail, and they disagree
+until the next click. Three ways out, cheapest first:
+
+1. **Render the error inside the frame.** If the response contains
+   `<turbo-frame id="inbox-detail">` with the message in it, Turbo swaps it like
+   any other reply and the pane says what went wrong. This is the only option
+   that keeps the user on the screen they were on, and it is usually right when
+   a failed detail is an expected outcome (gone, forbidden).
+2. **Add `<meta name="turbo-visit-control" content="reload">`** to the error
+   page's `<head>` — Turbo names this in the message itself — to get the
+   full-page behaviour of the first case for a genuine bug.
+3. **Handle `turbo:frame-missing` yourself**: `event.preventDefault()` in a
+   listener and then decide (a toast, a retry, a redirect).
+
+Bali does not choose for you, because the right answer depends on whether a
+failing detail is an expected outcome on that screen or a defect.
+
 ---
 
 ## Styling the rows

--- a/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
+++ b/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
@@ -1,0 +1,116 @@
+---
+title: Master-Detail Screens
+label: Master-Detail
+---
+
+# Master-Detail Screens
+
+The inbox shape: a list on the left, the detail of the selected row on the right.
+Clicking a row swaps only the right column, so the list keeps its scroll position
+and its highlight.
+
+`Bali::SplitView::Component` owns the three parts that are identical in every such
+screen — the responsive grid, the Turbo Frame around the detail, and the Stimulus
+controller that moves the highlight. Tabs, filter chips, pagination and the rows
+themselves are content and go inside the `master` slot.
+
+- Preview: [SplitView](/lookbook/inspect/bali/split_view/default)
+- Working reference in this app: [/split-view](/split-view)
+- Full guide, with the recipes this page leaves out: `docs/guides/master-detail.md`
+
+## The shape
+
+```erb
+<%%= render Bali::SplitView::Component.new(frame_id: "inbox-detail") do |split| %>
+  <%% split.with_master do %>
+    <%%= render "master_pane", items: @items, selected: @selected %>
+  <%% end %>
+
+  <%% if @selected %>
+    <%% split.with_detail { render "detail_pane", item: @selected } %>
+  <%% else %>
+    <%% split.with_empty_detail do %>
+      <%%= render Bali::EmptyState::Component.new(title: "Select an item", icon: "inbox") %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+```
+
+`frame_id:` is required. `master_width:` (default `"420px"`) sets the left column
+from `lg` up; below `lg` the panes stack, master on top. `advance:` (default
+`true`) makes the selection deep-linkable.
+
+## The Rails side
+
+One action renders both the full page and the frame response — no second
+controller, no `respond_to`:
+
+```ruby
+class InboxController < ApplicationController
+  def show
+    @items    = filter(current_user.inbox_items)
+    @selected = @items.find_by(id: params[:selected])
+  end
+end
+```
+
+Loaded cold, `/inbox?selected=42` renders the whole page with row 42 highlighted.
+Reached by a row click, Turbo fetches the same URL and takes only the frame out
+of the reply.
+
+Order the list deterministically: the master is not re-rendered on a row click,
+so an `updated_at` ordering will disagree with itself once the detail writes.
+
+## The row
+
+```erb
+<%%= link_to inbox_path(selected: item.id, **@filters),
+      class: "split-view-row px-4 py-3 border-b border-base-200/70",
+      aria: { current: (item == @selected ? "true" : nil) },
+      data: { turbo_frame: "inbox-detail",
+              split_view_target: "row",
+              action: "click->split-view#select" } do %>
+  <div class="font-medium text-sm truncate"><%%= item.title %></div>
+<%% end %>
+```
+
+- **`split-view-row`** carries the look, including the selected state.
+- **`aria-current` from the server** paints the selection on first render and
+  after every full-page navigation. The controller only covers clicks in between.
+- **Carry the current filters in the href** — it is the URL the selection
+  deep-links to.
+- **Do not add `data-turbo-action` to the row.** The frame has it, and a
+  link-level one wins, silently defeating `advance: false`.
+
+## Making the list scroll
+
+`.split-view-scroll` is opt-in and goes around the part of the master that should
+scroll — usually the list alone, so tabs above it and pagination below it stay
+put. Its height is `var(--bali-split-master-max-h, calc(100vh - 20rem))`; set the
+variable on the element when your chrome is taller or shorter.
+
+```erb
+<div class="split-view-scroll" style="--bali-split-master-max-h: 26rem">
+```
+
+## Styling the selected row
+
+The selected row is `.split-view-row[aria-current]` — a tint plus an inset
+`box-shadow` bar down the left edge. It is a shadow and not a left border on
+purpose: rows are separated with `border-b border-base-200/70`, and Tailwind's
+`border-<color>` utility sets all four sides from the utilities layer, which beats
+`@layer components`. A `border-l-primary` in Bali's sheet renders base-200 under
+it and the highlight disappears.
+
+To add to the look rather than replace it:
+
+```erb
+<div data-controller="split-view" data-split-view-selected-class="ring-2 ring-primary">
+```
+
+## What this is not
+
+- **Not a list component** — the rows are yours.
+- **Not a filter or pagination host** — those go in `master` as content.
+- **Not a re-render** — never answer a row click by re-rendering the master; it
+  loses the scroll position, which is what the pattern exists to keep.

--- a/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
+++ b/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
@@ -108,6 +108,23 @@ To add to the look rather than replace it:
 <div data-controller="split-view" data-split-view-selected-class="ring-2 ring-primary">
 ```
 
+## When the detail request fails
+
+Two different things happen, and the error response decides which:
+
+- **A response that says to reload** — Rails' own exception page, or any page with
+  `<meta name="turbo-visit-control" content="reload">` — makes Turbo abandon the
+  frame and visit the URL as a whole page.
+- **Anything else with no matching frame** is **ignored**: the pane keeps the
+  detail it already had, while the highlight has already moved to the row that
+  failed. The two disagree until the next click, and nothing looks broken.
+
+Three ways out of the second, cheapest first: render the error *inside* the frame
+(the only one that keeps the user where they were); add the `turbo-visit-control`
+meta to the error page to get the first behaviour; or handle `turbo:frame-missing`
+yourself with `event.preventDefault()`. Which is right depends on whether a failed
+detail is an expected outcome on that screen or a defect.
+
 ## What this is not
 
 - **Not a list component** — the rows are yours.


### PR DESCRIPTION
Segundo y último PR de #728. **Apilado sobre `feat/728-split-view` (PR #967)** — mergear ese primero.

Solo documentación: `docs/guides/master-detail.md` (nueva), entrada de `SplitView` en el catálogo de `docs/guides/components.md`, espejo condensado en las páginas de Lookbook y una coda en la entrada del CHANGELOG.

## Por qué una guía y no un docstring más largo

El componente es la mitad de la pantalla. La otra mitad — la acción de Rails, el deep-linking, qué lleva el href de cada fila, qué pasa con el botón atrás — es del host, y es donde se pierde la gente. La guía cubre:

- **El cableado Rails entero en una sola acción.** Sin segundo controller y sin `respond_to`: Turbo pide la misma URL y saca el frame de la respuesta. `params[:selected]` es todo el mecanismo de deep-linking.
- **Por qué el href de la fila tiene que llevar los filtros vigentes.** Es la URL a la que apunta la selección; sin ellos, recargar esa URL da una lista sin filtrar con una fila misteriosamente seleccionada.
- **Ordenar la lista de forma determinista**, porque el master NO se re-renderiza al hacer click y un orden por `updated_at` se contradice a sí mismo en cuanto el detalle escribe.
- **Qué NO es**: no es un componente de listas, no es un host de filtros ni de paginación, y nunca se responde a un click re-renderizando el master (que es justo lo que perdería el scroll).

## Las dos decisiones de Fede que aterrizan como receta

**D728-4 — empty state dual, como receta y no como API.** Una lista vacía significa dos cosas distintas y piden palabras distintas: "no hay nada todavía" contra "tus filtros no devolvieron nada". La segunda es un callejón sin salida si no le ofrecés la salida. Se compone con el slot `cta` que `Bali::EmptyState` ya tiene, así que no hace falta ninguna opción nueva. El del panel de detalle es un tercer estado, distinto de los dos, y va en `empty_detail`.

**D728-2 — detalle a página completa en móvil, documentado y no implementado.** Escribí la receta obvia (`hidden lg:block`), la medí, y estaba mal. Lo que hace Turbo:

| El frame que nombra `data-turbo-frame`… | Qué hace un click en la fila |
|---|---|
| está en el DOM | intercambia el frame — **incluso con `display: none`** |
| no está en el DOM | visita de página completa al href de la fila |

O sea que `lg:hidden` deja el frame en el DOM y Turbo intercambia un frame que nadie ve. Si un teléfono recibe el split view o no **es una decisión del servidor**, y la guía la resuelve con variants de Rails (`request.variant = :phone` → `show.html+phone.erb` sin `SplitView` y sin frame), señalando también las alternativas sin sniffear el User-Agent. El markup de la fila no cambia en ninguno de los dos casos.

## Evidencia

- Ambas filas de la tabla de arriba medidas en el browser contra el preview: con el frame oculto por CSS el documento NO se reemplaza y el frame se intercambia; con el frame quitado del DOM el documento se reemplaza y se aterriza en la página completa del dummy.
- `/lookbook/pages/guides/master_detail` responde **200** y los bloques de código ERB salen literales (escapado `<%%`).
- Suite completa en el hook de pre-push: **4462 runs, 10761 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)