### PR TITLE
fix(split-view): height: :full clampea con una página uno más alta que el viewport (#979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Bali::SplitView height: :full` now clamps when page one is taller than the viewport** (#979
+  follow-up; found adopting the component in afal-apps' inbox — the adoption run these betas exist
+  for). The pairing rule gave AppLayout's body container `flex: 1 0 auto`: basis `auto` makes the
+  container's hypothetical size its **content** size, and shrink `0` means it never comes back
+  down — so with a list taller than the screen (a real inbox's normal state) the container never
+  clamped, the page scrolled as a whole, each pane's own scroll never engaged, and the
+  infinite-scroll sentinel — permanently in view — fetched every page at once. Measured in
+  afal-apps with 87 pending items: a 7,537px container inside a 1,061px `<main>`. The rule is now
+  `flex: 1 1 0%` plus `min-height: 0`: the container is exactly the leftover space, the split fills
+  it, each pane scrolls. The `:content` case never matched this `:has()` rule, so nothing else
+  changes. The reference page missed this for a whole beta because its page one (5 rows) was
+  shorter than the viewport and flex-grow stretched it into looking right; `/split-view/full` now
+  paginates 12 per page — taller than the pane by construction, with a second page left so the
+  sentinel still demonstrates infinite scroll inside the clamp — and
+  `cypress/e2e/split-view-full-height.cy.js` reproduces the regression explicitly and pins the new
+  flex pair (a `flex-shrink: 0` assertion was the old value's alarm; it now guards the fix).
+
 ## [v3.1.0.beta.9] - 2026-08-07
 
 ### Added

--- a/app/components/bali/split_view/index.css
+++ b/app/components/bali/split_view/index.css
@@ -204,9 +204,20 @@
    `:has()` is what keeps them off every other locked page: a layout with
    ordinary content is byte-for-byte what it was.
 
-   `flex: 1 0 auto` and not `flex: 1`: grow to fill the screen, but never shrink
-   below the content. A page taller than the viewport keeps its height and
-   `<main>` scrolls, which is what `:content` inside a locked layout still wants.
+   `flex: 1 1 0%` and not `flex: 1 0 auto`. The first shipped version used
+   `1 0 auto` — "grow to fill the screen, never shrink below the content" — but
+   basis `auto` makes the container's hypothetical size its CONTENT size, and
+   shrink `0` means it never comes back down: with a list taller than the
+   viewport (a real inbox's normal state) the container never clamps, the page
+   scrolls as a whole, each pane's own scroll never engages, and the
+   infinite-scroll sentinel — permanently visible — fetches every page at once.
+   Measured in afal-apps' inbox with 87 items: a 7537px container inside a
+   1061px `<main>`. Basis `0%` sizes the container purely by grow — exactly the
+   leftover space — and `min-height: 0` lets it hand that bound down. The
+   `:content` case never hits this rule (no `--full` child), so nothing else
+   changes. The dummy's reference page missed this for a whole beta because its
+   page ONE was shorter than the viewport; it now paginates large enough to
+   reproduce (see `SplitViewsController::FULL_PER_PAGE`).
 
    The split has to be a DIRECT child of the body container. A wrapper in
    between is a link in the chain with `height: auto`, and the fill dies there —
@@ -219,6 +230,7 @@
 
   .app-layout--viewport-locked
     .app-layout-body-container:has(> .split-view-component--full) {
-    flex: 1 0 auto;
+    flex: 1 1 0%;
+    min-height: 0;
   }
 }

--- a/cypress/e2e/split-view-full-height.cy.js
+++ b/cypress/e2e/split-view-full-height.cy.js
@@ -50,15 +50,33 @@ describe('SplitView height: :full', () => {
     })
   })
 
-  // The interaction the issue asks about: in `:full` the scroll container is
-  // taller than it was, so one page of rows no longer fills it. The sentinel
-  // stays in view and has to keep asking — the container changed size, not
-  // identity, and the observer is rooted on it either way.
-  it('keeps the infinite scroll loading until the taller pane is full', () => {
-    // 5 rows a page, 20 in the table. A pane this tall does not stop at one
-    // page: the sentinel stays in view after each append and keeps asking, so
-    // the listing runs to the end without anybody scrolling.
-    cy.get('.split-view-item').should('have.length.greaterThan', 5)
+  // The bali#979 regression, reproduced by construction: page one (12 rows) is
+  // TALLER than the pane. The first shipped version used `flex: 1 0 auto` on
+  // the body container — basis `auto` made its hypothetical size the CONTENT
+  // size and shrink 0 never brought it back down, so exactly this arrangement
+  // scrolled the page as a whole and the pane scroll never engaged. Measured in
+  // afal-apps' inbox (87 items): a 7537px container inside a 1061px <main>.
+  it('clamps even when page one is taller than the pane (bali#979 regression)', () => {
+    cy.get('[data-split-view-list-target="scroller"]').then(($s) => {
+      const el = $s[0]
+      expect(el.scrollHeight, 'the fixture really overflows the pane')
+        .to.be.greaterThan(el.clientHeight + 100)
+      expect(el.clientHeight, 'the pane is bounded by the viewport, not the content')
+        .to.be.lessThan(800)
+    })
+    cy.document().then((doc) => {
+      expect(doc.documentElement.scrollHeight, 'the page still does not scroll')
+        .to.be.at.most(doc.documentElement.clientHeight + 1)
+    })
+  })
+
+  // Infinite scroll inside the clamp: page one overfills the pane, so the
+  // sentinel starts OUT of view and nothing auto-loads — reaching the bottom of
+  // the pane is what asks for page two. The observer is rooted on the scroller,
+  // and the scroller is the thing the clamp finally bounded.
+  it('keeps the infinite scroll working inside the clamped pane', () => {
+    cy.get('.split-view-item').should('have.length', 12)
+    cy.get('[data-split-view-list-target="scroller"]').scrollTo('bottom')
     cy.get('.split-view-item').should('have.length', 20)
     cy.get('[data-split-view-list-target="end"]').should('not.have.attr', 'hidden')
   })
@@ -70,9 +88,13 @@ describe('SplitView height: :full', () => {
   // assertions are the alarm.
   it('applies the layout fix only where a full-height split actually is', () => {
     cy.get('main').should('have.css', 'display', 'flex')
+    // basis 0% + shrink 1: the container is exactly the leftover space. With
+    // basis auto/shrink 0 (the first version) a long list re-inflated it — the
+    // bali#979 regression above is the symptom this pair prevents.
     cy.get('.app-layout-body-container')
       .should('have.css', 'flex-grow', '1')
-      .and('have.css', 'flex-shrink', '0')
+      .and('have.css', 'flex-shrink', '1')
+      .and('have.css', 'flex-basis', '0%')
   })
 
   it('still swaps only the detail frame when a row is clicked', () => {

--- a/spec/dummy/app/controllers/split_views_controller.rb
+++ b/spec/dummy/app/controllers/split_views_controller.rb
@@ -22,30 +22,42 @@
 # on screen to highlight yet — it lights up when infinite scroll reaches its page.
 class SplitViewsController < ApplicationController
   PER_PAGE = 5
+  # `:full`'s page one must be TALLER than its pane. Clamping under a long list
+  # is precisely what the first version of bali#979 got wrong — `flex: 1 0 auto`
+  # on the body container never came back down from the content's height, the
+  # page scrolled as a whole and the pane scroll never engaged — and a short
+  # page one is why this reference couldn't catch it: five rows fit the screen,
+  # flex-grow stretched them, and everything looked right for a whole beta.
+  # Twelve rows overflow the pane at 1280x800 AND leave a second page in the
+  # table, so the sentinel keeps demonstrating infinite scroll inside the clamp.
+  FULL_PER_PAGE = 12
 
   # AppLayout renders its own <body>, so the shell around it must not have one.
   layout "app_layout_preview", only: :full
 
   def show
-    # A real screen picks one semantics and stays there. This page takes it from
-    # a param so the reference can show both: `:single` is the bucket strip
-    # (status, one value at a time) and `:multi` the independent toggles (genre,
-    # several at once over `q[genre_in][]`).
-    @filter_mode = params[:filter_mode] == "multi" ? :multi : :single
-
-    @pagy, @movies = pagy(filtered.includes(:studio).order(:name), limit: PER_PAGE)
-    @selected = Movie.find_by(id: params[:selected])
+    load_listing(limit: PER_PAGE)
   end
 
   # The same listing, in the arrangement `height: :full` is built for: inside an
   # AppLayout that locks the viewport, so the split fills the screen and each
   # pane scrolls on its own instead of the page scrolling as a whole.
   def full
-    show
+    load_listing(limit: FULL_PER_PAGE)
     render :full
   end
 
   private
+
+  # A real screen picks one semantics and stays there. This page takes it from
+  # a param so the reference can show both: `:single` is the bucket strip
+  # (status, one value at a time) and `:multi` the independent toggles (genre,
+  # several at once over `q[genre_in][]`).
+  def load_listing(limit:)
+    @filter_mode = params[:filter_mode] == "multi" ? :multi : :single
+    @pagy, @movies = pagy(filtered.includes(:studio).order(:name), limit: limit)
+    @selected = Movie.find_by(id: params[:selected])
+  end
 
   def filtered
     @filter_mode == :multi ? by_genres : by_status


### PR DESCRIPTION
Hallazgo de la adopción real (afal-apps#470, el inbox de TDFlow con 87 pendientes) — el tipo de bug que las betas existen para cazar antes de congelar la API en GA.

## El bug

La regla del pairing le daba a `.app-layout-body-container` un `flex: 1 0 auto`: con basis `auto` el tamaño hipotético del contenedor es el de su **contenido**, y con shrink `0` nunca baja de ahí. Con una lista más alta que la pantalla — el estado normal de una bandeja real — el contenedor jamás clampeaba:

- La página scrolleaba entera (header y pills se iban del viewport).
- El scroll propio de cada panel jamás enganchaba.
- El sentinel del infinite scroll, permanentemente visible, cargaba **todas** las páginas de golpe.

Medido en afal-apps: contenedor de **7,537px dentro de un `main` de 1,061px**.

## Por qué el dummy no lo vio

Su página uno eran 5 filas — más corta que el viewport. El `flex-grow` la estiraba y todo parecía correcto. El escenario de referencia demostraba el arreglo solo en el caso en el que el bug no puede ocurrir.

## El fix

`flex: 1 1 0%` + `min-height: 0`: el contenedor es exactamente el hueco sobrante, el split lo llena y cada panel scrollea. El caso `:content` nunca matchea esta regla `:has()` — nada más cambia. (El comentario original justificaba `1 0 auto` por el caso `:content`… que este selector no alcanza.)

## La regresión, reproducida por construcción

- `/split-view/full` pagina ahora de a **12**: página uno más alta que el panel Y una segunda página en la tabla, para que el sentinel siga demostrando el infinite scroll dentro del clamp.
- `split-view-full-height.cy.js`: test nuevo que exige que la lista desborde el panel y la página no scrollee; el test del auto-fill se rehace (con el clamp, el sentinel arranca fuera de vista y es llegar al fondo lo que pide la página dos); y el assert de `flex-shrink: 0` — que era la alarma del valor viejo — ahora fija el par nuevo.

## Verificación

- Suite Minitest completa verde (pre-push hook).
- Cypress: pendiente de correr con el server del dummy (no lo levanté en :3001 — reservado).
- El fix está medido en vivo en afal-apps (afal-apps#470, comentario con las mediciones); ahí quedó un workaround local con el patrón #638 que se borra al re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)