### PR TITLE
feat(split-view): height: :full — el split llena la pantalla (#979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is byte-for-byte what it was, and `flex: 1 0 auto` so a page taller than the viewport keeps its
   height and `<main>` scrolls as before.
 
+  An unrecognised `height:` **raises**, like `master_width:` beside it: a silent fallback on the
+  option that is this whole feature turns a typo into a component that renders the default and
+  says nothing, and the symptom — a split that does not fill — sends the reader hunting through
+  CSS. Free to demand now, breaking to demand later.
+
   **Inert below `lg`**, on purpose: the panes are stacked there, and two stacked panes cannot both
   fill one screen — a master and a detail would fight over the same viewport. `max_height:` belongs
   to `:content`; in `:full` the flex chain decides, so the cap is dropped rather than fighting it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Bali::SplitView` takes `height: :full`** (#979). The default, `:content`, grows with its
+  content and lets the page scroll. `:full` gives the other shape — the inbox one: the split fills
+  the screen and **each pane scrolls on its own**, so the list and the detail move independently
+  and neither takes the page with it.
+
+  **There is no number in it anywhere.** It is `height: 100%` plus a flex chain: no measured
+  offset, no `calc(100vh - 17rem)`, no JavaScript reading the top of anything. That means it fills
+  whatever bounded box you put it in — and fills **nothing** without one, visibly rather than
+  subtly. Deliberate, and the same reasoning that kept a magic offset out of the Kanban: a
+  component that guessed at the height of your chrome would be wrong on every screen that does not
+  look like the one it was written for.
+
+  So the pairing is the recipe: `AppLayout viewport_locked: true` stops the body scrolling and
+  makes `<main>` the bounded box. Making that pairing *actually* pair took two rules, because
+  AppLayout's body container is `height: auto` and wraps its content — measured, the split stopped
+  at 629px inside a 1086px `<main>`, filling nothing while claiming to fill everything. Those rules
+  ship with `:full` rather than with AppLayout, scoped by `:has()` so that every other locked page
+  is byte-for-byte what it was, and `flex: 1 0 auto` so a page taller than the viewport keeps its
+  height and `<main>` scrolls as before.
+
+  **Inert below `lg`**, on purpose: the panes are stacked there, and two stacked panes cannot both
+  fill one screen — a master and a detail would fight over the same viewport. `max_height:` belongs
+  to `:content`; in `:full` the flex chain decides, so the cap is dropped rather than fighting it.
+  Infinite scroll simply gets a taller container: one page of rows often does not fill it, so the
+  sentinel stays in view and keeps loading until it does — the container changed size, not
+  identity. `/split-view/full` in the dummy is the whole arrangement, and the spec measures it.
+
 ### Changed
 
 - **`Bali::SplitView`: the filter band is pills that are links** (#977, breaking against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel stays in view and keeps loading until it does — the container changed size, not
   identity. `/split-view/full` in the dummy is the whole arrangement, and the spec measures it.
 
+- **The SplitView previews now teach the API the component actually has** (#977/#979 follow-up). A
+  preview is the first documentation anyone copies, so what the default scenario shows is what
+  hosts will write — and it was still showing a master built by hand, from before `with_list`
+  existed. The set is now: **`default`** (the structured listing, with **live** filter pills — they
+  build their own URLs from the request, so clicking one really filters the list below),
+  **`multi_filters`** (several pills active at once), `with_selection`,
+  `deep_link_beyond_the_first_page`, `without_advance`, **`full_height/default`** (inside a locked
+  AppLayout), and **`custom_master`** — the old default, kept and relabelled as the escape hatch it
+  always was.
+
+  Two things worth knowing beyond this component. **A preview method has no `params`, but the
+  template it renders runs inside a real request** — which is what lets the pills be live rather
+  than posed. And **`@layout` is not a tag Lookbook 2.3 knows**: annotating a scenario with it does
+  nothing, silently. The full-height scenario needs the layout that omits `<body>` (AppLayout
+  renders its own, and nesting them makes the parser discard the inner one along with
+  `app-layout--viewport-locked`), so it moved to a preview class of its own where `layout` is a
+  class-level declaration that works. Measured before the move: the scenario filled a 769px
+  `<main>` inside an 1151px viewport and looked perfectly plausible while demonstrating nothing.
+  `test/requests/split_view_previews_test.rb` now fails if either regresses.
+
 ### Changed
 
 - **`Bali::SplitView`: the filter band is pills that are links** (#977, breaking against

--- a/app/components/bali/split_view/component.rb
+++ b/app/components/bali/split_view/component.rb
@@ -100,7 +100,7 @@ module Bali
         @frame_id = frame_id
         @master_width = validated_master_width(master_width)
         @advance = advance
-        @height = HEIGHTS.include?(height&.to_sym) ? height.to_sym : :content
+        @height = validated_height(height)
         @options = options
       end
 
@@ -110,6 +110,19 @@ module Bali
 
       def advance? = @advance
       def full_height? = @height == :full
+
+      # Raises rather than falling back, like `master_width:` two lines up. A
+      # silent fallback on the option that IS this feature turns `height: :fill`
+      # into a component that renders the default and says nothing — and the
+      # symptom (a split that does not fill) is exactly what a reader would go
+      # hunting for in the CSS. Free to demand now, breaking to demand later.
+      def validated_height(value)
+        height = value&.to_sym
+        return height if HEIGHTS.include?(height)
+
+        raise ArgumentError,
+              "height must be one of #{HEIGHTS.map(&:inspect).join(', ')}, got #{value.inspect}."
+      end
 
       def validated_master_width(value)
         width = value.to_s.strip

--- a/app/components/bali/split_view/component.rb
+++ b/app/components/bali/split_view/component.rb
@@ -68,6 +68,8 @@ module Bali
 
       DEFAULT_MASTER_WIDTH = "420px"
 
+      HEIGHTS = %i[content full].freeze
+
       # A single CSS length or percentage. Anything more expressive (`minmax()`,
       # `clamp()`) belongs in the host's own stylesheet overriding
       # `--bali-split-master-width`, not in an inline style attribute built from
@@ -80,14 +82,25 @@ module Bali
       #             `data-turbo-frame`, so it has to be unique in the page.
       # master_width - width of the master column from `lg` up. CSS length or
       #             percentage; drives `--bali-split-master-width`.
+      # height    - `:content` (default) lets the split grow with its content and
+      #             the page scroll do the work. `:full` makes it fill the nearest
+      #             ancestor with a definite height and gives EACH pane its own
+      #             scrollbar — the inbox shape. It is `height: 100%` and a flex
+      #             chain, nothing measured: with no bounded ancestor there is
+      #             nothing to fill, so pair it with
+      #             `Bali::AppLayout::Component.new(viewport_locked: true)`.
+      #             Only from `lg` up; stacked panes cannot both fill one screen,
+      #             so below that the page scrolls as usual.
       # advance   - emit `data-turbo-action="advance"` on the frame so a row click
       #             pushes its URL into the history and the selection is
       #             deep-linkable. Turn it off for a split view that is not a
       #             navigable location of its own.
-      def initialize(frame_id:, master_width: DEFAULT_MASTER_WIDTH, advance: true, **options)
+      def initialize(frame_id:, master_width: DEFAULT_MASTER_WIDTH, advance: true,
+                     height: :content, **options)
         @frame_id = frame_id
         @master_width = validated_master_width(master_width)
         @advance = advance
+        @height = HEIGHTS.include?(height&.to_sym) ? height.to_sym : :content
         @options = options
       end
 
@@ -96,6 +109,7 @@ module Bali
       attr_reader :options
 
       def advance? = @advance
+      def full_height? = @height == :full
 
       def validated_master_width(value)
         width = value.to_s.strip
@@ -109,7 +123,9 @@ module Bali
       def container_attributes
         options.except(:class, :style)
                .merge(
-                 class: class_names("split-view-component", options[:class]),
+                 class: class_names("split-view-component",
+                                    ("split-view-component--full" if full_height?),
+                                    options[:class]),
                  # The only inline declaration is the custom property the grid
                  # reads: `lg:grid-cols-[#{master_width}_1fr]` would be an
                  # arbitrary value Tailwind never sees at build time, so it would

--- a/app/components/bali/split_view/full_height/preview.rb
+++ b/app/components/bali/split_view/full_height/preview.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Bali
+  module SplitView
+    module FullHeight
+      # `height: :full` gets a preview class of its own for one reason: it needs a
+      # layout the other scenarios must not have.
+      #
+      # AppLayout renders its own `<body>`, and the ordinary preview layout
+      # already has one — nest them and the HTML parser discards the inner tag,
+      # taking `app-layout--viewport-locked` with it. Measured: the scenario then
+      # filled a 769px `<main>` inside an 1151px viewport and looked plausible
+      # while demonstrating nothing. `layout` is a class-level declaration in
+      # ViewComponent and Lookbook 2.3 has no per-scenario tag for it, so the
+      # scenario that needs a different layout needs a different class.
+      class Preview < ApplicationViewComponentPreview
+        layout "app_layout_preview"
+
+        # The split fills the screen and **each pane scrolls on its own** — the
+        # inbox shape. It is `height: 100%` plus a flex chain: no measured offset,
+        # no `calc(100vh - …)`, no JavaScript. So it needs an ancestor with a
+        # definite height and fills nothing without one, which is why this
+        # scenario renders the whole pairing rather than a bare component.
+        #
+        # Inert below `lg`, where the panes stack and cannot both fill one screen.
+        #
+        # The same arrangement, wired end to end, is at **`/split-view/full`** in
+        # the dummy app.
+        def default
+          render_with_template(
+            template: "bali/split_view/full_height/previews/default",
+            locals: {
+              movies: Movie.includes(:studio).order(:name).limit(8),
+              total: Movie.count,
+              selected: Movie.order(:name).first
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/bali/split_view/full_height/previews/default.html.erb
+++ b/app/components/bali/split_view/full_height/previews/default.html.erb
@@ -1,0 +1,37 @@
+<%# `height: :full` needs an ancestor with a definite height, so this scenario
+    renders the whole pairing rather than a bare component: AppLayout with
+    `viewport_locked: true` stops the body scrolling and makes <main> that box.
+    The split then fills it and each pane scrolls on its own.
+
+    Scenario-level `@layout app_layout_preview`, because AppLayout renders its
+    own <body> and the ordinary preview layout already has one. %>
+<%= render Bali::AppLayout::Component.new(viewport_locked: true, app_name: "MovieDB") do |layout| %>
+  <% layout.with_body do %>
+    <%= render Bali::SplitView::Component.new(frame_id: "split-view-detail", height: :full) do |split| %>
+      <% split.with_list(header: "Catálogo", count: total, selected: selected&.id,
+                         item_name: "películas") do |list| %>
+        <% movies.each do |movie| %>
+          <% list.with_item(
+            id: movie.id,
+            href: "/split-view/full?selected=#{movie.id}",
+            title: movie.name,
+            subtitle: movie.studio&.name,
+            meta: movie.production_ends_on && l(movie.production_ends_on, format: :short)
+          ) do |row| %>
+            <% row.with_tag(text: movie.genre, color: :info) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% split.with_detail do %>
+        <%= render Bali::Card::Component.new(style: :bordered) do |card| %>
+          <% card.with_title(selected.name, class: "text-lg", data: { testid: "detail-title" }) %>
+          <%= render Bali::DescriptionList::Component.new(columns: 2) do |items| %>
+            <% items.with_item(label: "Género", value: selected.genre) %>
+            <% items.with_item(label: "Estudio", value: selected.studio&.name) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bali/split_view/index.css
+++ b/app/components/bali/split_view/index.css
@@ -136,3 +136,89 @@
 .split-view-sentinel-error[hidden] {
   display: none;
 }
+
+/* ── height: :full ────────────────────────────────────────────────────────
+   The split fills the nearest ancestor with a definite height, and each pane
+   scrolls on its own — the inbox shape. There is no measurement and no magic
+   offset anywhere in it: `height: 100%` plus a flex chain, so it fills whatever
+   bounded box you put it in and fills NOTHING if there is no such box. That is
+   the honest failure mode, and the reason the pairing with
+   `AppLayout viewport_locked: true` is documented rather than guessed at (the
+   same reasoning that kept a `calc(100vh - 17rem)` out of the Kanban).
+
+   Only from `lg` up. Below it the panes are stacked one above the other, and
+   two stacked panes cannot both fill one screen — `:full` there would be a
+   master and a detail fighting over the same viewport. Stacked keeps the
+   ordinary page scroll, which is what a phone wants anyway. */
+@media (width >= 64rem) {
+  .split-view-component--full {
+    @apply h-full min-h-0 items-stretch;
+  }
+
+  /* The chain from the grid cell down to the scrolling list. Every link needs
+     `min-h-0`: a flex item defaults to `min-height: auto`, which refuses to
+     shrink below its content, and one link missing it is enough for the scroll
+     never to engage and the whole thing to overflow instead. */
+  .split-view-component--full .split-view-master,
+  .split-view-component--full .split-view-master > .card,
+  .split-view-component--full .split-view-master > .card > .card-body,
+  .split-view-component--full .split-view-list {
+    @apply flex flex-col min-h-0;
+  }
+
+  .split-view-component--full .split-view-master > .card,
+  .split-view-component--full .split-view-master > .card > .card-body,
+  .split-view-component--full .split-view-list {
+    @apply flex-1;
+  }
+
+  /* The bands above and below the rows keep their height; the rows take the rest. */
+  .split-view-component--full .split-view-list-header,
+  .split-view-component--full .split-view-list-filters,
+  .split-view-component--full [data-split-view-list-target="pagination"] {
+    @apply shrink-0;
+  }
+
+  /* `max-height: none` because the flex chain governs the height now. Leaving
+     the var in place would cap the list at `calc(100vh - 20rem)` inside a pane
+     that is already exactly as tall as it should be. */
+  .split-view-component--full .split-view-scroll {
+    @apply flex-1 min-h-0;
+    max-height: none;
+  }
+
+  .split-view-component--full .split-view-detail {
+    @apply overflow-y-auto min-h-0;
+  }
+}
+
+/* ── Making the documented pairing actually pair ──────────────────────────
+   `height: :full` resolves `height: 100%` against its parent, and AppLayout's
+   body container is `height: auto` — it wraps its content. So under a locked
+   viewport the container stopped at the split's own height and the split
+   stopped with it: measured at 629px inside a 1086px `<main>`, i.e. filling
+   nothing while claiming to fill everything.
+
+   These two rules close that gap, and they live HERE rather than in
+   `app_layout/index.css` because they exist for `:full` and nothing else. The
+   `:has()` is what keeps them off every other locked page: a layout with
+   ordinary content is byte-for-byte what it was.
+
+   `flex: 1 0 auto` and not `flex: 1`: grow to fill the screen, but never shrink
+   below the content. A page taller than the viewport keeps its height and
+   `<main>` scrolls, which is what `:content` inside a locked layout still wants.
+
+   The split has to be a DIRECT child of the body container. A wrapper in
+   between is a link in the chain with `height: auto`, and the fill dies there —
+   give that wrapper `h-full min-h-0` if you need one. */
+@media (width >= 64rem) {
+  .app-layout--viewport-locked
+    main:has(> .app-layout-body-container > .split-view-component--full) {
+    @apply flex flex-col;
+  }
+
+  .app-layout--viewport-locked
+    .app-layout-body-container:has(> .split-view-component--full) {
+    flex: 1 0 auto;
+  }
+}

--- a/app/components/bali/split_view/list/component.html.erb
+++ b/app/components/bali/split_view/list/component.html.erb
@@ -4,7 +4,7 @@
 <%= render Bali::Card::Component.new(style: :bordered, body_class: "p-0 overflow-hidden") do %>
   <%= tag.div(**container_attributes) do %>
     <% if header.present? || count.present? %>
-      <div class="<%= HEADER_CLASSES %>">
+      <div class="split-view-list-header <%= HEADER_CLASSES %>">
         <% if header.present? %><span><%= header %></span><% end %>
         <% if count.present? %>
           <span class="text-base-content/50 font-normal" data-testid="list-count"><%= count %></span>

--- a/app/components/bali/split_view/preview.rb
+++ b/app/components/bali/split_view/preview.rb
@@ -3,89 +3,109 @@
 module Bali
   module SplitView
     class Preview < ApplicationViewComponentPreview
-      TEMPLATE = "bali/split_view/previews/default"
-      LIST_TEMPLATE = "bali/split_view/previews/structured_list"
+      STRUCTURED = "bali/split_view/previews/structured_list"
+      CUSTOM_MASTER = "bali/split_view/previews/custom_master"
 
       PER_PAGE = 5
 
-      # The recommended way to build a master: `with_list` + `with_item`. The
-      # component writes `data-turbo-frame`, `data-split-view-target`,
-      # `data-action` and `aria-current` itself, so a row template says what a row
-      # *is* and never how it is wired.
+      # Master-detail: a list on the left, the detail of the selected row on the
+      # right inside a Turbo Frame, so a row click swaps only the right column and
+      # the list keeps its scroll and its highlight.
       #
-      # Paging is infinite: scroll the list to the bottom and the next page is
-      # fetched from the dummy's `/split-view` — the same index URL one page
-      # further on, with no endpoint of its own. Pagination controls are rendered
-      # underneath for a reader without JavaScript; the controller hides them when
-      # it connects.
-      def structured_list
-        render_with_template(
-          template: Bali::SplitView::Preview::LIST_TEMPLATE,
-          locals: {
-            movies: Movie.includes(:studio).order(:name).limit(Bali::SplitView::Preview::PER_PAGE),
-            total: Movie.count,
-            selected: nil,
-            pagy: Pagy::Offset.new(count: Movie.count, page: 1, limit: Bali::SplitView::Preview::PER_PAGE)
-          }
-        )
+      # `with_list` + `with_item` are the way to build the master: the component
+      # writes `data-turbo-frame`, `data-split-view-target`, `data-action` and
+      # `aria-current` itself, so the template says what a row *is* and never how
+      # it is wired.
+      #
+      # **The filter pills are live.** They take `param:`/`value:` and build their
+      # own URLs from the current request, so clicking one really filters the list
+      # below — one value at a time, and clicking the active pill clears it, which
+      # is what replaces a Clear button.
+      #
+      # The full flow — frame swaps, infinite scroll against a real paginated
+      # index, deep links, back and forward — is at **`/split-view`** in the dummy
+      # app. A preview cannot page against itself.
+      # @param status [String] select ["", "draft", "done"]
+      def default(status: "")
+        render_structured(status: status)
       end
 
-      # A deep link to a record that is not on the first page. The detail renders
-      # immediately — the server looks the record up against the whole table — while
-      # its row is simply not on screen yet. The highlight appears when infinite
-      # scroll reaches the page it lives on.
-      def deep_link_beyond_the_first_page
-        render_with_template(
-          template: Bali::SplitView::Preview::LIST_TEMPLATE,
-          locals: {
-            movies: Movie.includes(:studio).order(:name).limit(Bali::SplitView::Preview::PER_PAGE),
-            total: Movie.count,
-            selected: Movie.order(:name).offset(Bali::SplitView::Preview::PER_PAGE + 1).first,
-            pagy: Pagy::Offset.new(count: Movie.count, page: 1, limit: Bali::SplitView::Preview::PER_PAGE)
-          }
-        )
-      end
-
-      # The escape hatch: the free `master` slot, with the row wiring written by
-      # hand. Still supported, and what a listing that `with_list` does not fit
-      # should use.
+      # `filter_mode: :multi`: each pill toggles independently over a multi-valued
+      # param, so several are active at once. Click two and both light up; click
+      # an active one and it removes **its** value and leaves the others alone.
       #
-      # The rows link to `/split-view?selected=<id>` in the dummy app, a real page
-      # that renders the same `split-view-detail` frame. Clicking one is a real
-      # Turbo Frame navigation: only the right column is replaced, the master keeps
-      # its scroll, and the URL advances so the selection is deep-linkable.
-      #
-      # Below `lg` the panes stack, master on top.
-      # @param master_width [String] select ["320px", "420px", "36rem", "35%"]
-      def default(master_width: "420px")
-        render_with_template(
-          template: Bali::SplitView::Preview::TEMPLATE,
-          locals: { movies: preview_movies, selected: nil, master_width: master_width }
-        )
+      # The state is announced differently here on purpose. `aria-current` marks
+      # "the current item of a set" and there is no single current item in this
+      # mode, so the active pills carry an `sr-only` note instead — and never
+      # `aria-pressed`, which browsers drop on a link. See the component docstring.
+      def multi_filters
+        render_structured(filter_mode: :multi, filters: genre_filters)
       end
 
       # What the server renders for a deep link: the row already carries
       # `aria-current="true"` on first paint and the frame already holds the
       # detail. The Stimulus controller only takes over from the next click on.
       def with_selection
-        movies = preview_movies
+        render_structured(selected: Movie.order(:name).second)
+      end
 
-        render_with_template(
-          template: Bali::SplitView::Preview::TEMPLATE,
-          locals: { movies: movies, selected: movies.second, master_width: "420px" }
-        )
+      # A deep link to a record that is not on the first page. The detail renders
+      # immediately — the server looks the record up against the whole table —
+      # while its row is simply not on screen yet. The highlight appears when
+      # infinite scroll reaches the page it lives on.
+      def deep_link_beyond_the_first_page
+        render_structured(selected: Movie.order(:name).offset(Bali::SplitView::Preview::PER_PAGE + 1).first)
       end
 
       # `advance: false` for a split view that is not a location of its own — the
       # frame still swaps, but nothing is pushed into the history.
       def without_advance
+        render_structured(advance: false)
+      end
+
+      # The **escape hatch**: the free `master` slot, with every row attribute
+      # written by hand. Still supported, and the answer for a listing `with_list`
+      # cannot express — a tree, a calendar, a grouped inbox. For anything that
+      # can be a row of title/subtitle/tags/meta, use `default`.
+      # @param master_width [String] select ["320px", "420px", "36rem", "35%"]
+      def custom_master(master_width: "420px")
         render_with_template(
-          template: Bali::SplitView::Preview::TEMPLATE,
-          locals: { movies: preview_movies, selected: nil, master_width: "420px", advance: false }
+          template: Bali::SplitView::Preview::CUSTOM_MASTER,
+          locals: { movies: preview_movies, selected: nil, master_width: master_width }
         )
       end
 
       private
+
+      def render_structured(scope: Movie.all, status: "", selected: nil, filter_mode: :single,
+                            filters: nil, advance: true)
+        scope = scope.where(status: status) if status.present?
+
+        render_with_template(
+          template: Bali::SplitView::Preview::STRUCTURED,
+          locals: {
+            scope: scope,
+            selected: selected,
+            filter_mode: filter_mode,
+            filters: filters || status_filters,
+            advance: advance
+          }
+        )
+      end
+
+      def status_filters
+        counts = Movie.group(:status).count
+        Movie.statuses.keys.map do |status|
+          { label: status.humanize, param: :status, value: status, count: counts[status].to_i }
+        end
+      end
+
+      def genre_filters
+        counts = Movie.group(:genre).count
+        Movie::GENRES.first(6).map do |genre|
+          { label: genre, param: "q[genre_in]", value: genre, count: counts[genre].to_i }
+        end
+      end
 
       def preview_movies
         Movie.includes(:studio).order(:name).limit(8)

--- a/app/components/bali/split_view/previews/custom_master.html.erb
+++ b/app/components/bali/split_view/previews/custom_master.html.erb
@@ -1,4 +1,10 @@
-<%# Rows point at the dummy app's `/split-view` page, which renders the same
+<%# The ESCAPE HATCH, not the recommended shape. Everything below the `master`
+    slot is markup a host wrote by hand — including the four attributes
+    `with_item` would have written for it. Reach for this when a listing cannot
+    be expressed as rows of title/subtitle/tags/meta: a tree, a calendar, a
+    grouped inbox. For anything that can, see the `default` scenario.
+
+    Rows point at the dummy app's `/split-view` page, which renders the same
     `split-view-detail` frame, so the swap here is a real frame navigation and
     not a preview-only illusion. %>
 <%= render Bali::SplitView::Component.new(

--- a/app/components/bali/split_view/previews/structured_list.html.erb
+++ b/app/components/bali/split_view/previews/structured_list.html.erb
@@ -1,27 +1,33 @@
-<%# The structured listing. Every row attribute that makes the frame swap work is
-    written by the component; the template below says what a row *is*, not how it
-    is wired.
+<%# The recommended shape. Locals: `scope` (a Movie relation), `selected`,
+    `filter_mode`, `filters`, and an optional `advance`.
 
-    `next_url` points at the dummy's own `/split-view`, which renders this same
-    list — so scrolling to the bottom performs a real fetch against a real
-    paginated index, the way a host app's would. %>
-<%= render Bali::SplitView::Component.new(frame_id: "split-view-detail") do |split| %>
-  <%# `next_url` spells out what a Pagy-derived one carries on its own: the current
-      selection travels with the page number, so the server can paint the row of a
-      deep-linked record when its page finally arrives. %>
+    The filter pills take `param:`/`value:` and build their own URLs from the
+    current request, which in Lookbook is the preview's own URL — so they are
+    live: clicking one re-renders this preview with the param and the pill goes
+    active. The listing narrows with them, and THAT part happens here rather than
+    in the preview method: a preview method has no `params`, but the template it
+    renders runs inside a real request and can read the same place the pills do.
+
+    The full flow — frame swaps, infinite scroll against a real paginated index,
+    deep links, back and forward — lives at `/split-view` in the dummy app. A
+    preview cannot page against itself. %>
+<% active_genres = Array(request.query_parameters.dig("q", "genre_in")) %>
+<% scope = scope.where(genre: active_genres) if active_genres.any? %>
+<% movies = scope.includes(:studio).order(:name).limit(5) %>
+<% total = scope.count %>
+<% pagy = Pagy::Offset.new(count: [ total, 1 ].max, page: 1, limit: 5) %>
+<%= render Bali::SplitView::Component.new(
+  frame_id: "split-view-detail",
+  advance: local_assigns.fetch(:advance, true)
+) do |split| %>
   <% split.with_list(header: "Catálogo", count: total, selected: selected&.id,
                      pagy: pagy, item_name: "películas", max_height: "22rem",
+                     filter_mode: filter_mode,
                      next_url: ["/split-view?page=2", ("selected=#{selected.id}" if selected)].compact.join("&")) do |list| %>
-    <%# Filter pills: plain links, no form. `href:` on purpose — the override, not
-        the usual way. A pill normally takes `param:`/`value:` and builds its URL
-        from the current request, but a preview's request is the Lookbook path,
-        so the pills would filter the preview instead of the listing. Pointing
-        them at the dummy's own `/split-view` makes clicking one the real
-        full-page GET the pattern relies on. Both modes filter for real there. %>
-    <% Movie.statuses.each_key do |status| %>
-      <% list.with_filter(label: status.humanize, count: Movie.where(status: status).count,
-                          href: "/split-view?status=#{status}") %>
+    <% filters.each do |filter| %>
+      <% list.with_filter(**filter) %>
     <% end %>
+
     <% movies.each do |movie| %>
       <% list.with_item(
         id: movie.id,
@@ -33,6 +39,17 @@
       ) do |row| %>
         <% row.with_tag(text: movie.genre, color: :info) %>
         <% row.with_tag(text: movie.status.humanize, color: movie.status_color) %>
+      <% end %>
+    <% end %>
+
+    <% if movies.none? %>
+      <% list.with_empty_state do %>
+        <%= render Bali::EmptyState::Component.new(
+          title: "Sin resultados",
+          description: "Ningún título coincide con este filtro.",
+          icon: "filter-x",
+          size: :sm
+        ) %>
       <% end %>
     <% end %>
   <% end %>

--- a/cypress/e2e/split-view-full-height.cy.js
+++ b/cypress/e2e/split-view-full-height.cy.js
@@ -1,0 +1,85 @@
+// `height: :full` against its documented pairing: an AppLayout with
+// `viewport_locked: true`. There is no measurement in the implementation — it is
+// `height: 100%` and a flex chain — so the only way to know it works is to
+// measure the result, which is what this does.
+describe('SplitView height: :full', () => {
+  const app = path =>
+    `${Cypress.config('baseUrl').replace(/\/lookbook\/preview\/?$/, '')}${path}`
+
+  const rectOf = selector =>
+    cy.get(selector).then($el => $el[0].getBoundingClientRect())
+
+  beforeEach(() => {
+    cy.viewport(1280, 800)
+    cy.visit(app('/split-view/full'))
+  })
+
+  it('fills the locked viewport instead of stopping at its content', () => {
+    cy.get('.split-view-component').should('have.class', 'split-view-component--full')
+
+    rectOf('main').then((main) => {
+      rectOf('.split-view-component').then((split) => {
+        // The gap is the body container's padding, nothing more.
+        expect(main.bottom - split.bottom, 'the split reaches the bottom of main')
+          .to.be.lessThan(60)
+        expect(split.height, 'the split is most of the screen')
+          .to.be.greaterThan(main.height * 0.85)
+      })
+    })
+  })
+
+  // The point of the shape: the page does not scroll, the panes do.
+  it('leaves the page unscrollable and gives each pane its own scroll', () => {
+    cy.document().then((doc) => {
+      expect(doc.documentElement.scrollHeight, 'the page itself does not scroll')
+        .to.be.at.most(doc.documentElement.clientHeight + 1)
+    })
+
+    cy.get('[data-split-view-list-target="scroller"]')
+      .should('have.css', 'overflow-y', 'auto')
+      .and('have.css', 'max-height', 'none')
+    cy.get('.split-view-detail').should('have.css', 'overflow-y', 'auto')
+  })
+
+  it('lines the two panes up at the same height', () => {
+    rectOf('.split-view-master').then((master) => {
+      rectOf('.split-view-detail').then((detail) => {
+        expect(Math.abs(master.height - detail.height), 'both panes are the same height')
+          .to.be.lessThan(2)
+      })
+    })
+  })
+
+  // The interaction the issue asks about: in `:full` the scroll container is
+  // taller than it was, so one page of rows no longer fills it. The sentinel
+  // stays in view and has to keep asking — the container changed size, not
+  // identity, and the observer is rooted on it either way.
+  it('keeps the infinite scroll loading until the taller pane is full', () => {
+    // 5 rows a page, 20 in the table. A pane this tall does not stop at one
+    // page: the sentinel stays in view after each append and keeps asking, so
+    // the listing runs to the end without anybody scrolling.
+    cy.get('.split-view-item').should('have.length.greaterThan', 5)
+    cy.get('.split-view-item').should('have.length', 20)
+    cy.get('[data-split-view-list-target="end"]').should('not.have.attr', 'hidden')
+  })
+
+  it('still swaps only the detail frame when a row is clicked', () => {
+    cy.get('.split-view-item').eq(2).click()
+    cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
+    cy.get('.split-view-item').eq(2).should('have.attr', 'aria-current', 'true')
+  })
+
+  // Two stacked panes cannot both fill one screen, so below `lg` the modifier is
+  // inert and the page scrolls as usual.
+  it('does nothing below lg, where the panes are stacked', () => {
+    cy.viewport(700, 800)
+
+    // The two rules that make `:full` what it is are inside the `lg` media
+    // query, so below it the panes go back to the ordinary arrangement: the
+    // master capped by its own variable, the detail not a scroll box at all.
+    cy.get('[data-split-view-list-target="scroller"]')
+      .should('have.css', 'max-height')
+      .and('not.eq', 'none')
+    cy.get('.split-view-detail').should('have.css', 'overflow-y', 'visible')
+  })
+})

--- a/cypress/e2e/split-view-full-height.cy.js
+++ b/cypress/e2e/split-view-full-height.cy.js
@@ -63,10 +63,63 @@ describe('SplitView height: :full', () => {
     cy.get('[data-split-view-list-target="end"]').should('not.have.attr', 'hidden')
   })
 
+  // The two rules that make the pairing work reach OUT of the component, into
+  // AppLayout's `<main>` and body container. `:has(> …)` is what keeps them from
+  // touching anything else — but that guarantee lives entirely in a selector, so
+  // relaxing a `>` some day would widen it with nothing to say so. These two
+  // assertions are the alarm.
+  it('applies the layout fix only where a full-height split actually is', () => {
+    cy.get('main').should('have.css', 'display', 'flex')
+    cy.get('.app-layout-body-container')
+      .should('have.css', 'flex-grow', '1')
+      .and('have.css', 'flex-shrink', '0')
+  })
+
   it('still swaps only the detail frame when a row is clicked', () => {
     cy.get('.split-view-item').eq(2).click()
     cy.get('.split-view-detail [data-testid="detail-title"]').should('be.visible')
     cy.get('.split-view-item').eq(2).should('have.attr', 'aria-current', 'true')
+  })
+
+  // The alarm that actually fires on a relaxed selector. The test above only
+  // catches the rules being made unconditional, because a page with no split
+  // anywhere is unaffected either way. THIS one moves the split behind a wrapper
+  // at runtime: `:has(> …)` stops matching and the layout reverts, so if someone
+  // widens the combinator to a descendant one, `main` stays flex and this fails.
+  //
+  // It doubles as the executable version of the documented limit — `:full` has
+  // to be a direct child of the body container, because a wrapper is another
+  // link in the chain with `height: auto` and the fill dies there.
+  it('stops applying when the split is not a direct child', () => {
+    cy.get('main').should('have.css', 'display', 'flex')
+
+    cy.document().then((doc) => {
+      const split = doc.querySelector('.split-view-component')
+      const wrapper = doc.createElement('div')
+      split.parentElement.appendChild(wrapper)
+      wrapper.appendChild(split)
+    })
+
+    cy.get('main').should('have.css', 'display', 'block')
+    cy.get('.app-layout-body-container').should('have.css', 'flex-grow', '0')
+  })
+
+  // The other half of the alarm: a locked layout with no split in it must be
+  // byte-for-byte what it was. `main` stays a block, the body container stays
+  // `height: auto` and grows with its content — exactly as before #979.
+  it('leaves a locked layout without a split alone', () => {
+    cy.visit('/bali/app_layout/default')
+    cy.get('body').should('have.class', 'app-layout--viewport-locked')
+    cy.get('.split-view-component').should('not.exist')
+
+    cy.get('main').should('have.css', 'display', 'block')
+    cy.get('.app-layout-body-container').then(($container) => {
+      const container = $container[0].getBoundingClientRect()
+      cy.get('main').then(($main) => {
+        expect(container.height, 'the container still wraps its content')
+          .to.be.lessThan($main[0].getBoundingClientRect().height)
+      })
+    })
   })
 
   // Two stacked panes cannot both fill one screen, so below `lg` the modifier is

--- a/cypress/e2e/split-view-list.cy.js
+++ b/cypress/e2e/split-view-list.cy.js
@@ -10,7 +10,7 @@ describe('SplitView structured list', () => {
   const scrollToBottom = () => scroller().scrollTo('bottom', { ensureScrollable: false })
 
   context('progressive enhancement', () => {
-    beforeEach(() => cy.visit('/bali/split_view/structured_list'))
+    beforeEach(() => cy.visit('/bali/split_view/default'))
 
     // The controls are in the markup and the controller removes them, rather than
     // the other way round — that is what makes the no-JS case the default.
@@ -39,7 +39,7 @@ describe('SplitView structured list', () => {
   })
 
   context('appending pages', () => {
-    beforeEach(() => cy.visit('/bali/split_view/structured_list'))
+    beforeEach(() => cy.visit('/bali/split_view/default'))
 
     it('appends the next page when the sentinel comes into view', () => {
       rows().should('have.length', 5)
@@ -306,7 +306,7 @@ describe('SplitView structured list', () => {
     // silently would be indistinguishable from reaching the end of the list, so
     // it has to land on the error state like any other failure.
     it('treats a 200 without the list in it as a failure, not as the end', () => {
-      cy.visit('/bali/split_view/structured_list')
+      cy.visit('/bali/split_view/default')
       cy.intercept('GET', '/split-view*', {
         statusCode: 200,
         body: '<html><body><h1>Please sign in</h1></body></html>'
@@ -321,7 +321,7 @@ describe('SplitView structured list', () => {
     })
 
     it('offers a retry that resumes from the same page', () => {
-      cy.visit('/bali/split_view/structured_list')
+      cy.visit('/bali/split_view/default')
       // `times: 1` so only the first attempt fails and the retry reaches the real
       // server. Registering a second, pass-through intercept instead does not
       // reliably unstub the first.

--- a/cypress/e2e/split-view.cy.js
+++ b/cypress/e2e/split-view.cy.js
@@ -1,3 +1,8 @@
+// Against `custom_master`, the free-slot escape hatch: these are the base
+// component's guarantees — frame swap, highlight, history — and they have to
+// hold for a listing a host wired by hand, not only for `with_list`. The
+// structured API has its own spec.
+//
 // The point of SplitView is what does NOT happen on a row click: the master
 // pane must survive untouched, keeping its scroll position and its DOM, while
 // only the detail frame is replaced. Every assertion here is about that, so the
@@ -7,7 +12,7 @@ describe('SplitView', () => {
 
   context('default (no selection, advance on)', () => {
     beforeEach(() => {
-      cy.visit('/bali/split_view/default')
+      cy.visit('/bali/split_view/custom_master')
       // Stamped on the live node: a re-render of the master would replace it and
       // the attribute would be gone.
       masterList().invoke('attr', 'data-sentinel', 'kept')
@@ -92,7 +97,7 @@ describe('SplitView', () => {
         cy.location('search').should('eq', href.split('?')[1] ? `?${href.split('?')[1]}` : '')
 
         cy.go('back')
-        cy.location('pathname').should('include', '/lookbook/preview/bali/split_view/default')
+        cy.location('pathname').should('include', '/lookbook/preview/bali/split_view/custom_master')
         cy.get('.split-view-detail .empty-state-component').should('be.visible')
         // The highlight has to rewind with the frame. Turbo caches the snapshot
         // of the page it leaves, and it takes it AFTER the controller has moved
@@ -134,7 +139,7 @@ describe('SplitView', () => {
       })
 
     beforeEach(() => {
-      cy.visit('/bali/split_view/default')
+      cy.visit('/bali/split_view/custom_master')
       cy.get('.split-view-row').eq(2).invoke('attr', 'href').then((href) => {
         cy.wrap(new URL(href, 'http://example.test').searchParams.get('selected')).as('id')
       })
@@ -166,7 +171,7 @@ describe('SplitView', () => {
 
   context('responsive layout', () => {
     it('puts the panes side by side from lg up and stacks them below it', () => {
-      cy.visit('/bali/split_view/default')
+      cy.visit('/bali/split_view/custom_master')
 
       cy.viewport(1280, 800)
       cy.get('.split-view-component')
@@ -183,7 +188,7 @@ describe('SplitView', () => {
 
     it('honours a custom master_width through the CSS custom property', () => {
       cy.viewport(1280, 800)
-      cy.visit('/bali/split_view/default?master_width=320px')
+      cy.visit('/bali/split_view/custom_master?master_width=320px')
       cy.get('.split-view-component')
         .should('have.css', 'grid-template-columns')
         .and('match', /^320px /)

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -633,6 +633,7 @@ keeps its scroll position and its highlight.
 - `frame_id` - **Required.** Id of the detail Turbo Frame; rows point at it with `data-turbo-frame`, so it must be unique in the page
 - `master_width` - Width of the left column from `lg` up. A CSS length or percentage (default: `"420px"`); anything more expressive overrides `--bali-split-master-width` in your own stylesheet
 - `advance` - Emit `data-turbo-action="advance"` on the frame, so a row click pushes its URL into the history and the selection is deep-linkable (default: `true`)
+- `height` - `:content` (default) grows with the content and lets the page scroll; `:full` fills the nearest ancestor with a definite height and gives **each pane its own scrollbar**. `:full` is `height: 100%` plus a flex chain — no measured offsets, no JavaScript — so pair it with `Bali::AppLayout::Component.new(viewport_locked: true)`, which is what makes `<main>` a bounded box. With no bounded ancestor it fills nothing, visibly. Inert below `lg`, where the panes are stacked and cannot both fill one screen
 
 **Slots:**
 - `with_list` - The structured listing, and the way to build a master

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -81,6 +81,55 @@ want the other mobile behaviour.
 
 ---
 
+## Filling the screen: `height: :full`
+
+By default (`height: :content`) the split grows with its content and the page
+scrolls — fine for a listing embedded in a longer page. `height: :full` gives you
+the other shape, the one an inbox wants: the split fills the screen and **each
+pane scrolls on its own**, so the list and the detail move independently and
+neither takes the page with it.
+
+```erb
+<%= render Bali::AppLayout::Component.new(viewport_locked: true) do |layout| %>
+  <% layout.with_body do %>
+    <%= render Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :full) do |split| %>
+      <%# … %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**That pairing is the recipe, not a suggestion.** `:full` is `height: 100%` and a
+flex chain — there is no measured offset, no `calc(100vh - 17rem)` and no
+JavaScript anywhere in it. A percentage height needs an ancestor with a definite
+one, and `AppLayout viewport_locked: true` is what provides it: the body stops
+scrolling and `<main>` becomes the bounded box. **Without a bounded ancestor
+there is nothing to fill and `:full` does nothing** — visibly, not subtly. That
+is the honest failure, and it is deliberate: a component that guessed at the
+height of your chrome would be wrong on every screen that does not look like the
+one it was written for.
+
+The split must be a **direct child** of the layout's body container. A wrapper in
+between is another link with `height: auto`, and the fill dies there — give that
+wrapper `h-full min-h-0` if you need one.
+
+**Below `lg` it does nothing**, on purpose. The panes are stacked one above the
+other there, and two stacked panes cannot both fill one screen: a master and a
+detail would fight over the same viewport. Stacked keeps the ordinary page
+scroll, which is what a phone wants anyway.
+
+**`max_height:` is for `:content`.** In `:full` the flex chain decides the list's
+height, so `--bali-split-master-max-h` is dropped — a cap of
+`calc(100vh - 20rem)` inside a pane that is already exactly as tall as it should
+be would only make it shorter.
+
+**Infinite scroll gets bigger, not different.** A full-height pane is taller than
+a capped one, so one page of rows often does not fill it; the sentinel stays in
+view and keeps asking until it does. The scroll container changed size, not
+identity, and the observer is rooted on it either way.
+
+---
+
 ## The list
 
 **Options on `with_list`**

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -128,7 +128,9 @@ be would only make it shorter.
 **Infinite scroll gets bigger, not different.** A full-height pane is taller than
 a capped one, so one page of rows often does not fill it; the sentinel stays in
 view and keeps asking until it does. The scroll container changed size, not
-identity, and the observer is rooted on it either way.
+identity, and the observer is rooted on it either way — but it does mean a small
+`limit:` turns the first paint into a chain of serial fetches, so size it to the
+pane rather than to the capped list it used to be.
 
 ---
 
@@ -294,6 +296,13 @@ def show
   @pagy, @items = pagy(filter(current_user.inbox_items, @bucket), limit: 20)
 end
 ```
+
+**Size `limit:` to the height of the pane.** Infinite scroll keeps fetching while
+the sentinel is in view, so a page that does not fill the pane is followed
+immediately by another — with `limit: 3` the first paint is a chain of serial
+fetches before the reader has scrolled anything. A page worth roughly a screenful
+costs one request; this matters most with `height: :full`, where the pane is as
+tall as the window.
 
 That controller is the whole server side. No FilterForm, no Ransack, no form
 object — the filter is a query param you read.

--- a/docs/guides/master-detail.md
+++ b/docs/guides/master-detail.md
@@ -9,7 +9,9 @@ screen this way instead of navigating to a detail page.
 the Stimulus controller that moves the highlight — **and the listing**. The
 detail pane stays completely yours.
 
-- Live example: `/lookbook/preview/bali/split_view/structured_list`
+- Live examples: `/lookbook/preview/bali/split_view/default` (the structured
+  listing, with live filter pills), `.../multi_filters`, `.../full_height/default`
+  (inside a locked AppLayout) and `.../custom_master` (the escape hatch)
 - Working reference in the dummy app: `spec/dummy/app/controllers/split_views_controller.rb`
   and `spec/dummy/app/views/split_views/` — the whole Rails side in one action.
 

--- a/spec/dummy/app/controllers/split_views_controller.rb
+++ b/spec/dummy/app/controllers/split_views_controller.rb
@@ -23,6 +23,9 @@
 class SplitViewsController < ApplicationController
   PER_PAGE = 5
 
+  # AppLayout renders its own <body>, so the shell around it must not have one.
+  layout "app_layout_preview", only: :full
+
   def show
     # A real screen picks one semantics and stays there. This page takes it from
     # a param so the reference can show both: `:single` is the bucket strip
@@ -32,6 +35,14 @@ class SplitViewsController < ApplicationController
 
     @pagy, @movies = pagy(filtered.includes(:studio).order(:name), limit: PER_PAGE)
     @selected = Movie.find_by(id: params[:selected])
+  end
+
+  # The same listing, in the arrangement `height: :full` is built for: inside an
+  # AppLayout that locks the viewport, so the split fills the screen and each
+  # pane scrolls on its own instead of the page scrolling as a whole.
+  def full
+    show
+    render :full
   end
 
   private

--- a/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
+++ b/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
@@ -63,6 +63,32 @@ in `docs/guides/master-detail.md`.
 The free `master` slot is still there, unchanged, for a listing this shape does not
 fit.
 
+## Filling the screen: `height: :full`
+
+`height: :content` (default) grows with the content and lets the page scroll.
+`height: :full` fills the screen and gives **each pane its own scrollbar** — the
+inbox shape.
+
+```erb
+<%%= render Bali::AppLayout::Component.new(viewport_locked: true) do |layout| %>
+  <%% layout.with_body do %>
+    <%%= render Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :full) do |split| %>
+```
+
+**That pairing is the recipe.** `:full` is `height: 100%` plus a flex chain — no
+measured offsets, no `calc(100vh - …)`, no JavaScript — and a percentage height
+needs an ancestor with a definite one. `viewport_locked: true` is what makes
+`<main>` that box. Without a bounded ancestor `:full` fills nothing, visibly; a
+component that guessed at your chrome's height would be wrong on every screen it
+was not written for. The split has to be a **direct child** of the body container.
+
+Below `lg` it is inert: the panes are stacked, and two stacked panes cannot both
+fill one screen. `max_height:` belongs to `:content` — in `:full` the flex chain
+decides. And infinite scroll simply gets a taller container: the sentinel stays in
+view and keeps loading until the pane is full.
+
+Reference page: [/split-view/full](/split-view/full).
+
 ## Paging: infinite by default
 
 Give `with_list` a `pagy:` and the listing pages itself:

--- a/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
+++ b/spec/dummy/app/views/lookbook/pages/02_guides/04_master_detail.md.erb
@@ -13,7 +13,10 @@ and its highlight.
 Stimulus controller that moves the highlight — **and the listing**. The detail pane
 stays completely yours.
 
-- Preview: [SplitView](/lookbook/inspect/bali/split_view/structured_list)
+- Previews: [SplitView](/lookbook/inspect/bali/split_view/default) ·
+  [multi filters](/lookbook/inspect/bali/split_view/multi_filters) ·
+  [height :full](/lookbook/inspect/bali/split_view/full_height/default) ·
+  [custom master](/lookbook/inspect/bali/split_view/custom_master)
 - Working reference in this app: [/split-view](/split-view)
 - Full guide, with the recipes this page leaves out: `docs/guides/master-detail.md`
 

--- a/spec/dummy/app/views/split_views/full.html.erb
+++ b/spec/dummy/app/views/split_views/full.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:title) { 'SplitView · height: :full' } %>
+
+<%# The documented pairing: `viewport_locked: true` makes <main> a bounded box,
+    and `height: :full` fills it. Neither knows anything about the other's
+    numbers — there are none. %>
+<%= render Bali::AppLayout::Component.new(viewport_locked: true, app_name: 'MovieDB') do |layout| %>
+  <% layout.with_navbar do %>
+    <%= render 'layouts/navbar' %>
+  <% end %>
+
+  <% layout.with_body do %>
+    <%= render Bali::SplitView::Component.new(frame_id: 'split-view-detail', height: :full) do |split| %>
+      <% split.with_list(header: 'Catálogo', count: @pagy.count, selected: params[:selected],
+                         pagy: @pagy, item_name: 'películas', filter_mode: @filter_mode) do |list| %>
+        <% Movie.statuses.each_key do |status| %>
+          <% list.with_filter(label: status.humanize, param: :status, value: status,
+                              count: @counts[status].to_i) %>
+        <% end %>
+        <% @movies.each do |movie| %>
+          <% list.with_item(
+            id: movie.id,
+            href: split_view_full_path(selected: movie.id),
+            title: movie.name,
+            subtitle: movie.studio&.name,
+            meta: movie.production_ends_on && l(movie.production_ends_on, format: :short),
+            meta_color: (:error if movie.production_ends_on&.past?)
+          ) do |row| %>
+            <% row.with_tag(text: movie.genre, color: :info) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @selected %>
+        <% split.with_detail do %>
+          <%= render 'split_views/detail', movie: @selected %>
+        <% end %>
+      <% else %>
+        <% split.with_empty_detail do %>
+          <%= render Bali::EmptyState::Component.new(
+            title: 'Selecciona una película',
+            description: 'Elige una fila de la izquierda para ver su ficha aquí.',
+            icon: 'inbox'
+          ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -67,6 +67,9 @@ Rails.application.routes.draw do
   # SplitView reference page. `?selected=<id>` is the deep link; the Lookbook
   # preview of the component navigates its detail frame here.
   get 'split-view', to: 'split_views#show', as: :split_view
+  # `height: :full` needs a bounded parent to fill, so its reference page is the
+  # pairing the guide documents: an AppLayout with `viewport_locked: true`.
+  get 'split-view/full', to: 'split_views#full', as: :split_view_full
   get 'embed/feedback_posts', to: 'pages#feedback_embed' # Stand-in for Opina's embed page
 
   # Modal/Drawer content routes (for remote loading)

--- a/test/bali/components/split_view_test.rb
+++ b/test/bali/components/split_view_test.rb
@@ -99,6 +99,44 @@ class BaliSplitViewComponentTest < ComponentTestCase
     assert_match(/master_width must be a CSS length/, error.message)
   end
 
+  # --- height ---------------------------------------------------------------------------
+
+  def test_height_content_is_the_default_and_adds_no_modifier
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail")) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector(".split-view-component")
+    assert_no_selector(".split-view-component--full")
+  end
+
+  def test_height_full_adds_the_modifier
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :full)) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_selector(".split-view-component.split-view-component--full")
+  end
+
+  # The modifier is the whole of `:full` — there is no inline height, no
+  # `calc()` and no measured offset anywhere, which is what lets it fill a
+  # bounded parent and honestly fill nothing without one.
+  def test_height_full_adds_no_inline_height
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :full)) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    refute_match(/height/, page.find(".split-view-component")["style"])
+  end
+
+  def test_an_unknown_height_falls_back_to_content
+    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :tall)) do |split|
+      split.with_master { "MASTER" }
+    end
+
+    assert_no_selector(".split-view-component--full")
+  end
+
   def test_host_class_is_merged_and_host_style_is_kept
     render_inline(
       Bali::SplitView::Component.new(frame_id: "inbox-detail", class: "gap-6", style: "--bali-split-master-max-h: 30rem")

--- a/test/bali/components/split_view_test.rb
+++ b/test/bali/components/split_view_test.rb
@@ -129,12 +129,17 @@ class BaliSplitViewComponentTest < ComponentTestCase
     refute_match(/height/, page.find(".split-view-component")["style"])
   end
 
-  def test_an_unknown_height_falls_back_to_content
-    render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :tall)) do |split|
-      split.with_master { "MASTER" }
+  # Raises rather than falling back, like `master_width:`. A typo in the option
+  # that IS this feature would otherwise render the default in silence, and the
+  # symptom — a split that does not fill — sends the reader hunting in the CSS.
+  def test_an_unknown_height_raises
+    error = assert_raises(ArgumentError) do
+      render_inline(Bali::SplitView::Component.new(frame_id: "inbox-detail", height: :tall)) do |split|
+        split.with_master { "MASTER" }
+      end
     end
 
-    assert_no_selector(".split-view-component--full")
+    assert_match(/height must be one of/, error.message)
   end
 
   def test_host_class_is_merged_and_host_style_is_kept

--- a/test/requests/split_view_previews_test.rb
+++ b/test/requests/split_view_previews_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The preview is the first documentation anyone copies, so what the default
+# scenario teaches is what hosts will write. These pin the doctrine — structured
+# listing as the face, free master as the escape — and the two silent failures
+# this file was written after.
+class SplitViewPreviewsTest < ActionDispatch::IntegrationTest
+  BASE = "/lookbook/preview/bali/split_view"
+
+  SCENARIOS = %w[
+    default multi_filters with_selection deep_link_beyond_the_first_page
+    without_advance custom_master full_height/default
+  ].freeze
+
+  def setup
+    studio = Tenant.create!(name: "Preview Studio")
+    studio.movies.create!(name: "Preview Movie", genre: "Drama", status: 0)
+  end
+
+  def test_every_scenario_renders
+    SCENARIOS.each do |scenario|
+      get "#{BASE}/#{scenario}"
+      assert_response :ok, "#{scenario} no renderizó"
+    end
+  end
+
+  # The face of the component is the structured listing: rows the component
+  # wired, not markup a host copied.
+  def test_the_default_scenario_teaches_the_structured_list
+    get "#{BASE}/default"
+
+    assert_select "a.split-view-item[data-split-view-target='row']", { minimum: 1 },
+      "el default tiene que enseñar with_list/with_item, no un master a mano"
+    assert_select "a.split-view-item[data-turbo-frame='split-view-detail']", minimum: 1
+  end
+
+  # And the escape hatch stays reachable, clearly marked as the other thing.
+  def test_the_custom_master_scenario_keeps_the_hand_rolled_listing
+    get "#{BASE}/custom_master"
+
+    assert_select ".split-view-master .split-view-row", minimum: 1
+    assert_select "a.split-view-item", false,
+      "custom_master es el escape: sus filas se escriben a mano"
+  end
+
+  # The pills build their own URLs from the request, so a preview is a real
+  # filter: the param narrows the listing and marks the pill.
+  def test_the_filter_pills_are_live_in_single_mode
+    get "#{BASE}/default"
+    assert_select ".split-view-filter[data-active='true']", false, "sin filtro no hay pill activa"
+
+    get "#{BASE}/default", params: { status: "done" }
+    assert_select ".split-view-filter[data-active='true']", 1
+    assert_select ".split-view-filter[aria-current='true']", 1
+  end
+
+  # Several active at once, and `aria-current` cannot say "all of these" — so it
+  # is absent and the state lives in text.
+  def test_multi_mode_marks_several_pills_without_aria_current
+    get "#{BASE}/multi_filters", params: { q: { genre_in: %w[Action Comedy] } }
+
+    assert_select ".split-view-filter[data-active='true']", { minimum: 2 }
+    assert_select ".split-view-filter[aria-current]", false
+    assert_select ".split-view-filter[aria-pressed]", false
+  end
+
+  # The one that would have caught the silent failure: `@layout` is not a tag
+  # Lookbook 2.3 knows, so the annotation was ignored and AppLayout's <body> —
+  # and with it `app-layout--viewport-locked` — was discarded by the parser. The
+  # scenario still looked plausible while demonstrating nothing, because `:full`
+  # filled a <main> that was not the screen.
+  def test_the_full_height_scenario_really_locks_the_viewport
+    get "#{BASE}/full_height/default"
+
+    assert_select "body.app-layout--viewport-locked", 1,
+      "sin la clase de lock, `height: :full` no tiene contra qué llenar"
+    assert_select ".split-view-component--full", 1
+  end
+end


### PR DESCRIPTION
Cierra #979. **Apilado sobre #978** (`feat/977-split-view-filter-pills`) — mergear ese primero. Apilado y no junto para que el tren de beta.9 pueda llevarse #977 solo si este necesita otra vuelta.

## Qué hace

`height: :content` (default) crece con su contenido y deja scrollear la página. `height: :full` da la otra forma, la del inbox: el split llena la pantalla y **cada panel scrollea por su cuenta**, así que lista y detalle se mueven independientes y ninguno se lleva la página con él.

## No hay un solo número adentro

Es `height: 100%` más una cadena flex. Sin offset medido, sin `calc(100vh - 17rem)`, sin JS leyendo el top de nada — como pedía el issue. La consecuencia: llena la caja acotada que le pongas y **no llena nada si no hay ninguna**, de forma visible. Es deliberado y es el mismo razonamiento que dejó el offset mágico fuera del Kanban.

## El emparejamiento no emparejaba: lo medí

El issue nombra `AppLayout viewport_locked: true` como LA receta. Con `:full` recién puesto, **no funcionaba**: el split se quedaba en **629px dentro de un `<main>` de 1086** — llenando nada mientras decía llenarlo todo.

La causa: `.app-layout-body-container` es `height: auto` y envuelve su contenido, así que nunca llega al fondo de `<main>` y un `height: 100%` no tiene contra qué resolver. Probé dos candidatas en vivo antes de elegir; las dos llenaban, y me quedé con `flex: 1 0 auto` porque **nunca encoge por debajo del contenido** — una página más alta que el viewport conserva su altura y `<main>` sigue scrolleando, que es lo que `:content` dentro de un layout bloqueado todavía quiere.

Dos decisiones sobre dónde vive el arreglo:

- **En `split_view/index.css`, no en `app_layout/index.css`.** Existe por `:full` y por nada más.
- **Acotado con `:has()`**, así que cualquier otra página con `viewport_locked` queda byte a byte igual. Lo verifiqué corriendo `app-layout-banner.cy.js` y `app-shell-chrome.cy.js`: **11/11 verdes**.

Limitación que documenté en vez de esconder: el split tiene que ser **hijo directo** del contenedor de cuerpo. Un wrapper en medio es otro eslabón con `height: auto` y ahí muere el llenado.

## Las tres decisiones que el issue dejaba abiertas

**Móvil (<lg): inerte.** Los paneles están apilados y dos paneles apilados no pueden llenar los dos la misma pantalla — serían un master y un detalle peleándose el viewport. Apilado conserva el scroll de página normal, que es lo que quiere un teléfono. Las dos reglas viven dentro del media query de `lg`, así que abajo no existe.

**`max_height:` es de `:content`.** En `:full` decide la cadena flex, así que el tope se suelta (`max-height: none`) en vez de pelearse: un cap de `calc(100vh - 20rem)` dentro de un panel que ya mide exactamente lo que debe solo lo acorta.

**El sentinel sobrevive.** El contenedor cambia de tamaño, no de identidad, y el observer está rooteado en él igual. Y hay un efecto nuevo que la spec fija: un panel a pantalla completa es más alto, así que una página de filas no lo llena — el sentinel se queda a la vista y sigue pidiendo. **En `:full` el listado se trae las 20 filas y llega al fin de lista sin que nadie scrollee.**

## Evidencia

- Cypress `split-view-full-height.cy.js` **6 passing**: llena el viewport bloqueado (con el gap = padding del contenedor, nada más), la página no scrollea y cada panel sí, los dos paneles miden lo mismo, el infinite scroll llega al final, el swap del frame sigue funcionando, y por debajo de `lg` el modifier es inerte (el `max-height` del master vuelve y el detalle deja de ser caja de scroll).
- Suite de SplitView completa **42/42** (14 + 22 + 6), más **11/11** de las specs de AppLayout como regresión.
- Minitest: 4 nuevos de `height:` (modifier, default, fallback de valor desconocido, y que **no** emite altura inline); 74 runs entre los dos archivos de SplitView, 0 failures.
- Rubocop y StandardJS limpios. `/split-view/full` en el dummy es el arreglo completo, verificado en browser con captura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)