### PR TITLE
feat(split-view): with_filters — filtrado del listado (#971, PR 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own: the attribute works by `display: none` in the UA stylesheet, which any author `display`
   beats, so the spinner was visible to exactly the readers it was hidden from.
 
+- **`with_filters`: the listing's tabs and chips get a place, not a system** (#971). Buckets and
+  filter chips belong to the listing — the inbox this was generalised from puts them inside the
+  master — so `with_list` has a slot for them. It renders a band between the header and the rows:
+  **outside** the scroll area, so the controls stay put while the rows move under them, and
+  **inside** the card, so they read as part of the listing instead of as page chrome. That
+  position is the whole of what the slot provides.
+
+  **Bali grows no second filtering system for it.** Put `Bali::DataTable::SimpleFilters` in the
+  band, which already has the control this pattern wants: `type: :radio_group` with
+  `auto_submit: true` (#725) is the pill that filters on click — one active value, submitted the
+  moment it changes. Counts in the pill labels stay the caller's, because SimpleFilters does not
+  count and teaching it to would be the second system. Worth knowing when you go looking for the
+  click target: daisyUI styles the radio *itself* as the pill and takes its text from
+  `aria-label`, so there is no `<label>` element.
+
+  **Filtering does nothing to the infinite scroll, and that is the design.** A filter submit is an
+  ordinary full-page GET, so the server renders page one and there is no reset to perform, no
+  browser state to clear and no coupling between the two features. The filter then travels into
+  every page the sentinel fetches on its own, because the next URL is derived from the request the
+  server answered and Pagy keeps its params — nothing in the controller knows what a filter is.
+  Measured rather than assumed; the spec asserts the fetched URL carries the filter and that the
+  appended rows really are the filtered ones. The submit button stays even when every filter
+  auto-submits, and should: without JavaScript `auto_submit` does nothing, so the button is how
+  the filter gets applied — the same progressive enhancement as the pagination controls.
+
 ### Fixed
 
 - **`docs/api/gantt.md`: `statuses:` must cover group statuses too** (#720 adoption finding, afal-apps#462). Groups render as bars and feed the same legend as items, and any status the catalog misses falls back to `value.humanize` — which is how an untranslated "Not started" leaked into a Spanish UI. One sentence in the option table now says so.

--- a/app/components/bali/split_view/index.css
+++ b/app/components/bali/split_view/index.css
@@ -81,6 +81,15 @@
   @apply px-4;
 }
 
+/* The filtering band. Sits between the header and the scroll area — outside the
+   part that moves, inside the card — and carries the separator so the controls
+   read as a band rather than as loose markup above the rows. Whatever the host
+   puts in it (SimpleFilters, a FilterForm) brings its own controls; this only
+   places them. */
+.split-view-list-filters {
+  @apply px-4 py-3 border-b border-b-base-200;
+}
+
 .split-view-sentinel {
   @apply flex items-center justify-center gap-2 px-4 py-6 text-xs text-base-content/60;
 }

--- a/app/components/bali/split_view/list/component.html.erb
+++ b/app/components/bali/split_view/list/component.html.erb
@@ -12,6 +12,12 @@
       </div>
     <% end %>
 
+    <% if filters? %>
+      <div class="split-view-list-filters" data-testid="list-filters">
+        <%= filters %>
+      </div>
+    <% end %>
+
     <%= tag.div(**scroll_attributes) do %>
       <div data-split-view-list-target="rows">
         <% items.each do |item| %>

--- a/app/components/bali/split_view/list/component.rb
+++ b/app/components/bali/split_view/list/component.rb
@@ -49,6 +49,19 @@ module Bali
         # stay the caller's words — see docs/guides/master-detail.md.
         renders_one :empty_state
 
+        # The filtering band, between the header and the rows. Its position is the
+        # whole of what this slot buys: **outside** the scroll area so the controls
+        # stay put while the rows move under them, and **inside** the card so they
+        # read as part of the listing rather than as page chrome.
+        #
+        # Bali does not grow a second filtering system for it. Put
+        # `Bali::DataTable::SimpleFilters::Component` here — a `:radio_group` with
+        # `auto_submit: true` is the pill that filters on click — or a FilterForm of
+        # your own. Filtering is an ordinary full-page navigation, which is what
+        # resets the infinite scroll: the server renders page one and the sentinel
+        # picks up the new URL with the filter params already on it.
+        renders_one :filters
+
         attr_reader :header, :count, :pagy
 
         # frame_id is injected by the SplitView; a caller never passes it.

--- a/cypress/e2e/split-view-list.cy.js
+++ b/cypress/e2e/split-view-list.cy.js
@@ -154,6 +154,68 @@ describe('SplitView structured list', () => {
     })
   })
 
+  // Filtering is an ordinary GET, which is the whole design: nothing in the
+  // component resets the infinite scroll, because a full-page navigation already
+  // does. These run against the dummy's page, where the filter is a real
+  // SimpleFilters row over a real Ransack scope.
+  context('filtering the list', () => {
+    const app = path =>
+      `${Cypress.config('baseUrl').replace(/\/lookbook\/preview\/?$/, '')}${path}`
+
+    beforeEach(() => cy.visit(app('/split-view')))
+
+    it('puts the filter band above the rows and outside the scroll area', () => {
+      cy.get('[data-testid="list-filters"]').should('be.visible')
+      cy.get('[data-split-view-list-target="scroller"] [data-testid="list-filters"]')
+        .should('not.exist')
+    })
+
+    // The pill submits on click (`auto_submit: true`), which is a full-page
+    // navigation and therefore renders page one — no reset to perform.
+    it('filters on a pill click and comes back on page one', () => {
+      rows().should('have.length', 5)
+      scrollToBottom()
+      rows().should('have.length', 10)
+
+      // The pill IS the radio: daisyUI styles `input[type=radio].btn` and takes its
+      // text from `aria-label`, so there is no <label> element to click.
+      cy.get('[data-testid="list-filters"] input[name="q[status_eq]"][aria-label^="Done"]')
+        .check()
+      cy.location('search').should('contain', 'status_eq')
+      rows().should('have.length', 5)
+      cy.get('[data-testid="list-count"]').should('have.text', '17')
+    })
+
+    // The sentinel fetches the URL the server handed it, so the filter travels
+    // without the controller knowing anything about filters. Measured, because
+    // "it should inherit them" is exactly the kind of thing that silently does not.
+    it('carries the filter into the pages the sentinel fetches', () => {
+      cy.visit(app('/split-view?q%5Bstatus_eq%5D=1'))
+      cy.get('[data-testid="list-count"]').should('have.text', '17')
+      rows().should('have.length', 5)
+
+      cy.intercept('GET', '/split-view*').as('nextPage')
+      scrollToBottom()
+      cy.wait('@nextPage').its('request.url').should('include', 'status_eq')
+      rows().should('have.length', 10)
+
+      // And the rows that arrived really are the filtered ones: 17 of 20 movies
+      // are `done`, so an unfiltered page 2 would overshoot the filtered total.
+      scrollToBottom()
+      scrollToBottom()
+      rows().should('have.length', 17)
+      cy.get('[data-split-view-list-target="end"]').should('not.have.attr', 'hidden')
+    })
+
+    it('keeps selecting a row while a filter is on', () => {
+      cy.visit(app('/split-view?q%5Bstatus_eq%5D=1'))
+      rows().eq(2).click()
+      cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+      cy.location('search').should('contain', 'selected=')
+      rows().eq(2).should('have.attr', 'aria-current', 'true')
+    })
+  })
+
   context('when a page fails to load', () => {
     it('offers a retry that resumes from the same page', () => {
       cy.visit('/bali/split_view/structured_list')

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -648,7 +648,8 @@ takes the id of the selected record and each item its own `id:`.
 
 **`with_list` options:** `header`, `count`, `selected`, `pagy`, `next_url`,
 `infinite_scroll` (default `true`), `item_name`, `max_height`. `with_empty_state`
-replaces the rows when there are none.
+replaces the rows when there are none, and `with_filters` renders a filtering band
+between the header and the rows.
 
 **`with_item` options:** `title` and `href` are required; `id`, `subtitle`,
 `icon`, `meta`, `meta_color` (`:error`, `:warning`, `:success`, `:primary`) are
@@ -661,6 +662,14 @@ controls on connect and fetches the same index URL one page further on as the
 sentinel comes into view, appending the rows. No endpoint, no Turbo Stream and
 no partial of its own — and a reader without JavaScript keeps working controls,
 because enhancement removes them rather than summoning them.
+
+**Filtering has a place, not a system.** `with_filters` puts a band between the
+header and the rows — outside the scroll area so the controls stay put, inside the
+card so they read as part of the listing. Put `Bali::DataTable::SimpleFilters` in
+it; a `:radio_group` with `auto_submit: true` is the pill that filters on click.
+Filtering is an ordinary full-page GET, so the infinite scroll resets to page one
+by itself and the filter params travel into the pages the sentinel fetches without
+the controller knowing what a filter is.
 
 Below `lg` the panes stack, master on top, with no extra JavaScript.
 

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -215,6 +215,78 @@ running out, which is how the end of the list is detected.
 
 ---
 
+## Filtering the list
+
+Tabs, buckets and filter chips belong to the listing, so `with_list` has a place
+for them: `with_filters` renders a band between the header and the rows —
+**outside** the scroll area, so the controls stay put while the rows move under
+them, and **inside** the card, so they read as part of the listing.
+
+That position is all the slot provides. **Bali does not grow a second filtering
+system for it**: put the one it already has in the band.
+
+```erb
+<% split.with_list(header: t("inbox.title"), count: @pagy.count,
+                   selected: params[:selected], pagy: @pagy) do |list| %>
+  <% list.with_filters do %>
+    <%= render Bali::DataTable::SimpleFilters::Component.new(
+      url: inbox_path,
+      filters: @filter_form.simple_filters_config,
+      show_clear: true
+    ) %>
+  <% end %>
+  <%# … items … %>
+<% end %>
+```
+
+```ruby
+@filter_form = Bali::FilterForm.new(
+  Inbox::Item.all, params,
+  simple_filters: [
+    { attribute: :bucket, collection: bucket_options, label: t("inbox.bucket"),
+      type: :radio_group, auto_submit: true }
+  ]
+)
+@pagy, @items = pagy(@filter_form.result, limit: 20)
+```
+
+`type: :radio_group` with `auto_submit: true` is **the pill that filters on
+click** — one active value, submitted the moment it changes, which is the bucket
+strip a master-detail listing usually wants. daisyUI styles the radio itself as
+the pill and takes its text from `aria-label`, so there is no `<label>` element:
+the thing you click is the `input`.
+
+**Counts on the pills are yours.** `"Aprobaciones (12)"` goes in the collection's
+label. SimpleFilters does not count, and teaching it to would be the second
+filtering system this is avoiding.
+
+### What filtering does to everything else
+
+Nothing, and that is the design. A filter submit is an **ordinary full-page GET**:
+
+- **The infinite scroll resets for free.** The server renders page one; there is
+  no reset to perform and no state in the browser to clear.
+- **The filter travels into the pages the sentinel fetches**, because the next
+  URL is derived from the request the server answered and Pagy keeps its params.
+  Nothing in the controller knows what a filter is. Measured in
+  `cypress/e2e/split-view-list.cy.js`, not assumed.
+- **Back still works**, because the highlight is re-derived from the URL and
+  matches on the params a row's href actually carries, ignoring the filter params
+  it does not.
+
+**The submit button stays even when every filter auto-submits, and should.**
+Without JavaScript `auto_submit` does nothing, so the button is how a reader
+without it applies the filter — the same progressive enhancement as the
+pagination controls.
+
+**Selection and filters are independent.** A row's href carries the filters (see
+[the row](#when-list-does-not-fit)), so the selection deep-links back into the
+filtered listing. Filtering does not clear the selection; if the selected record
+is filtered out, its detail stays and no row is highlighted — the same state as a
+deep link to a record on a later page.
+
+---
+
 ## When `list` does not fit
 
 The `master` slot takes any markup at all, and is what a listing the structured

--- a/spec/dummy/app/controllers/split_views_controller.rb
+++ b/spec/dummy/app/controllers/split_views_controller.rb
@@ -10,6 +10,10 @@
 # action one page further on. There is nothing here for it: no `respond_to`, no
 # format branch, no endpoint of its own. That is the point of fetch-and-extract.
 #
+# Filtering is an ordinary GET too. Nothing here resets the infinite scroll
+# either — a filter submit is a full-page navigation, so the server renders page
+# one and the sentinel picks up a next-page URL that already carries `q`.
+#
 # `@selected` is looked up against the whole table and not the current page, so a
 # deep link to a record on page 4 renders its detail immediately. Its row is not
 # on screen to highlight yet — it lights up when infinite scroll reaches its page.
@@ -17,10 +21,37 @@ class SplitViewsController < ApplicationController
   PER_PAGE = 5
 
   def show
-    # `limit:` and not `items:` — Pagy renamed it, and the old name is ignored in
-    # silence, so an `items:` here paginated at the default 10 and the listing
-    # quietly had only two pages.
-    @pagy, @movies = pagy(Movie.includes(:studio).order(:name), limit: PER_PAGE)
+    @filter_form = Bali::FilterForm.new(
+      Movie.all,
+      params,
+      # `:radio_group` + `auto_submit` is the pill that filters on click (#725) —
+      # the same control gc's inbox uses for its buckets, and the reason SplitView
+      # grows no filtering of its own.
+      simple_filters: [
+        { attribute: :genre, collection: genre_options, label: "Género",
+          type: :radio_group, auto_submit: true },
+        # `status` and not only `genre` because every genre fits in one page: a
+        # filter whose result still spans pages is the only one that can show the
+        # sentinel inheriting the filter params.
+        { attribute: :status, collection: status_options, label: "Estado",
+          type: :radio_group, auto_submit: true }
+      ]
+    )
+
+    @pagy, @movies = pagy(@filter_form.result.includes(:studio).order(:name), limit: PER_PAGE)
     @selected = Movie.find_by(id: params[:selected])
+  end
+
+  private
+
+  # Counts live in the label because SimpleFilters does not count, and teaching it
+  # to would be a filtering system of Bali's own. gc does the same thing.
+  def genre_options
+    Movie.group(:genre).count.sort.map { |genre, count| [ "#{genre} (#{count})", genre ] }
+  end
+
+  def status_options
+    counts = Movie.group(:status).count
+    Movie.statuses.map { |name, value| [ "#{name.humanize} (#{counts[name].to_i})", value ] }
   end
 end

--- a/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
+++ b/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
@@ -169,6 +169,33 @@ meta to the error page to get the first behaviour; or handle `turbo:frame-missin
 yourself with `event.preventDefault()`. Which is right depends on whether a failed
 detail is an expected outcome on that screen or a defect.
 
+## Filtering the list
+
+`with_filters` renders a band between the header and the rows — **outside** the
+scroll area so the controls stay put while the rows move under them, **inside** the
+card so they read as part of the listing. That position is all the slot provides:
+Bali does not grow a second filtering system, you put the one it already has in the
+band.
+
+```erb
+<%% list.with_filters do %>
+  <%%= render Bali::DataTable::SimpleFilters::Component.new(
+    url: inbox_path, filters: @filter_form.simple_filters_config, show_clear: true
+  ) %>
+<%% end %>
+```
+
+`type: :radio_group` with `auto_submit: true` is the pill that filters on click.
+daisyUI styles the radio itself as the pill and takes its text from `aria-label`,
+so the thing you click is the `input` — there is no `<label>`. Counts in the pill
+labels are yours; SimpleFilters does not count.
+
+Filtering is an **ordinary full-page GET**, and that is the whole design: the
+infinite scroll resets because the server renders page one, and the filter params
+travel into the pages the sentinel fetches because the next URL comes from the
+request the server answered. The submit button stays even when every filter
+auto-submits — without JavaScript it is how the filter gets applied.
+
 ## What this is not
 
 - **Not a list component** — the rows are yours.

--- a/spec/dummy/app/views/split_views/show.html.erb
+++ b/spec/dummy/app/views/split_views/show.html.erb
@@ -8,6 +8,16 @@
     <%= render Bali::SplitView::Component.new(frame_id: 'split-view-detail') do |split| %>
       <% split.with_list(header: 'Catálogo', count: @pagy.count, selected: params[:selected],
                          pagy: @pagy, item_name: 'películas', max_height: '26rem') do |list| %>
+        <%# Filtrar es una navegación normal: el servidor vuelve a pintar la página 1
+            y el sentinel arranca de una URL que ya trae el `q`. No hay nada que
+            resetear a mano. %>
+        <% list.with_filters do %>
+          <%= render Bali::DataTable::SimpleFilters::Component.new(
+            url: split_view_path,
+            filters: @filter_form.simple_filters_config,
+            show_clear: true
+          ) %>
+        <% end %>
         <% @movies.each do |movie| %>
           <% list.with_item(
             id: movie.id,

--- a/test/bali/components/split_view_list_test.rb
+++ b/test/bali/components/split_view_list_test.rb
@@ -133,6 +133,46 @@ class BaliSplitViewListComponentTest < ComponentTestCase
     assert_no_selector(".split-view-item")
   end
 
+  # --- the filtering band -----------------------------------------------------------------
+
+  def render_with_filters(list_options = {})
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_list(**list_options) do |list|
+        list.with_filters { "FILTER CONTROLS" }
+        list.with_item(id: 1, title: "First", href: "/inbox?selected=1")
+      end
+    end
+  end
+
+  def test_filters_render_when_given
+    render_with_filters
+    assert_selector('[data-testid="list-filters"]', text: "FILTER CONTROLS")
+  end
+
+  def test_no_filters_band_without_the_slot
+    render_list
+    assert_no_selector('[data-testid="list-filters"]')
+  end
+
+  # The position is the whole of what the slot buys. Outside the scroll area the
+  # controls stay put while the rows move under them; inside it they would scroll
+  # away with the first flick.
+  def test_filters_sit_outside_the_scroll_area
+    render_with_filters
+    assert_no_selector('[data-split-view-list-target="scroller"] [data-testid="list-filters"]')
+  end
+
+  def test_filters_sit_inside_the_list_and_after_the_header
+    render_with_filters({ header: "Inbox" })
+    assert_selector('.split-view-list [data-testid="list-filters"]')
+
+    html = rendered_content
+    assert_operator html.index("Inbox"), :<, html.index("FILTER CONTROLS"),
+      "the filtering band renders after the header"
+    assert_operator html.index("FILTER CONTROLS"), :<, html.index("split-view-scroll"),
+      "the filtering band renders before the rows"
+  end
+
   # --- paging ---------------------------------------------------------------------------
 
   def pagy(page: 1, count: 30, limit: 10)


### PR DESCRIPTION
Ampliación de #971 (Fede, 07/08). **Apilado sobre #973** (`feat/971-split-view-list`) — mergear ese primero.

Va apilado y no dentro de #973 porque #973 ya estaba pusheado, verde y listo para review cuando llegó la ampliación. Retrofitearlo obligaría a re-revisar desde cero algo ya verificado; así a927 revisa solo el delta.

## Lo que gc filtra de verdad

Leyendo su controller y su master pane, no el issue:

| Filtro | Dónde vive en gc | Qué es |
|---|---|---|
| `scope` (mine/team) | acciones del header de ShowPage, **no** el master | fuera de alcance |
| `bucket` (all/aprobaciones/revisiones/otros) | dentro del master | pills con **contador por pill**, un solo valor activo |
| `kind` / `module` | dentro del master | solo **chips de quitar** + "limpiar" |

Dato que conviene tener presente: los inputs para **añadir** `kind`/`module` no existen en la vista del inbox — los valores llegan por URL desde notificaciones. O sea que esa zona en gc es un display de estado, no un panel de filtros.

## Diseño: un lugar, no un sistema

`list.with_filters` renderiza una banda entre la cabecera y las filas: **fuera** del área que scrollea (los controles no se van con el primer flick) y **dentro** de la card (se leen como parte del listado). **Esa posición es todo lo que aporta el slot** — y es justo lo que costaba a mano, porque hay que quedar entre dos contenedores concretos.

Adentro va `Bali::DataTable::SimpleFilters`, que ya tiene el control: `type: :radio_group` + `auto_submit: true` (#725) es literalmente la pill que filtra al click. Cero filtrado nuevo en Bali.

Los contadores en las etiquetas los arma el host (`"Aprobaciones (12)"`): SimpleFilters no cuenta y enseñarle sería el segundo sistema. gc hace exactamente eso.

## Las tres interacciones

**Filtrar no le hace nada al infinite scroll, y ese es el diseño.** Es un GET normal de página completa: el servidor pinta la página 1, así que no hay reset que ejecutar, ni estado en el browser que limpiar, ni acoplamiento entre las dos funciones.

**El filtro viaja solo a las páginas del sentinel.** La URL siguiente sale del request que contestó el servidor y Pagy conserva sus params; nada en el controller sabe qué es un filtro. **Medido, no supuesto**: con `?q[status_eq]=1`, `next-url` sale `/split-view?q%5Bstatus_eq%5D=1&page=2` y en la página 2 encadena a `page=3`. La spec verifica la URL pedida **y** que las filas anexadas son las filtradas — 17 de 20 son `done`, así que una página 2 sin filtrar se pasaría del total y el test lo cazaría.

**Back sigue bien** sin tocar nada: `syncFromLocation` empata por path + los params que el href de la fila sí lleva, ignorando los del filtro. Eso ya tenía specs desde el retoque de #728.

## Dos cosas que quiero que consten

**Esto es una anatomía, no dos.** El widget de afal-apps no filtra — es un widget de dashboard. Es la misma objeción con la que dejé la agrupación fuera de #973. Lo implementé porque es decisión de Fede, y lo mantuve lo más delgado posible por eso: un slot y una regla CSS de posición, nada más. Si mañana el segundo consumidor quiere otra anatomía, mover un slot es barato; deshacer una API de filtros no.

**`SimpleFilters` vive bajo `Bali::DataTable::`.** Es genérico por dentro y se renderiza desde SplitView sin tocarlo, pero queda un SplitView usando un componente del namespace DataTable. Lo dejo así (reusar, no inventar). Promoverlo a `Bali::SimpleFilters` es un issue aparte y no lo cuelo acá.

**El botón "Filter" se queda aunque todos los filtros auto-envíen, y está bien.** Sin JS `auto_submit` no hace nada, así que el botón es cómo se aplica el filtro — la misma mejora progresiva que los controles de paginación. Parecía una verruga hasta que la miré.

## Evidencia

- Cypress `split-view-list.cy.js`: **15 passing** (4 nuevas de filtrado) + las 14 de #728 → **29/29**.
- Minitest: 4 nuevos del slot (incluida su posición fuera del scroller y después de la cabecera); **45 runs / 85 assertions / 0 failures** en los archivos tocados.
- Suite completa: **4574 runs, 11004 assertions, 0 failures**.
- `check:manifest` OK, Rubocop y StandardJS limpios.
- Browser: `/split-view?q[status_eq]=1` verificado con captura — banda de filtros dentro de la card sobre las filas, "Done (17)" activa, contador del listado en 17, filas todas `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)